### PR TITLE
fix: move ghost-job self-heal out of ready(); migrate deprecated querystring tag

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -52,7 +52,7 @@ The compose stack includes: NetBox, netbox-worker, postgres, redis, nginx (basic
 
 Playwright end-to-end tests live in `e2e/` and are separate from both unit and integration tests.
 
-CI tests against NetBox v4.0–v4.5 using a matrix build. Playwright traces on failure are uploaded as artifacts.
+CI tests against NetBox v4.3–v4.5 using a matrix build. Playwright traces on failure are uploaded as artifacts.
 
 Ruff is configured in `pyproject.toml` — migrations are excluded from linting. Line length (E501) is ignored.
 
@@ -107,7 +107,7 @@ URL request
 
 **`jobs.py`** — `KeaIpamSyncJob` decorated with `@system_job(interval=_DEFAULT_INTERVAL)`. Iterates all `Server` objects, calls sync.py functions, writes per-server summary to job log.
 
-**`__init__.py`** — `NetBoxKeaConfig.ready()` calls `_configure_sync_job_interval()` (patches in-memory registry from PLUGINS_CONFIG, no DB access) and `_heal_ghost_scheduled_jobs()` (removes ghost `scheduled`/`pending` DB records whose RQ counterpart is dead/missing — three-level exception nesting for startup safety).
+**`__init__.py`** — `NetBoxKeaConfig.ready()` calls `_configure_sync_job_interval()` (patches in-memory registry from PLUGINS_CONFIG, no DB access). Ghost-job healing (`_heal_ghost_scheduled_jobs()`) runs inside `KeaIpamSyncJob.enqueue_once()` — not in `ready()` — to avoid DB access at app startup.
 
 **REST API** (`api/`) uses `NetBoxModelViewSet` + `NetBoxModelSerializer` — only the `Server` model is exposed. All password fields are write-only in the serializer.
 
@@ -169,7 +169,7 @@ The serializer's `HyperlinkedIdentityField` uses `view_name="plugins-api:netbox_
 
 No Docker required. All Kea HTTP calls are mocked. Key test files:
 
-- `test_plugin_config.py` — `_heal_ghost_scheduled_jobs()`, `_configure_sync_job_interval()`, `ready()` wiring
+- `test_plugin_config.py` — `_heal_ghost_scheduled_jobs()` (on `KeaIpamSyncJob`), `_configure_sync_job_interval()`, `ready()` wiring
 - `test_jobs.py` — `KeaIpamSyncJob` sync logic, subnet/lease/reservation phases
 - `test_sync.py` — `sync_lease_to_netbox()`, `sync_reservation_to_netbox()`, stale IP cleanup
 - `test_sync_views.py` / `test_views_sync_jobs.py` — IPAM sync config UI and jobs tab views

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,15 @@ name: CI
   schedule:
     - cron: 0 0 * * 0
 
+permissions: read-all
+
 jobs:
   unit-test:
     runs-on: ubuntu-latest
 
     services:
       postgres:
-        image: postgres:16
+        image: postgres:16@sha256:adac386a3163424d8397b51b950187eaa661013020a1b9e0d5437a9752040f80
         env:
           POSTGRES_USER: netbox
           POSTGRES_PASSWORD: netbox
@@ -28,27 +30,30 @@ jobs:
         ports:
           - 5432:5432
       redis:
-        image: redis:7
+        image: redis:7@sha256:d7fcf65186e011faaa401b5e6edf5147e9dd01353984c795e515f6fee7dfbe6e
         ports:
           - 6379:6379
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Checkout NetBox
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           repository: netbox-community/netbox
           ref: v4.5.5
           path: netbox
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
           enable-cache: true
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version-file: pyproject.toml
 
@@ -94,7 +99,7 @@ jobs:
             --no-header -q
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238  # v4.6.0
         with:
           files: ./coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -103,15 +108,17 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
           enable-cache: true
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version-file: pyproject.toml
 
@@ -138,16 +145,18 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
           enable-cache: true
 
       - name: Setup Python 3.12
         id: setup-python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version-file: pyproject.toml
 
@@ -167,7 +176,7 @@ jobs:
           uv run pytest tests/ -p no:django --tracing=retain-on-failure -v
 
       - name: Upload Playwright traces
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         if: ${{ !cancelled() }}
         with:
           name: playwright-traces-${{ matrix.netbox }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,6 +15,10 @@ on:
   schedule:
     - cron: '44 18 * * 1'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
@@ -33,6 +37,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@c793b717bc78562f491db7b0e93a3a178b099162  # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,17 +17,17 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
           enable-cache: true
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version-file: pyproject.toml
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ E2E tests live in `e2e/` and are separate from both unit and integration tests.
 
 ### CI
 
-GitHub Actions matrix tests against NetBox v4.0–v4.5. Playwright traces uploaded as artifacts on failure.
+GitHub Actions matrix tests against NetBox v4.3–v4.5. Playwright traces uploaded as artifacts on failure.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ URL request
 - **`KeaClient`** (`kea.py`): Wraps `requests.Session`. All Kea API calls go through `.command(command, service, arguments)` which POSTs JSON to `/api/v1/`. Methods for leases, reservations, subnets, pools, status, config. `.clone()` creates a thread-safe copy for concurrent lookups.
 - **`sync.py`**: Bridges Kea data to NetBox IPAM — `sync_lease_to_netbox()` (status=active), `sync_reservation_to_netbox()` (status=reserved). Handles stale IP cleanup with `cleanup_stale_ips_batch()`. Raises `PartialPersistError` for partial failures.
 - **`jobs.py`**: `KeaIpamSyncJob` decorated with `@system_job`. Iterates all `Server` objects, runs lease/reservation/prefix/range sync phases, writes per-server summary to job log.
-- **`__init__.py`**: `ready()` calls `_configure_sync_job_interval()` (patches in-memory RQ registry from PLUGINS_CONFIG — no DB access, safe at image build time) and `_heal_ghost_scheduled_jobs()` (removes ghost `scheduled`/`pending` DB records whose RQ counterpart is dead/missing — three-level exception nesting for startup safety).
+- **`__init__.py`**: `ready()` calls `_configure_sync_job_interval()` (patches in-memory RQ registry from PLUGINS_CONFIG — no DB access, safe at image build time).
 - **REST API** (`api/`): `NetBoxModelViewSet` for `Server` only. All password fields are write-only.
 - **GraphQL** (`graphql.py`): strawberry-django types, auto-discovered by NetBox.
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -4,6 +4,31 @@
 version = 1
 
 [[annotations]]
+# All upstream files from Devon Mar (original netbox-kea author)
+path = [
+    "README.md",
+    "LICENSE",
+    "uv.lock",
+    ".gitignore",
+    "images/**",
+    "pyproject.toml",
+    "netbox_kea/**",
+    "tests/**",
+]
+SPDX-FileCopyrightText = "Devon Mar <devon-mar@users.noreply.github.com>"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+# Original upstream workflow/config files
+path = [
+    ".github/workflows/ci.yml",
+    ".github/workflows/release.yml",
+    ".github/dependabot.yml",
+]
+SPDX-FileCopyrightText = "Devon Mar <devon-mar@users.noreply.github.com>"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
 # New and modified files by Marcin Zieba
 path = [
     "REUSE.toml",
@@ -66,29 +91,4 @@ path = [
     ".superpowers/**",
 ]
 SPDX-FileCopyrightText = "Copyright (C) 2025 Marcin Zieba <marcinpsk@gmail.com>"
-SPDX-License-Identifier = "Apache-2.0"
-
-[[annotations]]
-# All upstream files from Devon Mar (original netbox-kea author)
-path = [
-    "README.md",
-    "LICENSE",
-    "uv.lock",
-    ".gitignore",
-    "images/**",
-    "pyproject.toml",
-    "netbox_kea/**",
-    "tests/**",
-]
-SPDX-FileCopyrightText = "Devon Mar <devon-mar@users.noreply.github.com>"
-SPDX-License-Identifier = "Apache-2.0"
-
-[[annotations]]
-# Original upstream workflow/config files
-path = [
-    ".github/workflows/ci.yml",
-    ".github/workflows/release.yml",
-    ".github/dependabot.yml",
-]
-SPDX-FileCopyrightText = "Devon Mar <devon-mar@users.noreply.github.com>"
 SPDX-License-Identifier = "Apache-2.0"

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -40,7 +40,6 @@ path = [
     "copilot-instructions.md",
     ".github/copilot-instructions.md",
     ".github/workflows/codeql.yml",
-    ".env.example",
     ".envrc.example",
     ".devcontainer/**",
     "netbox_kea/migrations/0003_server_dual_url.py",

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -36,7 +36,7 @@ uv run pre-commit install
 
 Unit tests live in `netbox_kea/tests/`. `pythonpath` is set to `/opt/netbox/netbox` and `DJANGO_SETTINGS_MODULE=netbox.settings`.
 
-Integration tests live in `tests/`. E2E tests live in `e2e/`. CI tests against NetBox v4.0–v4.5 using a matrix build. Playwright traces on failure are uploaded as artifacts.
+Integration tests live in `tests/`. E2E tests live in `e2e/`. CI tests against NetBox v4.3–v4.5 using a matrix build. Playwright traces on failure are uploaded as artifacts.
 
 Ruff is configured in `pyproject.toml` — migrations are excluded from linting. Line length 120, max complexity 15. E501 ignored (handled by formatter). Docstrings required except in tests/migrations/`__init__.py`.
 

--- a/e2e/test_kea_plugin_e2e.py
+++ b/e2e/test_kea_plugin_e2e.py
@@ -1303,7 +1303,7 @@ class TestSubnetManagementLiveKea:
     def _kea4_cleanup_subnet(self, kea4_call, cidr: str) -> None:
         """Remove every Kea subnet whose CIDR matches *cidr* (direct API call)."""
         data = kea4_call("subnet4-list")
-        for s in data.get("arguments", {}).get("subnets", []):
+        for s in (data.get("arguments") or {}).get("subnets", []):
             if s.get("subnet") == cidr:
                 kea4_call("subnet4-del", {"id": s["id"]})
 

--- a/netbox_kea/__init__.py
+++ b/netbox_kea/__init__.py
@@ -32,7 +32,6 @@ class NetBoxKeaConfig(PluginConfig):
         """Apply runtime configuration overrides after Django is fully initialised."""
         super().ready()
         self._configure_sync_job_interval()
-        self._heal_ghost_scheduled_jobs()
 
     def _configure_sync_job_interval(self) -> None:
         """Seed the KeaIpamSyncJob interval from PLUGINS_CONFIG at startup.
@@ -62,74 +61,6 @@ class NetBoxKeaConfig(PluginConfig):
         except Exception:  # noqa: BLE001
             logger.warning(
                 "Failed to apply netbox_kea sync interval override; using decorator default.",
-                exc_info=True,
-            )
-
-    def _heal_ghost_scheduled_jobs(self) -> None:
-        """Remove ghost scheduled-job DB records that have no live RQ counterpart.
-
-        A ghost record arises when a periodic job's execution fails at the DB level
-        (e.g. PostgreSQL in recovery mode) — the DB record stays ``scheduled`` forever
-        while RQ marks the job ``failed``.  NetBox's ``enqueue_once()`` trusts the DB
-        status and skips re-scheduling, silently breaking the periodic chain.
-
-        Deleting stale DB records here lets the worker's ``enqueue_once()`` call
-        (which runs immediately after ``ready()``) create a fresh schedule.
-
-        Safe to call in all contexts:
-        - Never enqueues jobs (deferred to ``rqworker``).
-        - All DB and Redis I/O is wrapped so a missing DB or Redis at image-build
-          time never breaks startup.
-        """
-        try:
-            import django_rq
-            from rq.exceptions import NoSuchJobError
-            from rq.job import Job as RQJob
-
-            from .jobs import KeaIpamSyncJob
-
-            candidates = KeaIpamSyncJob.get_jobs(None).filter(status__in=("scheduled", "pending"))
-            if not candidates.exists():
-                return
-
-            conn = django_rq.get_connection("default")
-            _DEAD = {"failed", "canceled", "stopped"}
-
-            deleted = 0
-            for db_job in candidates:
-                try:
-                    job_id = str(db_job.job_id) if db_job.job_id else None
-                    if job_id is None:
-                        db_job.delete()
-                        deleted += 1
-                        continue
-                    try:
-                        rq_job = RQJob.fetch(job_id, connection=conn)
-                        status = rq_job.get_status()
-                        # Handle both enum (rq ≥ 1.16) and plain string
-                        status_str = status.value if hasattr(status, "value") else str(status)
-                        if status_str in _DEAD:
-                            db_job.delete()
-                            deleted += 1
-                    except NoSuchJobError:
-                        db_job.delete()
-                        deleted += 1
-                except Exception:  # noqa: BLE001
-                    logger.debug(
-                        "netbox_kea: skipping ghost-job check for record %r due to per-record error.",
-                        getattr(db_job, "pk", None),
-                        exc_info=True,
-                    )
-
-            if deleted:
-                logger.warning(
-                    "netbox_kea: removed %d ghost scheduled-job record(s) with a dead or missing "
-                    "RQ counterpart. Periodic IPAM sync will resume on the next worker startup.",
-                    deleted,
-                )
-        except Exception:  # noqa: BLE001
-            logger.warning(
-                "netbox_kea: ghost-job self-heal skipped (DB or Redis not available at startup).",
                 exc_info=True,
             )
 

--- a/netbox_kea/api/views.py
+++ b/netbox_kea/api/views.py
@@ -86,6 +86,9 @@ class ServerViewSet(NetBoxModelViewSet):
         except KeaException:
             logger.exception("Kea error on server %s", server.name)
             return Response({"detail": "An internal error occurred"}, status=status.HTTP_502_BAD_GATEWAY)
+        except ValueError:
+            logger.exception("Configuration error for server %s", server.name)
+            return Response({"detail": "Server configuration error."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         except Exception:
             logger.exception("Unexpected error fetching leases from %s", server.name)
             return Response({"detail": "An internal error occurred"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
@@ -226,6 +229,9 @@ class ServerViewSet(NetBoxModelViewSet):
         except KeaException:
             logger.exception("Kea error on server %s", server.name)
             return Response({"detail": "An internal error occurred"}, status=status.HTTP_502_BAD_GATEWAY)
+        except ValueError:
+            logger.exception("Configuration error for server %s", server.name)
+            return Response({"detail": "Server configuration error."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         except Exception:
             logger.exception("Unexpected error fetching reservations from %s", server.name)
             return Response({"detail": "An internal error occurred"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/netbox_kea/constants.py
+++ b/netbox_kea/constants.py
@@ -23,9 +23,4 @@ LEASE_STATE_LABELS: dict[int, str] = {
     2: "Expired",
 }
 
-LEASE_STATE_CHOICES = [
-    ("", "Any"),
-    ("0", "Active"),
-    ("1", "Declined"),
-    ("2", "Expired"),
-]
+LEASE_STATE_CHOICES = [("", "Any")] + [(str(k), v) for k, v in LEASE_STATE_LABELS.items()]

--- a/netbox_kea/jobs.py
+++ b/netbox_kea/jobs.py
@@ -482,6 +482,93 @@ class KeaIpamSyncJob(JobRunner):
     class Meta:
         name = "Kea IPAM Sync"
 
+    @classmethod
+    def enqueue_once(cls, *args: Any, **kwargs: Any) -> Any:
+        """Heal ghost scheduled-job records before delegating to NetBox.
+
+        NetBox schedules system jobs by calling ``enqueue_once`` on the job class
+        once per ``rqworker`` startup (``core/management/commands/rqworker.py``).
+        That runs after app initialisation and on the worker process only — so it
+        is the correct place to reconcile stale schedule state, unlike
+        ``AppConfig.ready()`` which also fires during ``collectstatic``/``migrate``
+        (where the DB may be unreachable) and triggers Django's "database access
+        during app initialization" warning.
+
+        We clean ghost records first, then delegate to the stock
+        ``enqueue_once`` so it can create a fresh schedule.  ``*args``/``**kwargs``
+        are forwarded verbatim to insulate against signature drift across NetBox
+        versions.
+        """
+        cls._heal_ghost_scheduled_jobs()
+        return super().enqueue_once(*args, **kwargs)
+
+    @classmethod
+    def _heal_ghost_scheduled_jobs(cls) -> None:
+        """Remove ghost scheduled-job DB records that have no live RQ counterpart.
+
+        A ghost record arises when a periodic job's execution fails at the DB level
+        (e.g. PostgreSQL in recovery mode) — the DB record stays ``scheduled`` forever
+        while RQ marks the job ``failed``.  NetBox's ``enqueue_once()`` trusts the DB
+        status and skips re-scheduling, silently breaking the periodic chain.
+
+        Deleting stale DB records here lets the immediately-following
+        ``super().enqueue_once()`` call create a fresh schedule.
+
+        Safe to call in all contexts:
+        - Never enqueues jobs (the caller handles that).
+        - All DB and Redis I/O is wrapped so a missing DB or a Redis still coming
+          up at worker startup never breaks scheduling.
+        """
+        try:
+            import django_rq
+            from rq.exceptions import NoSuchJobError
+            from rq.job import Job as RQJob
+
+            candidates = cls.get_jobs(None).filter(status__in=("scheduled", "pending"))
+            if not candidates.exists():
+                return
+
+            conn = django_rq.get_connection("default")
+            _DEAD = {"failed", "canceled", "stopped"}
+
+            deleted = 0
+            for db_job in candidates:
+                try:
+                    job_id = str(db_job.job_id) if db_job.job_id else None
+                    if job_id is None:
+                        db_job.delete()
+                        deleted += 1
+                        continue
+                    try:
+                        rq_job = RQJob.fetch(job_id, connection=conn)
+                        status = rq_job.get_status()
+                        # Handle both enum (rq ≥ 1.16) and plain string
+                        status_str = status.value if hasattr(status, "value") else str(status)
+                        if status_str in _DEAD:
+                            db_job.delete()
+                            deleted += 1
+                    except NoSuchJobError:
+                        db_job.delete()
+                        deleted += 1
+                except Exception:  # noqa: BLE001
+                    logger.debug(
+                        "netbox_kea: skipping ghost-job check for record %r due to per-record error.",
+                        getattr(db_job, "pk", None),
+                        exc_info=True,
+                    )
+
+            if deleted:
+                logger.warning(
+                    "netbox_kea: removed %d ghost scheduled-job record(s) with a dead or missing "
+                    "RQ counterpart. Periodic IPAM sync will resume now.",
+                    deleted,
+                )
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "netbox_kea: ghost-job self-heal skipped (DB or Redis not available at scheduling time).",
+                exc_info=True,
+            )
+
     def run(self, *args: Any, **kwargs: Any) -> None:
         """Execute the sync across all servers."""
         from .models import Server, SyncConfig

--- a/netbox_kea/jobs.py
+++ b/netbox_kea/jobs.py
@@ -674,4 +674,7 @@ class KeaIpamSyncJob(JobRunner):
             if not isinstance(self.job.data, dict):
                 self.job.data = {}
             self.job.data["summary"] = summary
-            self.job.save(update_fields=["data"])
+            try:
+                self.job.save(update_fields=["data"])
+            except Exception:
+                logger.exception("Failed to persist sync job summary data")

--- a/netbox_kea/kea.py
+++ b/netbox_kea/kea.py
@@ -144,7 +144,7 @@ class KeaClient:
 
         """
         resp = self.command("list-commands", service=[service])
-        return set(resp[0].get("arguments", []))
+        return set(resp[0].get("arguments") or [])
 
     def reservation_get_page(
         self,
@@ -942,6 +942,10 @@ class KeaClient:
         if resp[0]["result"] == 3:
             raise KeaException(resp[0])
         lease = resp[0]["arguments"]
+        if not isinstance(lease, dict):
+            raise ValueError(
+                f"lease{version}-get returned result=0 but arguments is {type(lease).__name__}, expected dict"
+            )
         if hostname is not None:
             lease["hostname"] = hostname
         if hw_address is not None:

--- a/netbox_kea/kea.py
+++ b/netbox_kea/kea.py
@@ -144,6 +144,8 @@ class KeaClient:
 
         """
         resp = self.command("list-commands", service=[service])
+        if not resp or not isinstance(resp[0], dict):
+            raise RuntimeError(f"list-commands returned malformed response: {resp!r}")
         return set(resp[0].get("arguments") or [])
 
     def reservation_get_page(

--- a/netbox_kea/models.py
+++ b/netbox_kea/models.py
@@ -18,6 +18,18 @@ from .kea import KeaClient, KeaException
 logger = logging.getLogger(__name__)
 
 
+def _get_kea_timeout(default: int = 30) -> int:
+    """Return kea_timeout from PLUGINS_CONFIG, coerced to int with a safe fallback."""
+    plugins_config = getattr(settings, "PLUGINS_CONFIG", {})
+    if not isinstance(plugins_config, dict):
+        return default
+    raw = plugins_config.get("netbox_kea", {}).get("kea_timeout", default)
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return default
+
+
 class Server(JobsMixin, NetBoxModel):
     """A Kea DHCP server instance managed through the Kea Control API."""
 
@@ -206,7 +218,7 @@ class Server(JobsMixin, NetBoxModel):
             verify=self.ca_file_path or self.ssl_verify,
             client_cert=self.client_cert_path or None,
             client_key=self.client_key_path or None,
-            timeout=settings.PLUGINS_CONFIG.get("netbox_kea", {}).get("kea_timeout", 30),
+            timeout=_get_kea_timeout(),
             persist_config=self.persist_config,
         )
 

--- a/netbox_kea/models.py
+++ b/netbox_kea/models.py
@@ -206,7 +206,7 @@ class Server(JobsMixin, NetBoxModel):
             verify=self.ca_file_path or self.ssl_verify,
             client_cert=self.client_cert_path or None,
             client_key=self.client_key_path or None,
-            timeout=settings.PLUGINS_CONFIG["netbox_kea"]["kea_timeout"],
+            timeout=settings.PLUGINS_CONFIG.get("netbox_kea", {}).get("kea_timeout", 30),
             persist_config=self.persist_config,
         )
 

--- a/netbox_kea/models.py
+++ b/netbox_kea/models.py
@@ -23,7 +23,7 @@ def _get_kea_timeout(default: int = 30) -> int:
     plugins_config = getattr(settings, "PLUGINS_CONFIG", {})
     if not isinstance(plugins_config, dict):
         return default
-    raw = plugins_config.get("netbox_kea", {}).get("kea_timeout", default)
+    raw = (plugins_config.get("netbox_kea") or {}).get("kea_timeout", default)
     try:
         return int(raw)
     except (TypeError, ValueError):

--- a/netbox_kea/templates/netbox_kea/inc/server_dhcp_leases_paginator.html
+++ b/netbox_kea/templates/netbox_kea/inc/server_dhcp_leases_paginator.html
@@ -1,4 +1,3 @@
-{% load helpers %}
 <div class="d-flex justify-content-between align-items-center border-{% if placement == "top" %}bottom{% else %}top{% endif %} p-2">
   {% if paginate %}
     <div>
@@ -6,7 +5,7 @@
         class="btn btn-sm btn-outline-secondary{% if not next_page %} disabled{% endif %}"
         role="button"
         {% if next_page %}
-        hx-get="{% querystring request page=next_page %}"
+        hx-get="{% querystring page=next_page %}"
         hx-indicator="#next-indicator"
         {% else %}
         aria-disabled="true"
@@ -26,7 +25,7 @@
       </button>
       <div class="dropdown-menu">
         {% for n in page_lengths %}
-          <a href="#" hx-get="{% querystring request per_page=n %}" class="dropdown-item">{{ n }}</a>
+          <a href="#" hx-get="{% querystring per_page=n %}" class="dropdown-item">{{ n }}</a>
         {% endfor %}
       </div>
     </div>

--- a/netbox_kea/templates/netbox_kea/server_dhcp_leases_htmx.html
+++ b/netbox_kea/templates/netbox_kea/server_dhcp_leases_htmx.html
@@ -1,5 +1,5 @@
 {% load form_helpers %}
-{% load helpers %}
+{% load get_key from helpers %}
 {% load render_table from django_tables2 %}
 
 <div id="lease-search" hx-target="#lease-search" hx-swap="outerHTML" hx-push-url="true">
@@ -59,8 +59,8 @@
               <i class="mdi mdi-download"></i> Export
             </button>
             <ul class="dropdown-menu dropdown-menu-end">
-              <li><a class="dropdown-item" href="{% querystring request export="table" %}">Current View</a></li>
-              <li><a class="dropdown-item" href="{% querystring request export="" %}">All Data (CSV)</a></li>
+              <li><a class="dropdown-item" href="{% querystring export="table" %}">Current View</a></li>
+              <li><a class="dropdown-item" href="{% querystring export="" %}">All Data (CSV)</a></li>
               <li><hr class="dropdown-divider"></li>
               <li><a class="dropdown-item" href="?export_all=1">Export All Leases (CSV)</a></li>
             </ul>

--- a/netbox_kea/templates/netbox_kea/server_lease_add.html
+++ b/netbox_kea/templates/netbox_kea/server_lease_add.html
@@ -28,8 +28,11 @@
         {% endif %}
         <form method="post">
           {% csrf_token %}
-
-          {% for field in form %}
+          {% if form.non_field_errors %}
+            <div class="alert alert-danger" role="alert">
+              {% for err in form.non_field_errors %}<div>{{ err }}</div>{% endfor %}
+            </div>
+          {% endif %}
             <div class="mb-3">
               <label for="{{ field.id_for_label }}" class="form-label">{{ field.label }}</label>
               {{ field }}

--- a/netbox_kea/templates/netbox_kea/server_lease_add.html
+++ b/netbox_kea/templates/netbox_kea/server_lease_add.html
@@ -33,6 +33,7 @@
               {% for err in form.non_field_errors %}<div>{{ err }}</div>{% endfor %}
             </div>
           {% endif %}
+          {% for field in form %}
             <div class="mb-3">
               <label for="{{ field.id_for_label }}" class="form-label">{{ field.label }}</label>
               {{ field }}

--- a/netbox_kea/tests/test_api_leases.py
+++ b/netbox_kea/tests/test_api_leases.py
@@ -229,6 +229,15 @@ class TestLease4API(_APITestBase):
         response = self.api_client.get(self._url(), {"ip_address": "10.0.0.1"})
         self.assertEqual(response.status_code, 502)
 
+    @patch.object(Server, "get_client")
+    def test_get_client_called_with_version_4(self, mock_get_client):
+        """The view calls server.get_client(version=4) to select the DHCPv4 endpoint."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.command.return_value = _LEASE4_RESPONSE
+        self.api_client.get(self._url(), {"ip_address": "10.0.0.100"})
+        mock_get_client.assert_called_once_with(version=4)
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Lease6 search tests
@@ -313,3 +322,24 @@ class TestLease6API(_APITestBase):
         call_args = mock_client.command.call_args
         service = call_args.kwargs.get("service") or (call_args.args[1] if len(call_args.args) > 1 else None)
         self.assertEqual(service, ["dhcp6"])
+
+    @patch.object(Server, "get_client")
+    def test_get_client_called_with_version_6(self, mock_get_client):
+        """The view calls server.get_client(version=6) to select the DHCPv6 endpoint."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.command.return_value = [
+            {
+                "result": 0,
+                "arguments": {
+                    "ip-address": "2001:db8::1",
+                    "duid": "00:01:02:03",
+                    "iaid": 12345,
+                    "valid-lft": 3600,
+                    "cltt": 1700000000,
+                    "state": 0,
+                },
+            }
+        ]
+        self.api_client.get(self._url(), {"ip_address": "2001:db8::1"})
+        mock_get_client.assert_called_once_with(version=6)

--- a/netbox_kea/tests/test_api_views_direct.py
+++ b/netbox_kea/tests/test_api_views_direct.py
@@ -1,0 +1,452 @@
+# SPDX-FileCopyrightText: 2025 Marcin Zieba <marcinpsk@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+"""Direct unit tests for api/views.py — no database required.
+
+Covers all paths in _lease_search, _fetch_leases, _reservation_search, and
+_fetch_reservations.  The TestCase-based api test files cover the same happy
+paths via a real DB + HTTP stack; these SimpleTestCase tests provide fast,
+DB-free coverage for every branch.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import requests as rq
+from django.test import SimpleTestCase, override_settings
+from rest_framework import status
+
+from netbox_kea.api.views import ServerViewSet
+from netbox_kea.kea import KeaException
+
+_PLUGINS_CONFIG = {"netbox_kea": {"kea_timeout": 30}}
+
+# Minimal KeaResponse dict accepted by KeaException.__init__
+_KEA_ERR_RESP = {"result": 1, "text": "command failed"}
+
+
+def _make_view():
+    """Return a ServerViewSet with get_object() mocked to return a mock Server."""
+    view = ServerViewSet()
+    view.kwargs = {}
+    view.format_kwarg = None
+    mock_server = MagicMock()
+    mock_server.name = "test-server"
+    view.get_object = MagicMock(return_value=mock_server)
+    view.check_permissions = MagicMock()
+    view.check_object_permissions = MagicMock()
+    return view, mock_server
+
+
+def _make_request(query_params: dict):
+    """Return a minimal mock request with the given query_params dict."""
+    req = MagicMock()
+    req.query_params = query_params
+    return req
+
+
+def _view_with_command(command_return):
+    """Return (view, mock_client) with client.command pre-configured."""
+    view, server = _make_view()
+    mock_client = MagicMock()
+    mock_client.command.return_value = command_return
+    server.get_client.return_value = mock_client
+    return view, mock_client
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# leases4 / leases6 action dispatch
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
+class TestLeaseActionDispatch(SimpleTestCase):
+    """leases4() and leases6() dispatch to _lease_search with the right version."""
+
+    def test_leases4_dispatches_with_version_4(self):
+        view, server = _make_view()
+        mock_client = MagicMock()
+        mock_client.command.return_value = [{"result": 0, "arguments": None}]
+        server.get_client.return_value = mock_client
+        response = view.leases4(_make_request({"ip_address": "10.0.0.1"}), pk=1)
+        server.get_client.assert_called_once_with(version=4)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_leases6_dispatches_with_version_6(self):
+        view, server = _make_view()
+        mock_client = MagicMock()
+        mock_client.command.return_value = [{"result": 0, "arguments": None}]
+        server.get_client.return_value = mock_client
+        response = view.leases6(_make_request({"ip_address": "2001:db8::1"}), pk=1)
+        server.get_client.assert_called_once_with(version=6)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _lease_search — parameter validation and error handling
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
+class TestLeaseSearchValidation(SimpleTestCase):
+    """Parameter validation paths in _lease_search."""
+
+    def test_no_params_returns_400(self):
+        view, _ = _make_view()
+        response = view._lease_search(_make_request({}), version=4)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("required", response.data["detail"])
+
+    def test_no_params_v6_includes_duid_in_message(self):
+        view, _ = _make_view()
+        response = view._lease_search(_make_request({}), version=6)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("duid", response.data["detail"])
+
+    def test_invalid_subnet_id_returns_400(self):
+        view, _ = _make_view()
+        response = view._lease_search(_make_request({"subnet_id": "not-a-number"}), version=4)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("subnet_id", response.data["detail"])
+
+
+@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
+class TestLeaseSearchErrors(SimpleTestCase):
+    """Error handling paths in _lease_search."""
+
+    def test_connection_error_returns_502(self):
+        view, server = _make_view()
+        server.get_client.side_effect = rq.ConnectionError("refused")
+        response = view._lease_search(_make_request({"ip_address": "10.0.0.1"}), version=4)
+        self.assertEqual(response.status_code, status.HTTP_502_BAD_GATEWAY)
+
+    def test_kea_exception_returns_502(self):
+        view, server = _make_view()
+        server.get_client.side_effect = KeaException(_KEA_ERR_RESP)
+        response = view._lease_search(_make_request({"ip_address": "10.0.0.1"}), version=4)
+        self.assertEqual(response.status_code, status.HTTP_502_BAD_GATEWAY)
+
+    def test_value_error_returns_500(self):
+        view, server = _make_view()
+        server.get_client.side_effect = ValueError("missing DHCPv4 URL")
+        response = view._lease_search(_make_request({"ip_address": "10.0.0.1"}), version=4)
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertIn("configuration error", response.data["detail"].lower())
+
+    def test_generic_exception_returns_500(self):
+        view, server = _make_view()
+        server.get_client.side_effect = RuntimeError("unexpected internal error")
+        response = view._lease_search(_make_request({"ip_address": "10.0.0.1"}), version=4)
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertIn("internal error", response.data["detail"].lower())
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _fetch_leases — all dispatch branches
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
+class TestFetchLeasesIpAddress(SimpleTestCase):
+    """ip_address branch in _fetch_leases (lines 112-122)."""
+
+    def test_result3_returns_empty(self):
+        view, _ = _view_with_command([{"result": 3, "text": "not found"}])
+        response = view._lease_search(_make_request({"ip_address": "10.0.0.99"}), version=4)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 0)
+
+    def test_null_arguments_returns_empty(self):
+        view, _ = _view_with_command([{"result": 0, "arguments": None}])
+        response = view._lease_search(_make_request({"ip_address": "10.0.0.1"}), version=4)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 0)
+
+    def test_lease_returned_in_results(self):
+        lease = {"ip-address": "10.0.0.1", "subnet-id": 1}
+        view, _ = _view_with_command([{"result": 0, "arguments": lease}])
+        response = view._lease_search(_make_request({"ip_address": "10.0.0.1"}), version=4)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+
+
+@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
+class TestFetchLeasesHwAddress(SimpleTestCase):
+    """hw_address branch in _fetch_leases (lines 124-133)."""
+
+    def test_result3_returns_empty(self):
+        view, _ = _view_with_command([{"result": 3}])
+        response = view._lease_search(_make_request({"hw_address": "aa:bb:cc:dd:ee:ff"}), version=4)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 0)
+
+    def test_leases_returned_in_results(self):
+        lease = {"ip-address": "10.0.0.1", "hw-address": "aa:bb:cc:dd:ee:ff", "subnet-id": 1}
+        view, _ = _view_with_command([{"result": 0, "arguments": {"leases": [lease]}}])
+        response = view._lease_search(_make_request({"hw_address": "aa:bb:cc:dd:ee:ff"}), version=4)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+
+
+@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
+class TestFetchLeasesDuid(SimpleTestCase):
+    """duid branch in _fetch_leases (lines 135-144)."""
+
+    def test_result3_returns_empty(self):
+        view, _ = _view_with_command([{"result": 3}])
+        response = view._lease_search(_make_request({"duid": "00:01:02:03"}), version=6)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 0)
+
+    def test_leases_returned_in_results(self):
+        lease = {"ip-address": "2001:db8::1", "duid": "00:01:02:03", "subnet-id": 10}
+        view, _ = _view_with_command([{"result": 0, "arguments": {"leases": [lease]}}])
+        response = view._lease_search(_make_request({"duid": "00:01:02:03"}), version=6)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+
+    def test_duid_on_v4_falls_through_to_empty(self):
+        """duid provided on v4 skips the duid branch; no other param matches → empty (line 168)."""
+        view, server = _make_view()
+        mock_client = MagicMock()
+        server.get_client.return_value = mock_client
+        response = view._lease_search(_make_request({"duid": "00:01:02:03"}), version=4)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 0)
+        mock_client.command.assert_not_called()
+
+
+@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
+class TestFetchLeasesHostname(SimpleTestCase):
+    """hostname branch in _fetch_leases (lines 146-155)."""
+
+    def test_result3_returns_empty(self):
+        view, _ = _view_with_command([{"result": 3}])
+        response = view._lease_search(_make_request({"hostname": "host1"}), version=4)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 0)
+
+    def test_leases_returned_in_results(self):
+        lease = {"ip-address": "10.0.0.1", "hostname": "host1", "subnet-id": 1}
+        view, _ = _view_with_command([{"result": 0, "arguments": {"leases": [lease]}}])
+        response = view._lease_search(_make_request({"hostname": "host1"}), version=4)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+
+
+@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
+class TestFetchLeasesSubnetId(SimpleTestCase):
+    """subnet_id branch in _fetch_leases (lines 157-166)."""
+
+    def test_result3_returns_empty(self):
+        view, _ = _view_with_command([{"result": 3}])
+        response = view._lease_search(_make_request({"subnet_id": "1"}), version=4)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 0)
+
+    def test_leases_returned_in_results(self):
+        lease = {"ip-address": "10.0.0.1", "subnet-id": 1}
+        view, _ = _view_with_command([{"result": 0, "arguments": {"leases": [lease]}}])
+        response = view._lease_search(_make_request({"subnet_id": "1"}), version=4)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# reservations4 / reservations6 action dispatch
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
+class TestReservationActionDispatch(SimpleTestCase):
+    """reservations4() and reservations6() dispatch with correct version."""
+
+    def test_reservations4_dispatches_with_version_4(self):
+        view, server = _make_view()
+        mock_client = MagicMock()
+        mock_client.reservation_get.return_value = {"ip-address": "10.0.0.50", "subnet-id": 1}
+        server.get_client.return_value = mock_client
+        response = view.reservations4(_make_request({"ip_address": "10.0.0.50", "subnet_id": "1"}), pk=1)
+        server.get_client.assert_called_once_with(version=4)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_reservations6_dispatches_with_version_6(self):
+        view, server = _make_view()
+        mock_client = MagicMock()
+        mock_client.reservation_get.return_value = {"ip-addresses": ["2001:db8::50"], "subnet-id": 10}
+        server.get_client.return_value = mock_client
+        response = view.reservations6(_make_request({"ip_address": "2001:db8::50", "subnet_id": "10"}), pk=1)
+        server.get_client.assert_called_once_with(version=6)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _reservation_search — parameter validation and error handling
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
+class TestReservationSearchValidation(SimpleTestCase):
+    """Parameter validation paths in _reservation_search."""
+
+    def test_no_params_returns_400(self):
+        view, _ = _make_view()
+        response = view._reservation_search(_make_request({}), version=4)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("required", response.data["detail"])
+
+    def test_no_params_v6_includes_duid_in_message(self):
+        view, _ = _make_view()
+        response = view._reservation_search(_make_request({}), version=6)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("duid", response.data["detail"])
+
+    def test_invalid_subnet_id_returns_400(self):
+        view, _ = _make_view()
+        response = view._reservation_search(_make_request({"subnet_id": "not-a-number"}), version=4)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("subnet_id", response.data["detail"])
+
+
+@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
+class TestReservationSearchErrors(SimpleTestCase):
+    """Error handling paths in _reservation_search."""
+
+    def test_connection_error_returns_502(self):
+        view, server = _make_view()
+        server.get_client.side_effect = rq.ConnectionError("refused")
+        response = view._reservation_search(_make_request({"subnet_id": "1"}), version=4)
+        self.assertEqual(response.status_code, status.HTTP_502_BAD_GATEWAY)
+
+    def test_kea_exception_returns_502(self):
+        view, server = _make_view()
+        server.get_client.side_effect = KeaException(_KEA_ERR_RESP)
+        response = view._reservation_search(_make_request({"subnet_id": "1"}), version=4)
+        self.assertEqual(response.status_code, status.HTTP_502_BAD_GATEWAY)
+
+    def test_value_error_returns_500(self):
+        view, server = _make_view()
+        server.get_client.side_effect = ValueError("missing DHCPv4 URL")
+        response = view._reservation_search(_make_request({"subnet_id": "1"}), version=4)
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertIn("configuration error", response.data["detail"].lower())
+
+    def test_generic_exception_returns_500(self):
+        view, server = _make_view()
+        server.get_client.side_effect = RuntimeError("unexpected")
+        response = view._reservation_search(_make_request({"subnet_id": "1"}), version=4)
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertIn("internal error", response.data["detail"].lower())
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _fetch_reservations — all dispatch branches
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
+class TestFetchReservationsIpAndSubnet(SimpleTestCase):
+    """ip_address + subnet_id branch in _fetch_reservations (lines 253-255)."""
+
+    def test_found_returns_one_reservation(self):
+        view, server = _make_view()
+        mock_client = MagicMock()
+        mock_client.reservation_get.return_value = {"ip-address": "10.0.0.50", "subnet-id": 1}
+        server.get_client.return_value = mock_client
+        response = view._reservation_search(_make_request({"ip_address": "10.0.0.50", "subnet_id": "1"}), version=4)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+
+    def test_not_found_returns_empty(self):
+        view, server = _make_view()
+        mock_client = MagicMock()
+        mock_client.reservation_get.return_value = None
+        server.get_client.return_value = mock_client
+        response = view._reservation_search(_make_request({"ip_address": "10.0.0.99", "subnet_id": "1"}), version=4)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 0)
+
+
+@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
+class TestFetchReservationsHwAndSubnet(SimpleTestCase):
+    """hw_address + subnet_id branch in _fetch_reservations (lines 257-259)."""
+
+    def test_found_returns_one_reservation(self):
+        view, server = _make_view()
+        mock_client = MagicMock()
+        mock_client.reservation_get.return_value = {"ip-address": "10.0.0.50", "hw-address": "aa:bb:cc:dd:ee:ff"}
+        server.get_client.return_value = mock_client
+        response = view._reservation_search(
+            _make_request({"hw_address": "aa:bb:cc:dd:ee:ff", "subnet_id": "1"}), version=4
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+
+
+@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
+class TestFetchReservationsDuidAndSubnet(SimpleTestCase):
+    """duid + subnet_id + version=6 branch in _fetch_reservations (lines 261-263)."""
+
+    def test_found_returns_one_reservation(self):
+        view, server = _make_view()
+        mock_client = MagicMock()
+        mock_client.reservation_get.return_value = {"ip-addresses": ["2001:db8::50"], "duid": "00:01:02:03"}
+        server.get_client.return_value = mock_client
+        response = view._reservation_search(_make_request({"duid": "00:01:02:03", "subnet_id": "10"}), version=6)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+
+
+@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
+class TestFetchReservationsSubnetOnly(SimpleTestCase):
+    """subnet_id-only pagination branch in _fetch_reservations (lines 265-277)."""
+
+    def test_single_page_returns_all_hosts(self):
+        view, server = _make_view()
+        mock_client = MagicMock()
+        host = {"ip-address": "10.0.0.50", "subnet-id": 1}
+        mock_client.reservation_get_page.return_value = ([host], 0, 0)
+        server.get_client.return_value = mock_client
+        response = view._reservation_search(_make_request({"subnet_id": "1"}), version=4)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+
+    def test_multi_page_collects_all_hosts(self):
+        view, server = _make_view()
+        mock_client = MagicMock()
+        host1 = {"ip-address": "10.0.0.1", "subnet-id": 1}
+        host2 = {"ip-address": "10.0.0.2", "subnet-id": 1}
+        mock_client.reservation_get_page.side_effect = [
+            ([host1], 1, 1),  # first page: next_from=1 → continue
+            ([host2], 0, 0),  # second page: exhausted
+        ]
+        server.get_client.return_value = mock_client
+        response = view._reservation_search(_make_request({"subnet_id": "1"}), version=4)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 2)
+
+    def test_filters_by_subnet_id(self):
+        view, server = _make_view()
+        mock_client = MagicMock()
+        host_in = {"ip-address": "10.0.0.1", "subnet-id": 1}
+        host_out = {"ip-address": "10.0.0.2", "subnet-id": 2}
+        mock_client.reservation_get_page.return_value = ([host_in, host_out], 0, 0)
+        server.get_client.return_value = mock_client
+        response = view._reservation_search(_make_request({"subnet_id": "1"}), version=4)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+
+
+@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
+class TestFetchReservationsNoMatch(SimpleTestCase):
+    """Fallthrough return [] when no branch matches (line 279)."""
+
+    def test_duid_without_subnet_on_v4_returns_empty(self):
+        """duid only on v4 (no subnet_id) — none of the 4 branches fires → empty list."""
+        view, server = _make_view()
+        mock_client = MagicMock()
+        server.get_client.return_value = mock_client
+        response = view._reservation_search(_make_request({"duid": "00:01:02:03"}), version=4)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 0)
+        mock_client.reservation_get.assert_not_called()

