### PR TITLE
fix: remove DB query from AppConfig.ready()

### DIFF
--- a/netbox_kea/__init__.py
+++ b/netbox_kea/__init__.py
@@ -32,31 +32,28 @@ class NetBoxKeaConfig(PluginConfig):
         self._configure_sync_job_interval()
 
     def _configure_sync_job_interval(self) -> None:
-        """Override the KeaIpamSyncJob interval from persisted SyncConfig (falling back to PLUGINS_CONFIG).
+        """Seed the KeaIpamSyncJob interval from PLUGINS_CONFIG at startup.
 
         The ``@system_job`` decorator registers a static default interval.  We
-        patch the registry here so the configured interval is used by the
-        worker when it starts.  The persisted ``SyncConfig.interval_minutes``
-        value is the single source of truth; ``sync_interval_minutes`` in
-        PLUGINS_CONFIG is only the seed value used before the user has saved
-        any configuration via the UI.
+        patch the in-memory registry here so the worker uses the operator's
+        configured value from PLUGINS_CONFIG on startup.
+
+        We intentionally do NOT query the database here.  ``ready()`` is called
+        during every Django management command — including ``collectstatic`` and
+        ``migrate`` run inside Docker image builds where the database is not yet
+        reachable.  The UI (SyncJobsView) updates the registry live whenever the
+        operator saves a new interval, so runtime changes take effect immediately
+        without a restart.
         """
         try:
             from django.conf import settings
             from netbox.registry import registry
 
             from .jobs import KeaIpamSyncJob
-            from .models import SyncConfig
 
-            # Seed the SyncConfig with PLUGINS_CONFIG on first creation so the
-            # config file value is honoured until the operator saves via the UI.
-            # SyncConfig.get() only uses default_interval when the row doesn't yet exist.
             config = getattr(settings, "PLUGINS_CONFIG", {}).get("netbox_kea", {})
-            default_interval = int(config.get("sync_interval_minutes", 5))
-            interval = SyncConfig.get(default_interval=default_interval).interval_minutes
+            interval = max(1, int(config.get("sync_interval_minutes", 5)))
 
-            if interval < 1:
-                interval = 1
             if KeaIpamSyncJob in registry["system_jobs"]:
                 registry["system_jobs"][KeaIpamSyncJob]["interval"] = interval
         except Exception:  # noqa: BLE001

--- a/netbox_kea/tests/test_jobs.py
+++ b/netbox_kea/tests/test_jobs.py
@@ -838,6 +838,29 @@ class TestConfigureSyncJobInterval(SimpleTestCase):
 
         self.assertTrue(any("Failed to apply netbox_kea sync interval override" in msg for msg in cm.output))
 
+    def test_interval_set_from_plugins_config_no_db_query(self):
+        """PLUGINS_CONFIG.sync_interval_minutes seeds the registry without hitting the DB."""
+        from django.apps import apps
+        from netbox.registry import registry
+
+        from netbox_kea.jobs import KeaIpamSyncJob
+
+        cfg = apps.get_app_config("netbox_kea")
+
+        # Ensure the job is in the registry so we can check the interval update.
+        registry["system_jobs"].setdefault(KeaIpamSyncJob, {"interval": 999})
+        original_interval = registry["system_jobs"][KeaIpamSyncJob]["interval"]
+
+        try:
+            with override_settings(PLUGINS_CONFIG={"netbox_kea": {"sync_interval_minutes": 17}}):
+                # No DB access should occur — if it does, it raises OperationalError in the
+                # SimpleTestCase (no DB) and the test would fail with a DB error rather than pass.
+                cfg._configure_sync_job_interval()
+
+            self.assertEqual(registry["system_jobs"][KeaIpamSyncJob]["interval"], 17)
+        finally:
+            registry["system_jobs"][KeaIpamSyncJob]["interval"] = original_interval
+
 
 class TestGetPluginConfig(SimpleTestCase):
     """Tests for _get_plugin_config() defensive type-checking."""


### PR DESCRIPTION
_configure_sync_job_interval() was calling SyncConfig.get() which opens a DB connection.  ready() is invoked during every management command including collectstatic and migrate run inside Docker image builds where the database is not yet reachable, producing a noisy OperationalError traceback.

Fix: seed the in-memory registry interval from PLUGINS_CONFIG only. The SyncJobsView already updates the registry live when the operator saves a new interval, so runtime changes still take effect without a restart.

Add a SimpleTestCase (no DB) that asserts the happy path sets the registry interval from PLUGINS_CONFIG without touching the database.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sync job interval configuration now reads from settings instead of the database, improving startup reliability.

* **Tests**
  * Added test coverage for sync job interval configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->