### PR TITLE
docs: updates

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,15 @@
+# .envrc.example — direnv configuration for netbox-kea-ng
+#
+# Usage:
+#   cp .envrc.example .envrc
+#   direnv allow
+#
+# Requires: direnv (https://direnv.net), uv (https://docs.astral.sh/uv)
+#
+# On `cd` into the project directory, direnv will:
+#   1. Install / sync dev dependencies into .venv
+#   2. Activate the virtual environment so pytest, ruff, etc. work without `uv run`
+
+uv sync
+
+source .venv/bin/activate

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,39 +1,56 @@
 # Copilot Instructions — netbox-kea-ng
 
-A NetBox plugin that integrates [Kea DHCP](https://www.isc.org/kea/) server management. Published to PyPI as **`netbox-kea-ng`** — a fork of [netbox-kea](https://github.com/devon-mar/netbox-kea) by Devon Mar. The Django app/module name remains `netbox_kea` (unchanged from upstream). Exposes a `Server` model representing a Kea Control Agent endpoint, with views for live daemon status, lease search/delete, and subnet listing.
+A NetBox plugin that integrates [Kea DHCP](https://www.isc.org/kea/) server management. Published to PyPI as **`netbox-kea-ng`** — a fork of [netbox-kea](https://github.com/devon-mar/netbox-kea) by Devon Mar. The Django app/module name remains `netbox_kea` (unchanged from upstream). Exposes a `Server` model representing a Kea Control Agent endpoint, with views for live daemon status, lease search/delete/add/edit, host reservation CRUD, subnet/pool/shared-network management, and automatic Kea→NetBox IPAM sync via a background job.
 
 ## Build, Test & Lint
 
 ```bash
-# Install dev dependencies
+# Install dev dependencies (also activates .venv via .envrc if using direnv)
 uv sync
 
-# Lint
+# Lint / format
 uv run ruff check netbox_kea/
 uv run ruff format --check netbox_kea/
+uv run ruff format netbox_kea/
 
 # REUSE compliance
 uv run reuse lint
 
-# Format
-uv run ruff format netbox_kea/
-
-# Build wheel (required before running tests)
+# Build wheel (required before integration tests)
 uv build
-
-# Run full test suite (requires Docker — spins up NetBox + Kea + nginx + postgres + redis)
-./tests/test_setup.sh   # generates certs, builds Docker images, starts containers
-uv run pytest --tracing=retain-on-failure -v --cov=netbox_kea --cov-report=xml
-
-# Run a single test file
-uv run pytest tests/test_netbox_kea_api_server.py -v
-
-# Run a single test function
-uv run pytest tests/test_ui.py::test_function_name -v
 
 # Install pre-commit hooks
 uv run pre-commit install
 ```
+
+### Unit tests (no Docker required)
+
+`testpaths` in `pyproject.toml` defaults to `netbox_kea/tests`. These tests mock all Kea HTTP calls and use SQLite.
+
+```bash
+uv run pytest                                                        # run all unit tests
+uv run pytest netbox_kea/tests/test_views_leases.py -v               # single file
+uv run pytest netbox_kea/tests/test_jobs.py::TestClass::test_method -v  # single test
+```
+
+Note: `pythonpath` is set to `/opt/netbox/netbox` and `DJANGO_SETTINGS_MODULE=netbox.settings` — unit tests require a NetBox installation at that path (present in devcontainer).
+
+### Integration tests (Docker required)
+
+```bash
+./tests/test_setup.sh   # generates certs, builds Docker images, starts containers
+uv run pytest tests/ --tracing=retain-on-failure -v --cov=netbox_kea --cov-report=xml
+
+# Single file / function
+uv run pytest tests/test_netbox_kea_api_server.py -v
+uv run pytest tests/test_ui.py::test_function_name -v
+```
+
+The compose stack includes: NetBox, netbox-worker, postgres, redis, nginx (basic auth + TLS), kea-ctrl-agent, kea-dhcp4, kea-dhcp6.
+
+### E2E tests
+
+Playwright end-to-end tests live in `e2e/` and are separate from both unit and integration tests.
 
 CI tests against NetBox v4.0–v4.5 using a matrix build. Playwright traces on failure are uploaded as artifacts.
 
@@ -44,28 +61,63 @@ Ruff is configured in `pyproject.toml` — migrations are excluded from linting.
 ```text
 URL request
   → urls.py             (routes to view classes)
-  → views.py            (view calls server.get_client() → KeaClient)
+  → views/              (view modules, all import from _base.py helpers)
+      _base.py          (BaseTable, GenericTable, htmx_partial, OptionalViewTab, TypeVar views)
+      server.py         (Server CRUD, status tab)
+      leases.py         (DHCPv4/v6 lease search, delete, add, edit, bulk import)
+      reservations.py   (DHCPv4/v6 reservation CRUD)
+      subnets.py        (subnet/pool management)
+      shared_networks.py (shared network CRUD)
+      options.py        (global and per-subnet DHCP option editing)
+      dhcp_control.py   (enable/disable DHCP daemons)
+      combined.py       (cross-server dashboard, leases, reservations, subnets views)
+      sync_views.py     (per-server IPAM sync config UI)
+      sync_jobs.py      (jobs tab, periodic sync management, SyncConfig admin)
   → kea.py              (HTTP POST to Kea Control Agent /api/v1/)
-  → utilities.py        (format_leases, format_duration enrich raw Kea data)
+  → sync.py             (bridges Kea data to NetBox IPAM)
+  → jobs.py             (KeaIpamSyncJob — periodic background sync)
+  → signals.py          (Django signals for sync-related events)
+  → utilities.py        (format_leases, format_duration, helpers)
   → tables.py           (non-model GenericTable renders enriched dicts)
   → template            (rendered with django-tables2 + HTMX for pagination)
 ```
 
-**`Server` model** (`models.py`) is the only persisted model. It stores connection config and calls `get_client()` to produce a `KeaClient`. The `clean()` method actually connects to Kea to validate both DHCPv4 and DHCPv6 are reachable before saving.
+**`Server` model** (`models.py`) is the primary persisted model. Fields:
+- `ca_url` — default/fallback Kea Control Agent URL
+- `dhcp4_url` / `dhcp6_url` — optional per-protocol URLs (dual-URL mode)
+- `has_control_agent` — when False, skips Control Agent status row in status view
+- `ca_username` / `ca_password` — default credentials
+- `dhcp4_username` / `dhcp4_password` / `dhcp6_username` / `dhcp6_password` — per-protocol credential overrides
+- `dhcp4` / `dhcp6` — enable/disable per-protocol tabs
+- `ssl_verify`, `ca_file_path`, `client_cert_path`, `client_key_path` — TLS config
+- `sync_enabled`, `sync_leases_enabled`, `sync_reservations_enabled`, `sync_prefixes_enabled`, `sync_ip_ranges_enabled` — per-server IPAM sync toggles
+- `sync_vrf` — FK to `ipam.VRF` for prefix/range sync (no global fallback; blank = global routing table)
+- `persist_config` — auto-save Kea config after changes via `config-write`
 
-**`KeaClient`** (`kea.py`) wraps a `requests.Session`. All API calls go through `.command(command, service, arguments)` which POSTs JSON to the Kea Control Agent. Responses are `list[KeaResponse]` — one entry per service. `check_response()` raises `KeaException` if any result code is not in `ok_codes`.
+`clean()` performs live connectivity checks before saving. `get_client(version=4|6|None)` returns a protocol-aware `KeaClient`.
 
-**Lease/subnet views** operate entirely on live Kea data — no Django ORM queries for leases. `format_leases()` in `utilities.py` enriches raw Kea lease dicts by computing `expires_at`, `expires_in`, and normalising hyphenated keys to underscores (so templates can access `record.valid_lft` etc.).
+**`SyncConfig` model** (`models.py`) — singleton (pk=1 always) for global sync settings:
+- `interval_minutes`, `sync_enabled` (global kill-switch), four type-toggle fields, `backfill_applied`
+- `SyncConfig.get(default_interval)` handles creation-on-first-boot and one-time PLUGINS_CONFIG backfill
+- UI-editable; changes take effect without restart
 
-**REST API** (`api/`) uses `NetBoxModelViewSet` + `NetBoxModelSerializer` — only the `Server` model is exposed. Password is write-only in the serializer.
+**`KeaClient`** (`kea.py`) wraps a `requests.Session`. All API calls go through `.command(command, service, arguments)` which POSTs JSON to the Kea Control Agent. Responses are `list[KeaResponse]` — one entry per service. `check_response()` raises `KeaException` if any result code is not in `ok_codes`. `.clone()` creates a thread-safe copy for concurrent lookups.
 
-**GraphQL** (`graphql.py`) uses strawberry-django: define a `@strawberry_django.type` for the model and export `schema = [Query]`. NetBox picks this up automatically.
+**`sync.py`** bridges Kea data to NetBox IPAM: `sync_lease_to_netbox()` (status=active), `sync_reservation_to_netbox()` (status=reserved), `cleanup_stale_ips_batch()`. Handles `PartialPersistError` for partial failures.
+
+**`jobs.py`** — `KeaIpamSyncJob` decorated with `@system_job(interval=_DEFAULT_INTERVAL)`. Iterates all `Server` objects, calls sync.py functions, writes per-server summary to job log.
+
+**`__init__.py`** — `NetBoxKeaConfig.ready()` calls `_configure_sync_job_interval()` (patches in-memory registry from PLUGINS_CONFIG, no DB access) and `_heal_ghost_scheduled_jobs()` (removes ghost `scheduled`/`pending` DB records whose RQ counterpart is dead/missing — three-level exception nesting for startup safety).
+
+**REST API** (`api/`) uses `NetBoxModelViewSet` + `NetBoxModelSerializer` — only the `Server` model is exposed. All password fields are write-only in the serializer.
+
+**GraphQL** (`graphql.py`) uses strawberry-django: `@strawberry_django.type` for the model, `schema = [Query]`. NetBox picks this up automatically.
 
 ## Key Conventions
 
 ### Non-model tables
 
-Lease and subnet tables use `GenericTable(BaseTable)` instead of `NetBoxTable` because they have no Django model backing them. They accept plain `list[dict]`. `GenericTable` defines `objects_count` as a property returning `len(self.data)` to satisfy NetBox's pagination interface.
+Lease, subnet, and reservation tables use `GenericTable(BaseTable)` instead of `NetBoxTable` because they have no Django model backing them. They accept plain `list[dict]`. `GenericTable` defines `objects_count` as a property returning `len(self.data)` to satisfy NetBox's pagination interface.
 
 ### HTMX pagination
 
@@ -73,7 +125,7 @@ Lease views serve two response types from the same `get()` method: a full page r
 
 ### View registration
 
-Standard CRUD views use `@register_model_view(Server)` / `@register_model_view(Server, "edit")` etc. Custom tabs (Status, Leases, Subnets) use `OptionalViewTab` from `utilities.py` — a subclass of NetBox's `ViewTab` that accepts `is_enabled: Callable[[Server], bool]` to conditionally hide tabs based on model state (e.g. hide DHCPv6 tab if `server.dhcp6` is False).
+Standard CRUD views use `@register_model_view(Server)` / `@register_model_view(Server, "edit")` etc. Custom tabs (Status, Leases, Reservations, Subnets, Jobs) use `OptionalViewTab` from `utilities.py` — a subclass of NetBox's `ViewTab` that accepts `is_enabled: Callable[[Server], bool]` to conditionally hide tabs based on model state (e.g. hide DHCPv6 tab if `server.dhcp6` is False).
 
 ### Generic views with TypeVar
 
@@ -85,87 +137,73 @@ Standard CRUD views use `@register_model_view(Server)` / `@register_model_view(S
 
 ### URL structure
 
-`get_model_urls("netbox_kea", "server")` from `utilities.urls` auto-generates standard NetBox object URLs (detail, edit, delete, changelog, journal). Custom routes (leases, subnets) are declared explicitly before the `include()`.
+`get_model_urls("netbox_kea", "server")` from `utilities.urls` auto-generates standard NetBox object URLs (detail, edit, delete, changelog, journal). Custom routes (leases, reservations, subnets, shared networks, options, DHCP control) are declared explicitly before the `include()`.
 
 ### Forms
 
 Lease search forms inherit from `BaseLeasesSarchForm` (note the typo — it's intentional/existing). Each subclass defines an inner `Meta` with `ip_version: Literal[4, 6]` which the base class `clean()` uses to validate subnet CIDR, IP addresses, and hardware addresses (via `is_hex_string()` from `utilities.py`).
 
+### Protocol-aware `get_client()`
+
+Always pass `version=` to `server.get_client()` when the DHCP version is known: `server.get_client(version=self.dhcp_version)`. Omitting it falls back to `ca_url` regardless of whether a protocol-specific URL is configured.
+
 ### API URL naming
 
 The serializer's `HyperlinkedIdentityField` uses `view_name="plugins-api:netbox_kea-api:server-detail"` — the `plugins-api:` prefix and `-api:` namespace suffix are NetBox conventions.
 
-## Feature Roadmap & Development Approach
-
-### Kea API Reference
+## Kea API Reference
 
 - **Primary**: `kea.readthedocs.io/en/latest/api.html` — 206 commands with full JSON schemas. `web_fetch` specific anchors when implementing a new command.
-- **Live discovery**: run `list-commands` against the target server (see `get_available_commands()` pattern) to confirm which hook libraries are loaded. Many commands require hooks (see below).
+- **Live discovery**: run `list-commands` against the target server to confirm which hook libraries are loaded. Many commands require hooks.
 - **Key hooks** and the commands they gate:
   - `host_cmds` — all `reservation-*` commands (open source since Kea 2.7.7 / MPL 2.0)
   - `lease_cmds` — `lease4/6-get-by-hostname/hw-address/state`, `lease4/6-update/add`
   - `subnet_cmds` — `subnet4/6-list/get/add/update` (alternative to `config-get`)
   - `stat_cmds` — `stat-lease4/6-get` for utilization per subnet
 - **Hook detection pattern**: call `list-commands` with service, cache per request, show warning banner in UI if a required command is absent.
+- **Pool operations**: support both Kea 2.x and 3.x APIs.
 
-### Phase Plan (Priority Order)
+## Feature Roadmap
 
-#### Phase 1 — Dual-URL Server (model migration) [P1]
+### Done (current codebase)
 
-Add optional `dhcp4_url` / `dhcp6_url` fields to `Server` so a single object can point to separate
-`kea-v4-api.cnad.dev` and `kea-v6-api.cnad.dev` processes. Also add `has_control_agent` boolean.
-- `get_client()` gains a `version: Literal[4, 6] | None` parameter — returns a `KeaClient` at the
-  correct URL for that protocol.
-- Status view: `_get_ca_status()` is only called when `has_control_agent=True`; direct-daemon mode
-  shows per-service status without the misleading "Control Agent" row.
-- DB migration required. Backward compatible: existing configs (single `server_url`) keep working.
+- ✅ **Dual-URL Server** — `dhcp4_url`/`dhcp6_url` fields, `has_control_agent` boolean, protocol-aware `get_client(version=)`
+- ✅ **Reservation Management** — full CRUD via `host_cmds` hook; v4 hw-address, v6 DUID; options; journal entries
+- ✅ **NetBox IPAM Sync** — leases→`IPAddress` (active), reservations→`IPAddress` (reserved), per-server toggle, background job with configurable interval, stale IP cleanup, `SyncConfig` singleton for global settings
+- ✅ **Subnet/Pool Sync** — Kea subnets→NetBox Prefixes, Kea pools→NetBox IP Ranges
+- ✅ **DNS Integration** — `dns_name` set from Kea hostname; netbox-dns IPAMDNSsync picks it up automatically
+- ✅ **Ghost Job Self-Heal** — `_heal_ghost_scheduled_jobs()` in `ready()` removes stale `scheduled` DB records after PostgreSQL failures
 
-#### Phase 2 — Reservation Management [P2]
+### Pending
 
-Full CRUD against `host_cmds` hook. Requires Phase 1 (protocol-aware client).
-- `ServerReservations4/6View` list tabs with `reservation-get-page` pagination
-- `ServerReservationAdd/Edit/DeleteView` using `reservation-add/update/del`
-- v4 identifier: `hw-address`; v6 identifier: `duid`. Optional `hostname`, `client-classes`, `option-data`.
-- Degrade gracefully if `host_cmds` not loaded.
-
-#### Phase 3 — NetBox IPAM Integration [P3]
-
-Replace the brittle external IP-update script.
-- **3a**: "Sync to NetBox IP" bulk action on lease table → create/update `IPAddress` (status=active,
-  dns_name from hostname, optional interface assignment by MAC).
-- **3b**: Reservation form links to a NetBox `IPAddress`; saving creates/updates IP with status=reserved.
-- **3c**: Action on NetBox `IPAddress` detail → "Create Kea Reservation" (prefilled).
-
-#### Phase 4 — DNS via netbox-dns IPAMDNSsync [P4]
-
-No direct netbox-dns API calls needed. Set `dns_name` on `IPAddress` (from lease hostname / reservation) →
-netbox-dns IPAMDNSsync auto-creates A/AAAA/PTR records via Django signals, provided DNS views + zones exist.
-- Check `importlib.util.find_spec("netbox_dns")` at runtime; optional `NETBOX_KEA_DNS_SYNC` plugin setting.
-- No hard dependency.
-
-#### Phase 5 — Subnet Utilization Statistics [P5]
-
-- `stat-lease4/6-get` (requires `stat_cmds`) → add utilization % column to subnet tables.
-- Degrade gracefully.
-
-### Convention: protocol-aware `get_client()`
-
-After Phase 1, all view code that currently calls `server.get_client()` should pass the protocol
-version where known: `server.get_client(version=self.dhcp_version)`. This is the primary breaking
-change to be aware of when updating views.
+- 🔲 **Subnet Utilization Statistics** — `stat-lease4/6-get` (requires `stat_cmds`) → utilization % column on subnet tables; degrade gracefully when hook absent
 
 ## Test Infrastructure
 
-Tests require Docker. `tests/test_setup.sh` generates TLS certs, builds a wheel, and starts the compose stack. The compose stack includes: NetBox, netbox-worker, postgres, redis, nginx (with basic auth + TLS), kea-ctrl-agent, kea-dhcp4, kea-dhcp6.
+### Unit tests (`netbox_kea/tests/`)
+
+No Docker required. All Kea HTTP calls are mocked. Key test files:
+
+- `test_plugin_config.py` — `_heal_ghost_scheduled_jobs()`, `_configure_sync_job_interval()`, `ready()` wiring
+- `test_jobs.py` — `KeaIpamSyncJob` sync logic, subnet/lease/reservation phases
+- `test_sync.py` — `sync_lease_to_netbox()`, `sync_reservation_to_netbox()`, stale IP cleanup
+- `test_sync_views.py` / `test_views_sync_jobs.py` — IPAM sync config UI and jobs tab views
+- `test_views_leases.py`, `test_views_reservations.py`, `test_views_subnets.py`, etc. — feature views
+- `test_kea_client.py` — `KeaClient` command dispatch, error handling
+- `test_models.py` — `Server.clean()`, `SyncConfig.get()`, credential censoring
+
+### Integration tests (`tests/`)
+
+Require Docker. `tests/test_setup.sh` generates TLS certs, builds a wheel, and starts the compose stack.
 
 `conftest.py` fixtures:
-- `nb_api` (session-scoped, autouse) — creates a pynetbox API client and **deletes all existing Kea servers** before the suite runs
-- `netbox_token` — provisions a token via the API (handles both v1 `key` and v2 `nbt_` format)
-- `nb_http` — a `requests.Session` with auth headers pre-set
-- `kea_basic_url` / `kea_basic_username` / `kea_basic_password` — point to the nginx proxy with HTTP Basic auth
+- `nb_api` (session-scoped, autouse) — pynetbox client; **deletes all existing Kea servers** before suite runs
+- `netbox_token` — provisions a token via the API
+- `nb_http` — `requests.Session` with auth headers pre-set
+- `kea_basic_url` / `kea_basic_username` / `kea_basic_password` — nginx proxy with HTTP Basic auth
 - `kea_https_url` — nginx with TLS
 
 Test files:
-- `tests/test_netbox_kea_api_server.py` — REST API CRUD tests using pynetbox
+- `tests/test_netbox_kea_api_server.py` — REST API CRUD via pynetbox
 - `tests/test_ui.py` — Playwright browser tests covering the full UI
 - `tests/kea.py` / `tests/constants.py` — shared test helpers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,10 +60,13 @@ URL request
 
 ### Core components
 
-- **`Server` model** (`models.py`): Only persisted model. Stores Kea connection config. `get_client(version=4|6|None)` returns a protocol-aware `KeaClient`. `clean()` performs live connectivity checks before saving.
+- **`Server` model** (`models.py`): Primary persisted model. Stores Kea connection config including dual-URL fields (`dhcp4_url`/`dhcp6_url`), per-protocol credentials, sync toggles, `persist_config`, and `sync_vrf`. `get_client(version=4|6|None)` returns a protocol-aware `KeaClient`. `clean()` performs live connectivity checks before saving.
+- **`SyncConfig` model** (`models.py`): Singleton (pk=1 always) for global IPAM sync settings — `interval_minutes`, `sync_enabled` (global kill-switch), four type-toggle fields, `backfill_applied`. `SyncConfig.get(default_interval)` handles creation-on-first-boot and one-time PLUGINS_CONFIG backfill; once `backfill_applied=True` the method never overrides UI changes.
 - **`KeaClient`** (`kea.py`): Wraps `requests.Session`. All Kea API calls go through `.command(command, service, arguments)` which POSTs JSON to `/api/v1/`. Methods for leases, reservations, subnets, pools, status, config. `.clone()` creates a thread-safe copy for concurrent lookups.
-- **`sync.py`**: Bridges Kea data to NetBox IPAM — `sync_lease_to_netbox()` (status=dhcp/active), `sync_reservation_to_netbox()` (status=reserved/active). Handles stale IP cleanup with `cleanup_stale_ips_batch()`.
-- **REST API** (`api/`): `NetBoxModelViewSet` for `Server` only. Password is write-only.
+- **`sync.py`**: Bridges Kea data to NetBox IPAM — `sync_lease_to_netbox()` (status=active), `sync_reservation_to_netbox()` (status=reserved). Handles stale IP cleanup with `cleanup_stale_ips_batch()`. Raises `PartialPersistError` for partial failures.
+- **`jobs.py`**: `KeaIpamSyncJob` decorated with `@system_job`. Iterates all `Server` objects, runs lease/reservation/prefix/range sync phases, writes per-server summary to job log.
+- **`__init__.py`**: `ready()` calls `_configure_sync_job_interval()` (patches in-memory RQ registry from PLUGINS_CONFIG — no DB access, safe at image build time) and `_heal_ghost_scheduled_jobs()` (removes ghost `scheduled`/`pending` DB records whose RQ counterpart is dead/missing — three-level exception nesting for startup safety).
+- **REST API** (`api/`): `NetBoxModelViewSet` for `Server` only. All password fields are write-only.
 - **GraphQL** (`graphql.py`): strawberry-django types, auto-discovered by NetBox.
 
 ### Key patterns

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ uv run pre-commit install
 uv build
 
 # Run unit tests (no Docker required)
-uv run pytest netbox_kea/tests/ --reuse-db -q
+uv run pytest -q
 
 # Run integration tests (requires Docker — see tests/test_setup.sh)
 ./tests/test_setup.sh

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -16,6 +16,7 @@ path = [
     ".github/copilot-instructions.md",
     ".github/workflows/codeql.yml",
     ".env.example",
+    ".envrc.example",
     ".devcontainer/**",
     "netbox_kea/migrations/0003_server_dual_url.py",
     "netbox_kea/migrations/0005_add_syncconfig.py",

--- a/uv.lock
+++ b/uv.lock
@@ -808,7 +808,7 @@ wheels = [
 
 [[package]]
 name = "netbox-kea-ng"
-version = "1.3.3"
+version = "1.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "netaddr" },


### PR DESCRIPTION


- Rewrite .github/copilot-instructions.md to reflect current codebase state: views/ directory structure, SyncConfig singleton, sync.py/jobs.py/signals.py, __init__.py ghost-job healing, completed phases (dual-URL, reservations, IPAM sync, DNS), unit vs integration vs e2e test split
- Update CLAUDE.md: add SyncConfig and __init__.py to core components, correct sync.py status values (active/reserved not dhcp/active)
- README: remove non-existent --reuse-db flag from unit test command
- Add .envrc.example: uv sync + source .venv/bin/activate for direnv users
- uv.lock: fix stale self-version reference (1.3.3 → 1.4.3)
- REUSE.toml: register .envrc.example

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation with expanded module layout and detailed component descriptions.
  * Refreshed development build, test, and lint command guidance with current examples.
  * Enhanced core component documentation including startup initialization, behavior, and configuration details.

* **Chores**
  * Added development environment configuration example file for automated project setup.
  * Updated project file tracking configuration.
  * Refined test command documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marcinpsk/netbox-kea/pull/68)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->