--- a/netbox_kea/tests/test_jobs.py
+++ b/netbox_kea/tests/test_jobs.py
@@ -1199,6 +1199,28 @@ class TestSyncSubnetEntry(SimpleTestCase):
         )
         mock_range.assert_not_called()
 
+    def test_pool_too_large_is_silently_skipped(self):
+        """_POOL_TOO_LARGE sentinel from sync_pool_to_netbox_ip_range → stats unchanged (line 302)."""
+        from netbox_kea.jobs import _sync_subnet_entry
+        from netbox_kea.sync import _POOL_TOO_LARGE
+
+        stats = self._make_stats()
+        subnet = {"subnet": "10.0.0.0/8", "pools": [{"pool": "10.0.0.0-10.255.255.255"}]}
+        with patch("netbox_kea.sync.sync_pool_to_netbox_ip_range", return_value=_POOL_TOO_LARGE):
+            _sync_subnet_entry(subnet, sync_prefixes=False, sync_ip_ranges=True, vrf=None, stats=stats, server_name="s")
+        self.assertEqual(stats, {"created": 0, "updated": 0, "errors": 0, "prefix_errors": 0})
+
+    @patch("netbox_kea.sync.sync_pool_to_netbox_ip_range", return_value=(MagicMock(), False, True))
+    def test_pool_updated_increments_updated(self, mock_range):
+        """Updated IP range (created=False, did_update=True) increments stats['updated'] (lines 315-316)."""
+        from netbox_kea.jobs import _sync_subnet_entry
+
+        stats = self._make_stats()
+        subnet = {"subnet": "10.0.0.0/24", "pools": [{"pool": "10.0.0.10-10.0.0.50"}]}
+        _sync_subnet_entry(subnet, sync_prefixes=False, sync_ip_ranges=True, vrf=None, stats=stats, server_name="s")
+        self.assertEqual(stats["updated"], 1)
+        self.assertEqual(stats["created"], 0)
+
 
 # ---------------------------------------------------------------------------
 # Tests for _sync_server_prefixes_and_ranges (unit — no DB)
