### PR TITLE
fix: self-heal ghost scheduled-job DB records on worker startup

### DIFF
--- a/netbox_kea/__init__.py
+++ b/netbox_kea/__init__.py
@@ -32,6 +32,7 @@ class NetBoxKeaConfig(PluginConfig):
         """Apply runtime configuration overrides after Django is fully initialised."""
         super().ready()
         self._configure_sync_job_interval()
+        self._heal_ghost_scheduled_jobs()
 
     def _configure_sync_job_interval(self) -> None:
         """Seed the KeaIpamSyncJob interval from PLUGINS_CONFIG at startup.
@@ -61,6 +62,67 @@ class NetBoxKeaConfig(PluginConfig):
         except Exception:  # noqa: BLE001
             logger.warning(
                 "Failed to apply netbox_kea sync interval override; using decorator default.",
+                exc_info=True,
+            )
+
+    def _heal_ghost_scheduled_jobs(self) -> None:
+        """Remove ghost scheduled-job DB records that have no live RQ counterpart.
+
+        A ghost record arises when a periodic job's execution fails at the DB level
+        (e.g. PostgreSQL in recovery mode) — the DB record stays ``scheduled`` forever
+        while RQ marks the job ``failed``.  NetBox's ``enqueue_once()`` trusts the DB
+        status and skips re-scheduling, silently breaking the periodic chain.
+
+        Deleting stale DB records here lets the worker's ``enqueue_once()`` call
+        (which runs immediately after ``ready()``) create a fresh schedule.
+
+        Safe to call in all contexts:
+        - Never enqueues jobs (deferred to ``rqworker``).
+        - All DB and Redis I/O is wrapped so a missing DB or Redis at image-build
+          time never breaks startup.
+        """
+        try:
+            import django_rq
+            from rq.exceptions import NoSuchJobError
+            from rq.job import Job as RQJob
+
+            from .jobs import KeaIpamSyncJob
+
+            candidates = KeaIpamSyncJob.get_jobs(None).filter(status__in=("scheduled", "pending"))
+            if not candidates.exists():
+                return
+
+            conn = django_rq.get_connection("default")
+            _DEAD = {"failed", "canceled", "stopped"}
+
+            deleted = 0
+            for db_job in candidates:
+                job_id = str(db_job.job_id) if db_job.job_id else None
+                if job_id is None:
+                    db_job.delete()
+                    deleted += 1
+                    continue
+                try:
+                    rq_job = RQJob.fetch(job_id, connection=conn)
+                    status = rq_job.get_status()
+                    # Handle both enum (rq ≥ 1.16) and plain string
+                    status_str = status.value if hasattr(status, "value") else str(status)
+                    if status_str in _DEAD:
+                        db_job.delete()
+                        deleted += 1
+                except NoSuchJobError:
+                    db_job.delete()
+                    deleted += 1
+
+            if deleted:
+                logger.warning(
+                    "netbox_kea: removed %d ghost scheduled-job record(s) with a dead or missing "
+                    "RQ counterpart. Periodic IPAM sync will resume on the next worker startup.",
+                    deleted,
+                )
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "netbox_kea: ghost-job self-heal skipped (DB or Redis not available at startup).",
                 exc_info=True,
             )
 

--- a/netbox_kea/__init__.py
+++ b/netbox_kea/__init__.py
@@ -97,22 +97,29 @@ class NetBoxKeaConfig(PluginConfig):
 
             deleted = 0
             for db_job in candidates:
-                job_id = str(db_job.job_id) if db_job.job_id else None
-                if job_id is None:
-                    db_job.delete()
-                    deleted += 1
-                    continue
                 try:
-                    rq_job = RQJob.fetch(job_id, connection=conn)
-                    status = rq_job.get_status()
-                    # Handle both enum (rq ≥ 1.16) and plain string
-                    status_str = status.value if hasattr(status, "value") else str(status)
-                    if status_str in _DEAD:
+                    job_id = str(db_job.job_id) if db_job.job_id else None
+                    if job_id is None:
                         db_job.delete()
                         deleted += 1
-                except NoSuchJobError:
-                    db_job.delete()
-                    deleted += 1
+                        continue
+                    try:
+                        rq_job = RQJob.fetch(job_id, connection=conn)
+                        status = rq_job.get_status()
+                        # Handle both enum (rq ≥ 1.16) and plain string
+                        status_str = status.value if hasattr(status, "value") else str(status)
+                        if status_str in _DEAD:
+                            db_job.delete()
+                            deleted += 1
+                    except NoSuchJobError:
+                        db_job.delete()
+                        deleted += 1
+                except Exception:  # noqa: BLE001
+                    logger.debug(
+                        "netbox_kea: skipping ghost-job check for record %r due to per-record error.",
+                        getattr(db_job, "pk", None),
+                        exc_info=True,
+                    )
 
             if deleted:
                 logger.warning(
@@ -121,7 +128,7 @@ class NetBoxKeaConfig(PluginConfig):
                     deleted,
                 )
         except Exception:  # noqa: BLE001
-            logger.debug(
+            logger.warning(
                 "netbox_kea: ghost-job self-heal skipped (DB or Redis not available at startup).",
                 exc_info=True,
             )

--- a/netbox_kea/tests/test_plugin_config.py
+++ b/netbox_kea/tests/test_plugin_config.py
@@ -196,3 +196,69 @@ class TestHealGhostScheduledJobs(SimpleTestCase):
 
         bad_job.delete.assert_not_called()
         good_job.delete.assert_called_once()
+
+    # ------------------------------------------------------------------
+    # Plain-string status fallback (rq < enum era)
+    # ------------------------------------------------------------------
+
+    def test_plain_string_status_failed_is_deleted(self):
+        """Cover the str(status) fallback when get_status() returns a bare string."""
+        job = _make_db_job("job-plain")
+        mock_qs = MagicMock()
+        mock_qs.exists.return_value = True
+        mock_qs.filter.return_value = mock_qs
+        mock_qs.__iter__ = lambda self: iter([job])
+
+        rq_job = MagicMock()
+        # Return a plain string instead of an enum-like object with .value
+        rq_job.get_status.return_value = "failed"
+
+        cfg = _make_config()
+        with (
+            patch("netbox_kea.jobs.KeaIpamSyncJob.get_jobs", return_value=mock_qs),
+            patch("django_rq.get_connection", return_value=MagicMock()),
+            patch("rq.job.Job.fetch", return_value=rq_job),
+        ):
+            cfg._heal_ghost_scheduled_jobs()
+
+        job.delete.assert_called_once()
+
+    def test_plain_string_status_live_not_deleted(self):
+        """A plain-string live status must not trigger deletion."""
+        job = _make_db_job("job-plain-live")
+        mock_qs = MagicMock()
+        mock_qs.exists.return_value = True
+        mock_qs.filter.return_value = mock_qs
+        mock_qs.__iter__ = lambda self: iter([job])
+
+        rq_job = MagicMock()
+        rq_job.get_status.return_value = "scheduled"
+
+        cfg = _make_config()
+        with (
+            patch("netbox_kea.jobs.KeaIpamSyncJob.get_jobs", return_value=mock_qs),
+            patch("django_rq.get_connection", return_value=MagicMock()),
+            patch("rq.job.Job.fetch", return_value=rq_job),
+        ):
+            cfg._heal_ghost_scheduled_jobs()
+
+        job.delete.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # ready() wiring smoke test
+    # ------------------------------------------------------------------
+
+    def test_ready_calls_both_helpers(self):
+        """ready() must invoke _configure_sync_job_interval and _heal_ghost_scheduled_jobs."""
+        from netbox.plugins import PluginConfig
+
+        cfg = _make_config()
+        with (
+            patch.object(PluginConfig, "ready"),
+            patch.object(NetBoxKeaConfig, "_configure_sync_job_interval") as mock_configure,
+            patch.object(NetBoxKeaConfig, "_heal_ghost_scheduled_jobs") as mock_heal,
+        ):
+            cfg.ready()
+
+        mock_configure.assert_called_once()
+        mock_heal.assert_called_once()

--- a/netbox_kea/tests/test_plugin_config.py
+++ b/netbox_kea/tests/test_plugin_config.py
@@ -53,7 +53,6 @@ class TestHealGhostScheduledJobs(SimpleTestCase):
 
         cfg = _make_config()
         with (
-            patch("netbox_kea.NetBoxKeaConfig._configure_sync_job_interval"),
             patch("netbox_kea.jobs.KeaIpamSyncJob.get_jobs", return_value=mock_qs),
             patch("django_rq.get_connection", return_value=MagicMock()),
             patch("rq.job.Job.fetch", side_effect=_fetch),
@@ -169,3 +168,31 @@ class TestHealGhostScheduledJobs(SimpleTestCase):
         ):
             # Must not raise
             cfg._heal_ghost_scheduled_jobs()
+
+    def test_per_record_error_does_not_abort_remaining_records(self):
+        """A transient error on one record must not skip the others."""
+        bad_job = _make_db_job("job-bad")
+        good_job = _make_db_job("job-good")
+
+        mock_qs = MagicMock()
+        mock_qs.exists.return_value = True
+        mock_qs.filter.return_value = mock_qs
+        mock_qs.__iter__ = lambda self: iter([bad_job, good_job])
+
+        def _fetch(job_id, connection):
+            if job_id == "job-bad":
+                raise RuntimeError("transient Redis error")
+            rq = MagicMock()
+            rq.get_status.return_value = MagicMock(value="failed")
+            return rq
+
+        cfg = _make_config()
+        with (
+            patch("netbox_kea.jobs.KeaIpamSyncJob.get_jobs", return_value=mock_qs),
+            patch("django_rq.get_connection", return_value=MagicMock()),
+            patch("rq.job.Job.fetch", side_effect=_fetch),
+        ):
+            cfg._heal_ghost_scheduled_jobs()
+
+        bad_job.delete.assert_not_called()
+        good_job.delete.assert_called_once()

--- a/netbox_kea/tests/test_plugin_config.py
+++ b/netbox_kea/tests/test_plugin_config.py
@@ -1,0 +1,171 @@
+# SPDX-FileCopyrightText: 2025 Marcin Zieba <marcinpsk@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for NetBoxKeaConfig.ready() helpers — _heal_ghost_scheduled_jobs."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase
+
+from netbox_kea import NetBoxKeaConfig
+
+
+def _make_config() -> NetBoxKeaConfig:
+    """Return a bare NetBoxKeaConfig instance without triggering real ready() logic."""
+    return NetBoxKeaConfig.__new__(NetBoxKeaConfig)
+
+
+def _make_db_job(job_id: str | None = "abc-123") -> MagicMock:
+    mock = MagicMock()
+    mock.job_id = job_id
+    return mock
+
+
+class TestHealGhostScheduledJobs(SimpleTestCase):
+    """Tests for NetBoxKeaConfig._heal_ghost_scheduled_jobs()."""
+
+    def _run(self, candidates, rq_statuses: dict[str, str] | None = None, no_such: set[str] | None = None):
+        """
+        Helper: run _heal_ghost_scheduled_jobs() with mocked DB queryset and RQ jobs.
+
+        candidates  — list of mock DB job objects
+        rq_statuses — {job_id: status_str} for jobs that exist in RQ
+        no_such     — set of job_ids that raise NoSuchJobError
+        """
+        rq_statuses = rq_statuses or {}
+        no_such = no_such or set()
+
+        mock_qs = MagicMock()
+        mock_qs.exists.return_value = bool(candidates)
+        mock_qs.filter.return_value = mock_qs
+        mock_qs.__iter__ = lambda self: iter(candidates)
+
+        def _fetch(job_id, connection):
+            if job_id in no_such:
+                from rq.exceptions import NoSuchJobError
+
+                raise NoSuchJobError(job_id)
+            rq_job = MagicMock()
+            status_str = rq_statuses.get(job_id, "scheduled")
+            rq_job.get_status.return_value = MagicMock(value=status_str)
+            return rq_job
+
+        cfg = _make_config()
+        with (
+            patch("netbox_kea.NetBoxKeaConfig._configure_sync_job_interval"),
+            patch("netbox_kea.jobs.KeaIpamSyncJob.get_jobs", return_value=mock_qs),
+            patch("django_rq.get_connection", return_value=MagicMock()),
+            patch("rq.job.Job.fetch", side_effect=_fetch),
+        ):
+            cfg._heal_ghost_scheduled_jobs()
+
+        return candidates
+
+    # ------------------------------------------------------------------
+    # No candidates — early exit
+    # ------------------------------------------------------------------
+
+    def test_no_candidates_returns_early_without_rq_connection(self):
+        mock_qs = MagicMock()
+        mock_qs.exists.return_value = False
+        mock_qs.filter.return_value = mock_qs
+
+        cfg = _make_config()
+        with (
+            patch("netbox_kea.jobs.KeaIpamSyncJob.get_jobs", return_value=mock_qs),
+            patch("django_rq.get_connection") as mock_conn,
+        ):
+            cfg._heal_ghost_scheduled_jobs()
+
+        mock_conn.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # Ghost scenarios — DB record should be deleted
+    # ------------------------------------------------------------------
+
+    def test_failed_rq_job_is_deleted(self):
+        job = _make_db_job("job-1")
+        self._run([job], rq_statuses={"job-1": "failed"})
+        job.delete.assert_called_once()
+
+    def test_canceled_rq_job_is_deleted(self):
+        job = _make_db_job("job-2")
+        self._run([job], rq_statuses={"job-2": "canceled"})
+        job.delete.assert_called_once()
+
+    def test_stopped_rq_job_is_deleted(self):
+        job = _make_db_job("job-3")
+        self._run([job], rq_statuses={"job-3": "stopped"})
+        job.delete.assert_called_once()
+
+    def test_no_such_job_in_redis_is_deleted(self):
+        job = _make_db_job("job-4")
+        self._run([job], no_such={"job-4"})
+        job.delete.assert_called_once()
+
+    def test_no_job_id_is_deleted(self):
+        job = _make_db_job(job_id=None)
+        self._run([job])
+        job.delete.assert_called_once()
+
+    # ------------------------------------------------------------------
+    # Live job — must NOT be deleted
+    # ------------------------------------------------------------------
+
+    def test_live_scheduled_rq_job_not_deleted(self):
+        job = _make_db_job("job-live")
+        self._run([job], rq_statuses={"job-live": "scheduled"})
+        job.delete.assert_not_called()
+
+    def test_live_queued_rq_job_not_deleted(self):
+        job = _make_db_job("job-queued")
+        self._run([job], rq_statuses={"job-queued": "queued"})
+        job.delete.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # Warning log when ghosts are removed
+    # ------------------------------------------------------------------
+
+    def test_warning_logged_when_ghost_deleted(self):
+        job = _make_db_job("job-warn")
+        with self.assertLogs("netbox_kea", level="WARNING") as cm:
+            self._run([job], rq_statuses={"job-warn": "failed"})
+        self.assertTrue(any("ghost" in msg.lower() for msg in cm.output))
+
+    def test_no_warning_when_nothing_deleted(self):
+        job = _make_db_job("job-ok")
+        # Should not produce WARNING-level logs
+        import logging
+
+        with self.assertLogs("netbox_kea", level="DEBUG") as cm:
+            # Emit a debug log ourselves so assertLogs doesn't fail on empty
+            logging.getLogger("netbox_kea").debug("sentinel")
+            self._run([job], rq_statuses={"job-ok": "scheduled"})
+        warnings = [m for m in cm.output if "WARNING" in m and "ghost" in m.lower()]
+        self.assertEqual(warnings, [])
+
+    # ------------------------------------------------------------------
+    # Resilience — exceptions must not propagate
+    # ------------------------------------------------------------------
+
+    def test_db_unavailable_does_not_raise(self):
+        cfg = _make_config()
+        with patch("netbox_kea.jobs.KeaIpamSyncJob.get_jobs", side_effect=Exception("DB down")):
+            # Must not raise
+            cfg._heal_ghost_scheduled_jobs()
+
+    def test_redis_unavailable_does_not_raise(self):
+        job = _make_db_job("job-5")
+        mock_qs = MagicMock()
+        mock_qs.exists.return_value = True
+        mock_qs.filter.return_value = mock_qs
+        mock_qs.__iter__ = lambda self: iter([job])
+
+        cfg = _make_config()
+        with (
+            patch("netbox_kea.jobs.KeaIpamSyncJob.get_jobs", return_value=mock_qs),
+            patch("django_rq.get_connection", side_effect=Exception("Redis down")),
+        ):
+            # Must not raise
+            cfg._heal_ghost_scheduled_jobs()


### PR DESCRIPTION
After a transient PostgreSQL failure (e.g. recovery mode), a periodic job's DB record can stay at status=scheduled while RQ marks the job failed.  NetBox's enqueue_once() trusts the DB and never re-schedules, silently breaking the periodic sync chain.

Add _heal_ghost_scheduled_jobs() to NetBoxKeaConfig.ready() which:
- Queries DB for scheduled/pending KeaIpamSyncJob records
- For each: fetches the RQ job and checks its live status
- Deletes records whose RQ job is failed/canceled/stopped/missing
- Logs a WARNING when ghosts are removed
- Fails silently (broad except) when DB or Redis are unreachable at image-build time (same contract as _configure_sync_job_interval)

Add 12 unit tests in test_plugin_config.py covering all ghost/live/ resilience scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Startup now automatically removes stale/orphaned scheduled sync job records when their background jobs are missing or in terminal states; logs a warning when removals occur and safely skips the self-heal if backend services are unavailable.

* **Tests**
  * Added comprehensive unit tests covering cleanup behavior, logging, resilience to DB/Redis failures, per-record error isolation, and startup wiring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marcinpsk/netbox-kea/pull/67)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->