### PR TITLE
fix: use condition= instead of deprecated check= in CheckConstraint m…

### DIFF
--- a/netbox_kea/migrations/0007_syncconfig_constraints.py
+++ b/netbox_kea/migrations/0007_syncconfig_constraints.py
@@ -12,7 +12,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="syncconfig",
             constraint=models.CheckConstraint(
-                check=models.Q(interval_minutes__gte=1) & models.Q(interval_minutes__lte=1440),
+                condition=models.Q(interval_minutes__gte=1) & models.Q(interval_minutes__lte=1440),
                 name="syncconfig_interval_minutes_range",
             ),
         ),


### PR DESCRIPTION
…igration

Django 5.0 deprecated the check= keyword argument on CheckConstraint in favour of condition= (which has been available since Django 4.1).  The model definition was already updated; this aligns the historical migration so Django no longer emits RemovedInDjango60Warning at startup.

Backwards-compatible: condition= accepted since Django 4.1, which covers NetBox 4.0-4.5 (all require Django 4.2+).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal database constraint configuration for improved system consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marcinpsk/netbox-kea/pull/66)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->