@@ -1446,6 +1468,39 @@ class TestSyncServerPrefixesAndRanges(SimpleTestCase):
         self.assertEqual(stats["prefix_errors"], 1)
         self.assertEqual(stats["errors"], 0)
 
+    @patch("netbox_kea.jobs._sync_subnet_entry")
+    def test_non_dict_shared_network_entry_is_skipped(self, mock_entry):
+        """A non-dict item in shared-networks list is silently skipped (line 384)."""
+        from netbox_kea.jobs import _sync_server_prefixes_and_ranges
+
+        server = self._make_server()
+        client = MagicMock()
+        # shared-networks contains one non-dict entry followed by a valid dict entry
+        client.command.return_value = [
+            {
+                "result": 0,
+                "arguments": {
+                    "Dhcp4": {
+                        "subnet4": [],
+                        "shared-networks": [
+                            "not-a-dict",
+                            {
+                                "name": "net-a",
+                                "subnet4": [{"subnet": "10.1.0.0/24", "pools": []}],
+                            },
+                        ],
+                    }
+                },
+            }
+        ]
+        server.get_client.return_value = client
+
+        stats = {"created": 0, "updated": 0, "errors": 0, "prefix_errors": 0}
+        _sync_server_prefixes_and_ranges(server, version=4, sync_prefixes=True, sync_ip_ranges=True, stats=stats)
+        # The valid subnet from the second shared-network entry should still be processed
+        mock_entry.assert_called_once()
+        self.assertEqual(stats["prefix_errors"], 0)
+
 
 # ---------------------------------------------------------------------------
 # Tests for per-server prefix/range toggle in KeaIpamSyncJob.run()
@@ -1578,3 +1633,117 @@ class TestAllSyncTypesDisabled(SimpleTestCase):
 
         MockServer.objects.all.assert_not_called()
         self.assertTrue(any("nothing to do" in msg.lower() for msg in cm.output))
+
+
+# ---------------------------------------------------------------------------
+# Tests for _prefetch_reservation_ips edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestPrefetchReservationIpsEdgeCases(SimpleTestCase):
+    """Edge-case tests for _prefetch_reservation_ips (lines 90, 95-96 in jobs.py)."""
+
+    def _make_server(self):
+        server = MagicMock()
+        server.name = "kea1"
+        return server
+
+    def test_non_dict_page_item_is_skipped(self):
+        """Non-dict items in the reservation page are silently skipped (line 90)."""
+        from netbox_kea.jobs import _prefetch_reservation_ips
+
+        server = self._make_server()
+        client = MagicMock()
+        page = ["not-a-dict", {"ip-address": "10.0.0.1"}]
+        client.reservation_get_page.return_value = (page, 0, 0)
+        server.get_client.return_value = client
+
+        result = _prefetch_reservation_ips(server, version=4)
+
+        self.assertIsNotNone(result)
+        self.assertIn("10.0.0.1", result)
+        self.assertEqual(len(result), 1)
+
+    def test_ipv6_ip_addresses_list_collected(self):
+        """Reservation with ip-addresses list → all addresses added to result set (lines 95-96)."""
+        from netbox_kea.jobs import _prefetch_reservation_ips
+
+        server = self._make_server()
+        client = MagicMock()
+        page = [{"ip-addresses": ["2001:db8::1", "2001:db8::2"]}]
+        client.reservation_get_page.return_value = (page, 0, 0)
+        server.get_client.return_value = client
+
+        result = _prefetch_reservation_ips(server, version=6)
+
+        self.assertIsNotNone(result)
+        self.assertIn("2001:db8::1", result)
+        self.assertIn("2001:db8::2", result)
+
+
+# ---------------------------------------------------------------------------
+# Tests for reservation updated path in _sync_server_reservations
+# ---------------------------------------------------------------------------
+
+
+class TestSyncServerReservationsUpdated(SimpleTestCase):
+    """Tests that an updated reservation (changed=True, created=False) increments stats['updated']."""
+
+    def _make_server(self):
+        server = MagicMock()
+        server.name = "kea1"
+        return server
+
+    @patch("netbox_kea.sync.sync_reservation_to_netbox", return_value=(MagicMock(), False, True))
+    def test_reservation_updated_increments_stats(self, mock_sync_resv):
+        """changed=True in sync_reservation_to_netbox → stats['updated'] += 1 (line 233)."""
+        from netbox_kea.jobs import _sync_server_reservations
+
+        server = self._make_server()
+        client = MagicMock()
+        client.reservation_get_page.return_value = ([_RESV4], 0, 0)
+        server.get_client.return_value = client
+
+        stats = {"created": 0, "updated": 0, "errors": 0, "prefix_errors": 0}
+        all_synced: list = []
+        result = _sync_server_reservations(server, version=4, stats=stats, all_synced=all_synced)
+
+        self.assertTrue(result)
+        self.assertEqual(stats["updated"], 1)
+        self.assertEqual(stats["created"], 0)
+
+
+# ---------------------------------------------------------------------------
+# Tests for job.save() failure in run() finally block
+# ---------------------------------------------------------------------------
+
+
+class TestJobSaveFailure(SimpleTestCase):
+    """Tests that job.save() failure in the finally block is caught and logged."""
+
+    def setUp(self):
+        patcher = patch("netbox_kea.models.SyncConfig")
+        self.MockSyncConfig = patcher.start()
+        self.MockSyncConfig.get.return_value = MagicMock(
+            sync_enabled=True,
+            interval_minutes=5,
+            sync_leases_enabled=False,
+            sync_reservations_enabled=False,
+            sync_prefixes_enabled=False,
+            sync_ip_ranges_enabled=False,
+        )
+        self.addCleanup(patcher.stop)
+
+    @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
+    @patch("netbox_kea.models.Server")
+    def test_save_exception_is_caught_and_logged(self, MockServer):
+        """job.save() raising an exception is caught; run() does not re-raise (lines 679-680)."""
+        MockServer.objects.all.return_value = []
+        mock_job = _make_job()
+        mock_job.data = {}
+        mock_job.save.side_effect = Exception("db write failed")
+
+        with self.assertLogs("netbox_kea.jobs", level="ERROR") as cm:
+            KeaIpamSyncJob(mock_job).run()
+
+        self.assertTrue(any("persist" in msg.lower() or "summary" in msg.lower() for msg in cm.output))

--- a/netbox_kea/tests/test_kea_client.py
+++ b/netbox_kea/tests/test_kea_client.py
@@ -4624,3 +4624,255 @@ class TestPersistConfigFlag(TestCase):
         cmds = self._cmds(mock_post)
         self.assertNotIn("config-write", cmds)
         self.assertIn("config-set", cmds)
+
+
+# ---------------------------------------------------------------------------
+# Coverage-gap tests — lines not yet exercised by the suite above
+# ---------------------------------------------------------------------------
+
+
+class TestGetAvailableCommandsMalformed(TestCase):
+    """get_available_commands raises RuntimeError on empty / non-dict response (line 148)."""
+
+    def setUp(self):
+        self.client = KeaClient(url="http://kea:8000")
+
+    def test_empty_list_raises_runtime_error(self):
+        """Empty response list hits the 'not resp' branch and raises RuntimeError (line 148)."""
+        with patch.object(self.client._session, "post", return_value=_mock_http_response([])):
+            with self.assertRaises(RuntimeError):
+                self.client.get_available_commands("dhcp4")
+
+
+class TestReservationGetByIpMalformedSubnets(TestCase):
+    """reservation_get_by_ip skips subnets with bad CIDRs or missing 'id' (lines 332-333, 337)."""
+
+    def setUp(self):
+        self.client = KeaClient(url="http://kea:8000")
+
+    _RESERVATION_FOUND = [{"result": 0, "arguments": {"ip-address": "10.0.0.5", "subnet-id": 1}}]
+    _RESERVATION_NOT_FOUND = [{"result": 3, "text": "Host not found."}]
+
+    def _subnet_list_resp(self, subnets):
+        return [{"result": 0, "arguments": {"subnets": subnets}}]
+
+    def test_subnet_missing_subnet_key_is_skipped(self):
+        """Subnet without 'subnet' key triggers KeyError → continue (lines 332-333)."""
+        subnets = [
+            {"id": 99},  # no 'subnet' key → KeyError → skipped
+            {"subnet": "10.0.0.0/24", "id": 1},  # valid subnet found after
+        ]
+        with patch.object(
+            self.client._session,
+            "post",
+            side_effect=_side_effects(self._subnet_list_resp(subnets), self._RESERVATION_FOUND),
+        ):
+            result = self.client.reservation_get_by_ip(4, "10.0.0.5")
+        self.assertIsNotNone(result)
+
+    def test_subnet_invalid_cidr_is_skipped(self):
+        """Subnet with unparseable CIDR triggers ValueError → continue (lines 332-333)."""
+        subnets = [
+            {"subnet": "not-a-cidr", "id": 99},  # ValueError → skipped
+            {"subnet": "10.0.0.0/24", "id": 1},
+        ]
+        with patch.object(
+            self.client._session,
+            "post",
+            side_effect=_side_effects(self._subnet_list_resp(subnets), self._RESERVATION_FOUND),
+        ):
+            result = self.client.reservation_get_by_ip(4, "10.0.0.5")
+        self.assertIsNotNone(result)
+
+    def test_matching_subnet_without_id_is_skipped(self):
+        """Subnet matches the IP but has no 'id' key → skipped (line 337), returns None."""
+        subnets = [
+            {"subnet": "10.0.0.0/24"},  # matches 10.0.0.5 but no 'id' → skipped
+        ]
+        with patch.object(
+            self.client._session,
+            "post",
+            return_value=_mock_http_response(self._subnet_list_resp(subnets)),
+        ):
+            result = self.client.reservation_get_by_ip(4, "10.0.0.5")
+        self.assertIsNone(result)
+
+
+class TestNetworkUpdateClearInterface(TestCase):
+    """network_update with interface='' removes the interface key (line 563)."""
+
+    def setUp(self):
+        self.client = KeaClient(url="http://kea:8000")
+
+    def _payloads(self, mock_post):
+        return [(c.kwargs.get("json") or c[1]["json"]) for c in mock_post.call_args_list]
+
+    def test_empty_interface_string_removes_interface_key(self):
+        """Passing interface='' should call network.pop('interface', None), removing the key."""
+        config_with_iface = [
+            {
+                "result": 0,
+                "arguments": {
+                    "Dhcp4": {
+                        "shared-networks": [
+                            {"name": "prod-net", "interface": "eth0", "option-data": [], "subnet4": []},
+                        ],
+                        "subnet4": [],
+                    }
+                },
+            }
+        ]
+        with patch.object(
+            self.client._session,
+            "post",
+            side_effect=_side_effects(
+                config_with_iface,
+                _CONFIG_TEST_OK_RESP,
+                _CONFIG_SET_OK_RESP,
+                _CONFIG_WRITE_RESP,
+            ),
+        ) as mock_post:
+            self.client.network_update(version=4, name="prod-net", interface="")
+        payloads = self._payloads(mock_post)
+        config_set_payload = next(p for p in payloads if p["command"] == "config-set")
+        networks = config_set_payload["arguments"]["Dhcp4"]["shared-networks"]
+        target = next(n for n in networks if n["name"] == "prod-net")
+        self.assertNotIn("interface", target)
+
+
+class TestConfigGetShapeGuardAdditional(TestCase):
+    """network_update, subnet_update_options, and option_def_list raise KeaException on null config-get (lines 546, 746, 814)."""
+
+    def setUp(self):
+        self.client = KeaClient(url="http://kea:8000")
+
+    def _null_args_response(self):
+        return _mock_http_response([{"result": 0, "arguments": None}])
+
+    @patch("requests.Session.post")
+    def test_network_update_null_arguments_raises_kea_exception(self, mock_post):
+        """network_update raises KeaException when config-get returns null arguments (line 546)."""
+        mock_post.return_value = self._null_args_response()
+        with self.assertRaises(KeaException):
+            self.client.network_update(version=4, name="any-net")
+
+    @patch("requests.Session.post")
+    def test_subnet_update_options_null_arguments_raises_kea_exception(self, mock_post):
+        """subnet_update_options raises KeaException when config-get returns null arguments (line 746)."""
+        mock_post.return_value = self._null_args_response()
+        with self.assertRaises(KeaException):
+            self.client.subnet_update_options(version=4, subnet_id=1, options=[])
+
+    @patch("requests.Session.post")
+    def test_option_def_list_null_arguments_raises_kea_exception(self, mock_post):
+        """option_def_list raises KeaException when config-get returns null arguments (line 814)."""
+        mock_post.return_value = self._null_args_response()
+        with self.assertRaises(KeaException):
+            self.client.option_def_list(version=4)
+
+
+class TestLeaseUpdateGuards(TestCase):
+    """lease_update guards on result=3 and non-dict arguments (lines 944-945, 948)."""
+
+    def setUp(self):
+        self.client = KeaClient(url="http://kea:8000")
+
+    def test_result3_raises_kea_exception(self):
+        """command() returning result=3 directly (bypassing check_response) raises KeaException (line 945)."""
+        # check_response would normally raise for result=3; patch command() to bypass it
+        # and test the explicit guard at line 944-945.
+        with patch.object(
+            self.client,
+            "command",
+            return_value=[{"result": 3, "text": "Lease not found."}],
+        ):
+            with self.assertRaises(KeaException):
+                self.client.lease_update(version=4, ip_address="10.0.0.1")
+
+    def test_non_dict_arguments_raises_value_error(self):
+        """result=0 with non-dict arguments raises ValueError (line 948)."""
+        resp = [{"result": 0, "arguments": None}]
+        with patch.object(self.client._session, "post", return_value=_mock_http_response(resp)):
+            with self.assertRaises(ValueError):
+                self.client.lease_update(version=4, ip_address="10.0.0.1")
+
+
+class TestLeaseGetByIpNonDictArguments(TestCase):
+    """lease_get_by_ip raises ValueError when result=0 but arguments is not a dict (line 991)."""
+
+    def setUp(self):
+        self.client = KeaClient(url="http://kea:8000")
+
+    def test_non_dict_arguments_raises_value_error(self):
+        """result=0 with non-dict (e.g. None) arguments raises ValueError."""
+        resp = [{"result": 0, "arguments": None}]
+        with patch.object(self.client._session, "post", return_value=_mock_http_response(resp)):
+            with self.assertRaises(ValueError):
+                self.client.lease_get_by_ip(version=4, ip_address="10.0.0.1")
+
+
+class TestLeaseGetAllMalformedArguments(TestCase):
+    """lease_get_all raises RuntimeError when arguments is not a dict or leases is not a list (lines 1047, 1052)."""
+
+    def setUp(self):
+        self.client = KeaClient(url="http://kea:8000")
+
+    @patch("requests.Session.post")
+    def test_arguments_not_dict_raises_runtime_error(self, mock_post):
+        """result=0 with non-dict arguments raises RuntimeError (line 1047)."""
+        mock_post.return_value = _mock_http_response([{"result": 0, "arguments": "unexpected"}])
+        with self.assertRaises(RuntimeError) as cm:
+            self.client.lease_get_all(version=4)
+        self.assertIn("arguments", str(cm.exception))
+
+    @patch("requests.Session.post")
+    def test_leases_not_list_raises_runtime_error(self, mock_post):
+        """result=0, arguments is dict, but leases value is not a list raises RuntimeError (line 1052)."""
+        mock_post.return_value = _mock_http_response([{"result": 0, "arguments": {"leases": "bad"}}])
+        with self.assertRaises(RuntimeError) as cm:
+            self.client.lease_get_all(version=4)
+        self.assertIn("leases", str(cm.exception))
+
+
+class TestApplyConfigTransportError(TestCase):
+    """_apply_config raises KeaConfigTestError when config-test raises RequestException (lines 1203-1208)."""
+
+    def setUp(self):
+        self.client = KeaClient(url="http://kea:8000")
+
+    def test_config_test_request_exception_raises_kea_config_test_error(self):
+        """requests.ConnectionError during config-test propagates as KeaConfigTestError."""
+
+        def side_effect(*args, **kwargs):
+            cmd = (kwargs.get("json") or {}).get("command", "")
+            if cmd == "config-test":
+                raise requests.ConnectionError("Connection refused")
+            return _mock_http_response([{"result": 0, "text": "OK"}])
+
+        with patch.object(self.client._session, "post", side_effect=side_effect):
+            with self.assertRaises(KeaConfigTestError):
+                self.client._apply_config("dhcp4", {"Dhcp4": {}})
+
+
+class TestPersistConfigRespShape(TestCase):
+    """_persist_config handles an unexpected dict resp from command() (line 1254)."""
+
+    def setUp(self):
+        self.client = KeaClient(url="http://kea:8000")
+
+    def test_command_returns_dict_falls_through_to_config_write(self):
+        """When command() returns a plain dict for config-get, _persist_config still calls config-write."""
+        cmds_seen = []
+
+        def mock_command(cmd, **kwargs):
+            cmds_seen.append(cmd)
+            if cmd == "config-get":
+                # Return a dict (not a list) — hits the else branch at line 1254
+                return {"result": 0, "arguments": {"Dhcp4": {}}}
+            # config-test and config-write succeed normally
+            return [{"result": 0, "text": "OK"}]
+
+        with patch.object(self.client, "command", side_effect=mock_command):
+            self.client._persist_config("dhcp4")
+        self.assertIn("config-get", cmds_seen)
+        self.assertIn("config-write", cmds_seen)

--- a/netbox_kea/tests/test_models.py
+++ b/netbox_kea/tests/test_models.py
@@ -13,7 +13,7 @@ from django.test import SimpleTestCase, TestCase, override_settings
 from netbox.models import NetBoxModel
 
 from netbox_kea.kea import KeaClient
-from netbox_kea.models import Server, SyncConfig
+from netbox_kea.models import Server, SyncConfig, _get_kea_timeout
 from netbox_kea.tests.utils import _make_db_server
 
 # Default PLUGINS_CONFIG used across model tests so we don't need full NetBox config.
@@ -696,3 +696,48 @@ class TestServerSyncEnabled(TestCase):
         server.save(update_fields=["sync_enabled"])
         server.refresh_from_db()
         self.assertFalse(server.sync_enabled)
+
+
+class TestGetKeaTimeout(SimpleTestCase):
+    """Tests for _get_kea_timeout() helper."""
+
+    @override_settings(PLUGINS_CONFIG={"netbox_kea": {"kea_timeout": 10}})
+    def test_returns_configured_value(self):
+        self.assertEqual(_get_kea_timeout(), 10)
+
+    @override_settings(PLUGINS_CONFIG={"netbox_kea": {}})
+    def test_returns_default_when_key_missing(self):
+        self.assertEqual(_get_kea_timeout(), 30)
+
+    @override_settings(PLUGINS_CONFIG={})
+    def test_returns_default_when_netbox_kea_section_missing(self):
+        self.assertEqual(_get_kea_timeout(), 30)
+
+    @override_settings(PLUGINS_CONFIG={"netbox_kea": None})
+    def test_returns_default_when_netbox_kea_is_none(self):
+        """PLUGINS_CONFIG["netbox_kea"]=None must not raise AttributeError."""
+        self.assertEqual(_get_kea_timeout(), 30)
+
+    @override_settings(PLUGINS_CONFIG=None)
+    def test_returns_default_when_plugins_config_is_none(self):
+        self.assertEqual(_get_kea_timeout(), 30)
+
+    @override_settings(PLUGINS_CONFIG="not-a-dict")
+    def test_returns_default_when_plugins_config_is_not_dict(self):
+        self.assertEqual(_get_kea_timeout(), 30)
+
+    @override_settings(PLUGINS_CONFIG={"netbox_kea": {"kea_timeout": "abc"}})
+    def test_returns_default_when_kea_timeout_is_non_numeric_string(self):
+        self.assertEqual(_get_kea_timeout(), 30)
+
+    @override_settings(PLUGINS_CONFIG={"netbox_kea": {"kea_timeout": "15"}})
+    def test_accepts_numeric_string(self):
+        self.assertEqual(_get_kea_timeout(), 15)
+
+    @override_settings(PLUGINS_CONFIG={"netbox_kea": {"kea_timeout": None}})
+    def test_returns_default_when_kea_timeout_is_none(self):
+        self.assertEqual(_get_kea_timeout(), 30)
+
+    def test_custom_default(self):
+        with self.settings(PLUGINS_CONFIG={}):
+            self.assertEqual(_get_kea_timeout(default=60), 60)

--- a/netbox_kea/tests/test_plugin_config.py
+++ b/netbox_kea/tests/test_plugin_config.py
@@ -1,6 +1,11 @@
 # SPDX-FileCopyrightText: 2025 Marcin Zieba <marcinpsk@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
-"""Unit tests for NetBoxKeaConfig.ready() helpers — _heal_ghost_scheduled_jobs."""
+"""Unit tests for the ghost-job self-heal and its scheduling wiring.
+
+The self-heal lives on ``KeaIpamSyncJob`` and runs inside an ``enqueue_once``
+override (invoked once per ``rqworker`` startup), not in ``AppConfig.ready()`` —
+keeping all DB access off the app-initialisation path.
+"""
 
 from __future__ import annotations
 
@@ -8,12 +13,7 @@ from unittest.mock import MagicMock, patch
 
 from django.test import SimpleTestCase
 
-from netbox_kea import NetBoxKeaConfig
-
-
-def _make_config() -> NetBoxKeaConfig:
-    """Return a bare NetBoxKeaConfig instance without triggering real ready() logic."""
-    return NetBoxKeaConfig.__new__(NetBoxKeaConfig)
+from netbox_kea.jobs import KeaIpamSyncJob
 
 
 def _make_db_job(job_id: str | None = "abc-123") -> MagicMock:
@@ -23,7 +23,7 @@ def _make_db_job(job_id: str | None = "abc-123") -> MagicMock:
 
 
 class TestHealGhostScheduledJobs(SimpleTestCase):
-    """Tests for NetBoxKeaConfig._heal_ghost_scheduled_jobs()."""
+    """Tests for KeaIpamSyncJob._heal_ghost_scheduled_jobs()."""
 
     def _run(self, candidates, rq_statuses: dict[str, str] | None = None, no_such: set[str] | None = None):
         """
@@ -51,13 +51,12 @@ class TestHealGhostScheduledJobs(SimpleTestCase):
             rq_job.get_status.return_value = MagicMock(value=status_str)
             return rq_job
 
-        cfg = _make_config()
         with (
             patch("netbox_kea.jobs.KeaIpamSyncJob.get_jobs", return_value=mock_qs),
             patch("django_rq.get_connection", return_value=MagicMock()),
             patch("rq.job.Job.fetch", side_effect=_fetch),
         ):
-            cfg._heal_ghost_scheduled_jobs()
+            KeaIpamSyncJob._heal_ghost_scheduled_jobs()
 
         return candidates
 
@@ -70,12 +69,11 @@ class TestHealGhostScheduledJobs(SimpleTestCase):
         mock_qs.exists.return_value = False
         mock_qs.filter.return_value = mock_qs
 
-        cfg = _make_config()
         with (
             patch("netbox_kea.jobs.KeaIpamSyncJob.get_jobs", return_value=mock_qs),
             patch("django_rq.get_connection") as mock_conn,
         ):
-            cfg._heal_ghost_scheduled_jobs()
+            KeaIpamSyncJob._heal_ghost_scheduled_jobs()
 
         mock_conn.assert_not_called()
 
@@ -149,10 +147,9 @@ class TestHealGhostScheduledJobs(SimpleTestCase):
     # ------------------------------------------------------------------
 
     def test_db_unavailable_does_not_raise(self):
-        cfg = _make_config()
         with patch("netbox_kea.jobs.KeaIpamSyncJob.get_jobs", side_effect=Exception("DB down")):
             # Must not raise
-            cfg._heal_ghost_scheduled_jobs()
+            KeaIpamSyncJob._heal_ghost_scheduled_jobs()
 
     def test_redis_unavailable_does_not_raise(self):
         job = _make_db_job("job-5")
@@ -161,13 +158,12 @@ class TestHealGhostScheduledJobs(SimpleTestCase):
         mock_qs.filter.return_value = mock_qs
         mock_qs.__iter__ = lambda self: iter([job])
 
-        cfg = _make_config()
         with (
             patch("netbox_kea.jobs.KeaIpamSyncJob.get_jobs", return_value=mock_qs),
             patch("django_rq.get_connection", side_effect=Exception("Redis down")),
         ):
             # Must not raise
-            cfg._heal_ghost_scheduled_jobs()
+            KeaIpamSyncJob._heal_ghost_scheduled_jobs()
 
     def test_per_record_error_does_not_abort_remaining_records(self):
         """A transient error on one record must not skip the others."""
@@ -186,13 +182,12 @@ class TestHealGhostScheduledJobs(SimpleTestCase):
             rq.get_status.return_value = MagicMock(value="failed")
             return rq
 
-        cfg = _make_config()
         with (
             patch("netbox_kea.jobs.KeaIpamSyncJob.get_jobs", return_value=mock_qs),
             patch("django_rq.get_connection", return_value=MagicMock()),
             patch("rq.job.Job.fetch", side_effect=_fetch),
         ):
-            cfg._heal_ghost_scheduled_jobs()
+            KeaIpamSyncJob._heal_ghost_scheduled_jobs()
 
         bad_job.delete.assert_not_called()
         good_job.delete.assert_called_once()
@@ -213,13 +208,12 @@ class TestHealGhostScheduledJobs(SimpleTestCase):
         # Return a plain string instead of an enum-like object with .value
         rq_job.get_status.return_value = "failed"
 
-        cfg = _make_config()
         with (
             patch("netbox_kea.jobs.KeaIpamSyncJob.get_jobs", return_value=mock_qs),
             patch("django_rq.get_connection", return_value=MagicMock()),
             patch("rq.job.Job.fetch", return_value=rq_job),
         ):
-            cfg._heal_ghost_scheduled_jobs()
+            KeaIpamSyncJob._heal_ghost_scheduled_jobs()
 
         job.delete.assert_called_once()
 
@@ -234,31 +228,36 @@ class TestHealGhostScheduledJobs(SimpleTestCase):
         rq_job = MagicMock()
         rq_job.get_status.return_value = "scheduled"
 
-        cfg = _make_config()
         with (
             patch("netbox_kea.jobs.KeaIpamSyncJob.get_jobs", return_value=mock_qs),
             patch("django_rq.get_connection", return_value=MagicMock()),
             patch("rq.job.Job.fetch", return_value=rq_job),
         ):
-            cfg._heal_ghost_scheduled_jobs()
+            KeaIpamSyncJob._heal_ghost_scheduled_jobs()
 
         job.delete.assert_not_called()
 
-    # ------------------------------------------------------------------
-    # ready() wiring smoke test
-    # ------------------------------------------------------------------
 
-    def test_ready_calls_both_helpers(self):
-        """ready() must invoke _configure_sync_job_interval and _heal_ghost_scheduled_jobs."""
-        from netbox.plugins import PluginConfig
+class TestEnqueueOnceWiring(SimpleTestCase):
+    """The enqueue_once override must heal first, then delegate to NetBox."""
 
-        cfg = _make_config()
+    def test_enqueue_once_heals_then_delegates(self):
+        """Ghost-heal runs before super().enqueue_once(), and kwargs pass through."""
+        manager = MagicMock()
+        sentinel = object()
+
+        # Patch the heal on our class and JobRunner.enqueue_once (the super impl).
         with (
-            patch.object(PluginConfig, "ready"),
-            patch.object(NetBoxKeaConfig, "_configure_sync_job_interval") as mock_configure,
-            patch.object(NetBoxKeaConfig, "_heal_ghost_scheduled_jobs") as mock_heal,
+            patch.object(KeaIpamSyncJob, "_heal_ghost_scheduled_jobs") as mock_heal,
+            patch("netbox.jobs.JobRunner.enqueue_once", return_value=sentinel) as mock_super,
         ):
-            cfg.ready()
+            manager.attach_mock(mock_heal, "heal")
+            manager.attach_mock(mock_super, "enqueue")
 
-        mock_configure.assert_called_once()
-        mock_heal.assert_called_once()
+            result = KeaIpamSyncJob.enqueue_once(interval=5)
+
+        # Delegated return value is forwarded unchanged.
+        self.assertIs(result, sentinel)
+        # Heal ran before the delegation, and kwargs were forwarded.
+        self.assertEqual([c[0] for c in manager.mock_calls], ["heal", "enqueue"])
+        mock_super.assert_called_once_with(interval=5)


### PR DESCRIPTION
## Summary

Two independent fixes plus a docs correction.

### 1. Move ghost-job self-heal out of `AppConfig.ready()` (`4d480d1`)

Querying the DB in `AppConfig.ready()` triggered Django's *"Accessing the database during app initialization is discouraged"* `RuntimeWarning`, and ran in every context (`collectstatic`, `migrate`) where the DB may be unreachable.

NetBox schedules system jobs by calling `enqueue_once()` **on the job class**, once per `rqworker` startup (`core/management/commands/rqworker.py`) — after app init, on the worker process only, with the DB guaranteed up. So the heal now lives in a `KeaIpamSyncJob.enqueue_once()` override that cleans ghost `scheduled`/`pending` records, then delegates to `super()`. The heal logic moves verbatim (DB/Redis guards intact) onto the job class.

Verified against the real NetBox source: `rqworker.handle()` dispatches `job.enqueue_once(**kwargs)` to the subclass, and `JobRunner.enqueue_once` still trusts the DB status (returns a stale `scheduled` record without rescheduling) on v4.5/v4.6 — so the self-heal is still warranted.

### 2. Replace deprecated NetBox `{% querystring %}` tag with Django's built-in (`1048ba8`)

NetBox's `querystring` tag emits a `FutureWarning` pointing to Django's built-in (Django 5.1+). Dropped the `request` positional arg across all four usages in the lease views. Because loading the `helpers` library shadows the built-in tag of the same name, switched the htmx template to a selective `{% load get_key from helpers %}` and dropped the now-unused `helpers` load from the paginator partial.

Verified in a NetBox container: both templates parse, and all four invocations render identically to the old tag (including `export=""` preserving an empty `?export=`).

### 3. Docs: correct supported-version floor

`CLAUDE.md` updated v4.0–v4.5 → **v4.3–v4.5** to match the actual CI matrix and the Django ≥ 5.1 floor the built-in tag requires.

## Testing

- `netbox_kea/tests/test_plugin_config.py`: relocated heal tests to target `KeaIpamSyncJob`, added an `enqueue_once` wiring test (heals → delegates). **16/16 pass** in a real NetBox env.
- `ruff check` + `ruff format`: clean (pre-commit hooks passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable background IPAM sync interval, stale-IP cleanup and per-server sync options; plugin version bumped to 1.4.3
  * UI: improved pagination/export controls; Add Lease form now shows form-wide errors

* **Bug Fixes**
  * Safer handling of malformed Kea responses and clearer server-configuration error responses
  * Background-sync scheduling self-heals stale job records and tolerates DB/Redis/save failures

* **Tests**
  * Expanded unit and integration tests for job healing, client behavior, and IPv4/IPv6 client selection

* **Chores**
  * CI/test matrix narrowed to NetBox v4.3–v4.5; workflow and metadata updates (pinning and provenance)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marcinpsk/netbox-kea/pull/70?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->