### PR TITLE
feat: dhcp plugin import

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,3 +5,14 @@ comment:
   require_base: false
   require_head: true
   hide_project_coverage: false
+
+# The optional netbox_dhcp integration only executes when that plugin is
+# installed. CI installs netbox_kea alone (PLUGINS=['netbox_kea']), so the gated
+# integration/view tests skip here and these modules can't be exercised in CI —
+# they're covered by the devcontainer suite (test_integration_dhcp_plugin.py /
+# test_views_dhcp_plugin.py, gated on apps.is_installed("netbox_dhcp")). Those
+# tests still RUN and gate correctness in CI when present; ignore only excludes
+# these files from the CI coverage *metric*. Paths are repo-root-relative globs.
+ignore:
+  - "netbox_kea/integrations/dhcp_plugin.py"
+  - "netbox_kea/views/dhcp_plugin_sync.py"

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,6 +6,17 @@ comment:
   require_head: true
   hide_project_coverage: false
 
+coverage:
+  status:
+    patch:
+      default:
+        # New code should be well covered, but the default `auto` target pins the
+        # patch threshold to the project's overall coverage (~98%), which a feature
+        # PR can't hit once unavoidable defensive/edge branches are counted. A fixed
+        # floor keeps a meaningful gate without failing on a couple of uncovered lines.
+        target: 90%
+        threshold: 1%
+
 # The optional netbox_dhcp integration only executes when that plugin is
 # installed. CI installs netbox_kea alone (PLUGINS=['netbox_kea']), so the gated
 # integration/view tests skip here and these modules can't be exercised in CI —
@@ -13,6 +24,12 @@ comment:
 # test_views_dhcp_plugin.py, gated on apps.is_installed("netbox_dhcp")). Those
 # tests still RUN and gate correctness in CI when present; ignore only excludes
 # these files from the CI coverage *metric*. Paths are repo-root-relative globs.
+#
+# The test suite itself is also ignored: you measure coverage *of* the code under
+# test, not of the tests. (pyproject's `omit` does this for local runs, but CI runs
+# pytest from the NetBox checkout, so coverage.py never reads our pyproject — hence
+# excluding here, where Codecov applies it regardless of how coverage.xml was made.)
 ignore:
   - "netbox_kea/integrations/dhcp_plugin.py"
   - "netbox_kea/views/dhcp_plugin_sync.py"
+  - "netbox_kea/tests"

--- a/netbox_kea/api/views.py
+++ b/netbox_kea/api/views.py
@@ -7,7 +7,7 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 
 from .. import filtersets, models
-from ..kea import KeaClient, KeaException
+from ..kea import KeaClient, KeaException, iter_reservations
 from ..utilities import format_leases
 from .serializers import ServerSerializer
 
@@ -264,16 +264,6 @@ class ServerViewSet(NetBoxModelViewSet):
 
         if subnet_id:
             # Page through all reservations exhaustively, then filter by subnet_id client-side.
-            all_hosts: list[dict] = []
-            source_index, from_index = 0, 0
-            while True:
-                page, next_from, next_source = client.reservation_get_page(
-                    service, source_index=source_index, from_index=from_index
-                )
-                all_hosts.extend(page)
-                if not page or (next_from == 0 and next_source == 0):
-                    break
-                source_index, from_index = next_source, next_from
-            return [h for h in all_hosts if str(h.get("subnet-id", "")) == str(subnet_id)]
+            return [h for h in iter_reservations(client, service) if str(h.get("subnet-id", "")) == str(subnet_id)]
 
         return []

--- a/netbox_kea/integrations/__init__.py
+++ b/netbox_kea/integrations/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2025 Marcin Zieba <marcinpsk@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+"""Optional integrations with other NetBox plugins (guarded, lazily imported)."""

--- a/netbox_kea/integrations/dhcp_plugin.py
+++ b/netbox_kea/integrations/dhcp_plugin.py
@@ -29,6 +29,9 @@ v1 scope (import + diff, read-only against Kea):
   these fully defaulted and inherited, so each subnet field is stored **only when
   it differs from the DHCPServer parent** (parent-diff suppression) — otherwise it
   is left blank to inherit, keeping the records minimal and faithful.
+* **Client classes** (``client-classes``) are imported as ``ClientClass`` rows
+  (test/template-test, additional-list flag, BOOTP + lifetime settings, options),
+  named ``"<server>: <kea-name>"`` since the plugin requires a globally-unique name.
 * **Deferred** (reported, not imported): shared-network grouping (the plugin's
   ``SharedNetwork`` requires a prefix Kea does not model — member subnets are
   flattened onto the ``DHCPServer``).
@@ -42,6 +45,7 @@ from dataclasses import dataclass, field
 from django.apps import apps
 
 from ..mappers.kea_to_dhcp import (
+    ClientClassIntent,
     OptionDefIntent,
     OptionIntent,
     ReservationIntent,
@@ -72,6 +76,8 @@ class ImportSummary:
     options_updated: int = 0
     options_skipped: int = 0
     option_defs_created: int = 0
+    client_classes_created: int = 0
+    client_classes_updated: int = 0
     shared_networks_deferred: int = 0
     errors: int = 0
     warnings: list[str] = field(default_factory=list)
@@ -472,25 +478,27 @@ def _apply_global_settings(dhcp_server, settings: dict, summary: ImportSummary) 
             summary.warn(f"DHCPServer settings: {exc}")
 
 
-def _apply_subnet_settings(subnet_obj, dhcp_server, settings: dict, summary: ImportSummary) -> bool:
-    """Set subnet tuning fields only where they differ from the stored DHCPServer parent.
+def _apply_inherited_settings(obj, parent, settings: dict, field_map, summary: ImportSummary) -> bool:
+    """Set *obj* tuning fields only where they differ from the stored *parent*.
 
     This is the parent-diff suppression: ``config-get`` returns every value fully
-    inherited, so a subnet value equal to the server's is left blank (it inherits).
-    Returns ``True`` if any field on *subnet_obj* changed.
+    inherited, so a child value equal to its parent's is left blank (it inherits).
+    The ``model_fields`` guard skips fields *obj* does not have, so a single field
+    map can serve models with different mixins (e.g. ``Subnet`` vs ``ClientClass``).
+    Returns ``True`` if any field on *obj* changed.
     """
-    model_fields = {f.name for f in subnet_obj._meta.get_fields()}
+    model_fields = {f.name for f in obj._meta.get_fields()}
     changed = False
-    for kea_key, attr, transform in _SUBNET_FIELDS:
+    for kea_key, attr, transform in field_map:
         if attr not in model_fields or kea_key not in settings:
             continue
         value = _transform_value(transform, settings[kea_key], kea_key, summary)
         if _is_unset(value):
             continue
-        if value == getattr(dhcp_server, attr, None):
-            continue  # inherited from the DHCPServer parent — leave blank
-        if getattr(subnet_obj, attr, None) != value:
-            setattr(subnet_obj, attr, value)
+        if value == getattr(parent, attr, None):
+            continue  # inherited from the parent — leave blank
+        if getattr(obj, attr, None) != value:
+            setattr(obj, attr, value)
             changed = True
     return changed
 
@@ -507,6 +515,53 @@ def upsert_dhcp_server(server):
         name=server.name,
         defaults={"description": "Imported from Kea by netbox-kea"},
     )
+    return obj
+
+
+def _client_class_name(server, kea_name: str) -> str:
+    """Namespace a Kea class name to this server (NetBoxDHCPModelMixin needs a unique name)."""
+    return f"{server.name}: {kea_name}"[:255]
+
+
+def upsert_client_class(server, dhcp_server, intent: ClientClassIntent, custom_defs, summary: ImportSummary):
+    """Get/create the DHCP-plugin ``ClientClass`` for *intent* (match by namespaced name)."""
+    ClientClass = _model("ClientClass")
+    cc_name = _client_class_name(server, intent.name)
+    obj = ClientClass.objects.filter(name=cc_name).first()
+    created = obj is None
+    if obj is None:
+        obj = ClientClass(name=cc_name, dhcp_server=dhcp_server)
+
+    changed = created
+    if obj.dhcp_server_id != dhcp_server.pk:
+        obj.dhcp_server = dhcp_server
+        changed = True
+    if obj.test != (intent.test or ""):
+        obj.test = intent.test or ""
+        changed = True
+    if obj.template_test != (intent.template_test or ""):
+        obj.template_test = intent.template_test or ""
+        changed = True
+    if intent.only_in_additional_list is not None and obj.only_in_additional_list != intent.only_in_additional_list:
+        obj.only_in_additional_list = intent.only_in_additional_list
+        changed = True
+    if _apply_inherited_settings(obj, dhcp_server, intent.settings, _COMMON_FIELDS, summary):
+        changed = True
+
+    try:
+        if changed:
+            obj.save()
+    except Exception as exc:  # noqa: BLE001 — one bad class must not abort the import
+        summary.errors += 1
+        summary.warn(f"client-class {intent.name}: {exc}")
+        return None
+
+    if created:
+        summary.client_classes_created += 1
+    elif changed:
+        summary.client_classes_updated += 1
+
+    upsert_options(obj, intent.options, intent.family, dhcp_server, custom_defs, summary)
     return obj
 
 
@@ -560,7 +615,7 @@ def upsert_subnet(server, dhcp_server, intent: SubnetIntent, summary: ImportSumm
                 existing.dhcp_server = dhcp_server
                 existing.shared_network = None
                 changed = True
-            if _apply_subnet_settings(existing, dhcp_server, intent.settings, summary):
+            if _apply_inherited_settings(existing, dhcp_server, intent.settings, _SUBNET_FIELDS, summary):
                 changed = True
             if changed:
                 existing.save()
@@ -574,7 +629,7 @@ def upsert_subnet(server, dhcp_server, intent: SubnetIntent, summary: ImportSumm
                 dhcp_server=dhcp_server,
                 shared_network=None,
             )
-            _apply_subnet_settings(subnet_obj, dhcp_server, intent.settings, summary)
+            _apply_inherited_settings(subnet_obj, dhcp_server, intent.settings, _SUBNET_FIELDS, summary)
             subnet_obj.save()
             summary.subnets_created += 1
             if intent.kea_subnet_id is not None:
@@ -691,9 +746,11 @@ def import_server_config(server, config: ServerConfigIntent) -> ImportSummary:
     dhcp_server = upsert_dhcp_server(server)
     custom_defs = _custom_def_index(config)
 
-    # Global (server-level) tuning fields + options.
+    # Global (server-level) tuning fields + options + client classes.
     _apply_global_settings(dhcp_server, config.global_settings, summary)
     upsert_options(dhcp_server, config.global_options, config.family, dhcp_server, custom_defs, summary)
+    for cc_intent in config.client_classes:
+        upsert_client_class(server, dhcp_server, cc_intent, custom_defs, summary)
 
     for subnet_intent in config.subnets:
         subnet_obj = upsert_subnet(server, dhcp_server, subnet_intent, summary)

--- a/netbox_kea/integrations/dhcp_plugin.py
+++ b/netbox_kea/integrations/dhcp_plugin.py
@@ -1,0 +1,423 @@
+# SPDX-FileCopyrightText: 2025 Marcin Zieba <marcinpsk@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+"""Adapter to the optional NetBox DHCP plugin (``netbox_dhcp``, sys4).
+
+This is the **only** module that touches ``netbox_dhcp`` models, and it does so
+lazily inside functions — never at import time — so the rest of netbox-kea (and
+its CI, which does not install the plugin) imports cleanly whether or not the
+plugin is present.  Call :func:`is_available` before any other entry point.
+
+v1 scope (import + diff, read-only against Kea):
+
+* Imports the **data tier** of a Kea ``config-get`` into ``netbox_dhcp`` rows —
+  ``DHCPServer``, ``Subnet``, ``Pool``, ``HostReservation`` — reusing netbox-kea's
+  existing IPAM helpers so the DHCP-plugin rows **share** the same
+  ``ipam.Prefix``/``IPRange``/``IPAddress`` and ``dcim.MACAddress`` objects the
+  IPAM sync maintains.
+* Subnet identity is tracked in :class:`netbox_kea.models.KeaDhcpLink` keyed by
+  ``(server, family, kea_subnet_id)`` — Kea's subnet-id is unique only per
+  ``(server, protocol)`` and cannot live in the plugin's globally-unique
+  ``Subnet.subnet_id``.  Pools and reservations match structurally within their
+  resolved parent subnet.
+* **Deferred** (reported, not imported): shared-network grouping (the plugin's
+  ``SharedNetwork`` requires a prefix Kea does not model — member subnets are
+  flattened onto the ``DHCPServer``) and per-object DHCP options.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+from django.apps import apps
+
+from ..mappers.kea_to_dhcp import ReservationIntent, ServerConfigIntent, SubnetIntent
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_APP_LABEL = "netbox_dhcp"
+
+
+def is_available() -> bool:
+    """Return ``True`` when the optional NetBox DHCP plugin is installed."""
+    return apps.is_installed(PLUGIN_APP_LABEL)
+
+
+@dataclass
+class ImportSummary:
+    """Counters and warnings accumulated over one server-config import."""
+
+    subnets_created: int = 0
+    subnets_updated: int = 0
+    pools_created: int = 0
+    reservations_created: int = 0
+    reservations_updated: int = 0
+    shared_networks_deferred: int = 0
+    options_deferred: int = 0
+    errors: int = 0
+    warnings: list[str] = field(default_factory=list)
+
+    def warn(self, message: str) -> None:
+        """Record a non-fatal warning and log it."""
+        self.warnings.append(message)
+        logger.warning("DHCP-plugin import: %s", message)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Lazy model access
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _model(name: str):
+    """Return a ``netbox_dhcp`` model class by name (lazy; plugin must be installed)."""
+    return apps.get_model(PLUGIN_APP_LABEL, name)
+
+
+def _link_model():
+    from ..models import KeaDhcpLink
+
+    return KeaDhcpLink
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# IPAM / DCIM resolution (reuse netbox-kea sync helpers — share the same rows)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _ensure_prefix(cidr: str, vrf):
+    """Get/create the shared ``ipam.Prefix`` for *cidr* via the IPAM sync helper.
+
+    Refreshes the instance from the DB so ``.prefix`` is a ``netaddr.IPNetwork`` and
+    not the raw string assigned on create — ``netbox_dhcp`` validators (e.g.
+    ``Pool.clean``/``Subnet.clean``) do geometric containment checks that require it.
+    """
+    from ..sync import sync_subnet_to_netbox_prefix
+
+    prefix_obj, _created, _updated = sync_subnet_to_netbox_prefix(cidr, vrf=vrf)
+    prefix_obj.refresh_from_db()
+    return prefix_obj
+
+
+def _ensure_ip_range(pool_str: str, subnet_cidr: str, vrf):
+    """Get/create the shared ``ipam.IPRange`` for a Kea pool, or ``None`` if unusable.
+
+    Refreshed from the DB so ``.range``/address fields are netaddr objects for
+    ``netbox_dhcp``'s containment validators.
+    """
+    from ..sync import _POOL_TOO_LARGE, sync_pool_to_netbox_ip_range
+
+    result = sync_pool_to_netbox_ip_range(pool_str, subnet_cidr, vrf=vrf)
+    if result is None or result is _POOL_TOO_LARGE:
+        return None
+    range_obj, _created, _updated = result
+    range_obj.refresh_from_db()
+    return range_obj
+
+
+def _ensure_reservation_addresses(intent: ReservationIntent, kea_subnet_id: int | None, subnet_cidr: str):
+    """Ensure the reservation's IPAM rows exist (status=reserved) and return them.
+
+    Reuses :func:`sync_reservation_to_netbox` so the DHCP-plugin reservation shares
+    the very same ``ipam.IPAddress`` rows the reservation-sync owns (decision: one
+    row per address).  ``cleanup=False`` keeps the import from deleting unrelated IPs.
+
+    Returns ``(ipv4_ip, ipv6_ips, mac_obj)``.
+    """
+    from netaddr import IPNetwork
+
+    from ..sync import get_netbox_ip, sync_reservation_to_netbox
+
+    kea_res: dict = {"hostname": intent.hostname}
+    if kea_subnet_id is not None:
+        kea_res["subnet-id"] = kea_subnet_id
+    if intent.ip_address:
+        kea_res["ip-address"] = intent.ip_address
+    if intent.ip_addresses:
+        kea_res["ip-addresses"] = list(intent.ip_addresses)
+    if intent.identifier_type == "hw-address" and intent.identifier:
+        kea_res["hw-address"] = intent.identifier
+
+    try:
+        prefix_len = IPNetwork(subnet_cidr).prefixlen
+    except Exception:  # noqa: BLE001 — fall back to host mask if subnet CIDR is odd
+        prefix_len = 128 if ":" in subnet_cidr else 32
+    spm = {kea_subnet_id: prefix_len} if kea_subnet_id is not None else None
+
+    try:
+        sync_reservation_to_netbox(kea_res, cleanup=False, force=True, subnet_prefix_map=spm)
+    except ValueError:
+        # Reservation has no IP (e.g. options-only) — nothing to resolve.
+        pass
+
+    ipv4_ip = None
+    ipv6_ips = []
+    for addr in intent.all_addresses:
+        ip_obj = get_netbox_ip(addr)
+        if ip_obj is None:
+            continue
+        if ":" in addr:
+            ipv6_ips.append(ip_obj)
+        else:
+            ipv4_ip = ip_obj
+
+    mac_obj = _resolve_mac(intent.identifier) if intent.identifier_type == "hw-address" else None
+    return ipv4_ip, ipv6_ips, mac_obj
+
+
+def _resolve_mac(hw_address: str | None):
+    """Return the ``dcim.MACAddress`` row for *hw_address* (created by the sync helper)."""
+    if not hw_address:
+        return None
+    try:
+        from dcim.models import MACAddress
+        from netaddr import EUI, AddrFormatError, mac_unix_expanded
+    except ImportError:
+        return None
+    try:
+        mac_str = str(EUI(hw_address, dialect=mac_unix_expanded))
+    except AddrFormatError:
+        return None
+    return MACAddress.objects.filter(mac_address=mac_str).first()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Upserts
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def upsert_dhcp_server(server):
+    """Get/create the ``netbox_dhcp.DHCPServer`` mirroring this Kea *server* (match by name)."""
+    DHCPServer = _model("DHCPServer")
+    obj, _created = DHCPServer.objects.get_or_create(
+        name=server.name,
+        defaults={"description": "Imported from Kea by netbox-kea"},
+    )
+    return obj
+
+
+def _linked_subnet(server, family: int, kea_subnet_id: int):
+    """Return the DHCP-plugin Subnet previously linked for this Kea identity, or ``None``."""
+    KeaDhcpLink = _link_model()
+    link = KeaDhcpLink.objects.filter(server=server, family=family, kea_subnet_id=kea_subnet_id).first()
+    return link.sys4_object if link is not None else None
+
+
+def _subnet_name(server, intent: SubnetIntent) -> str:
+    """Build a globally-unique name (NetBoxDHCPModelMixin requires unique ``name``)."""
+    if intent.kea_subnet_id is not None:
+        return f"{server.name} DHCPv{intent.family} subnet {intent.kea_subnet_id}"[:255]
+    return f"{server.name} DHCPv{intent.family} {intent.cidr}"[:255]
+
+
+def _pool_name(subnet_obj, pool_intent) -> str:
+    """Build a unique pool name scoped to its parent subnet's (unique) name."""
+    return f"{subnet_obj.name} pool {pool_intent.pool}"[:255]
+
+
+def _reservation_name(subnet_obj, res: ReservationIntent) -> str:
+    """Build a unique reservation name scoped to its parent subnet's (unique) name."""
+    return f"{subnet_obj.name} {res.identifier_type}:{res.identifier}"[:255]
+
+
+def upsert_subnet(server, dhcp_server, intent: SubnetIntent, summary: ImportSummary):
+    """Get/create the DHCP-plugin ``Subnet`` for *intent*, tracked via ``KeaDhcpLink``.
+
+    Returns the ``netbox_dhcp.Subnet`` instance, or ``None`` on error.
+    """
+    from django.contrib.contenttypes.models import ContentType
+
+    Subnet = _model("Subnet")
+    KeaDhcpLink = _link_model()
+
+    prefix_obj = _ensure_prefix(intent.cidr, server.sync_vrf)
+
+    existing = None
+    if intent.kea_subnet_id is not None:
+        existing = _linked_subnet(server, intent.family, intent.kea_subnet_id)
+
+    try:
+        if existing is not None:
+            changed = False
+            if existing.prefix_id != prefix_obj.pk:
+                existing.prefix = prefix_obj
+                changed = True
+            if existing.dhcp_server_id != dhcp_server.pk or existing.shared_network_id is not None:
+                existing.dhcp_server = dhcp_server
+                existing.shared_network = None
+                changed = True
+            if changed:
+                existing.save()
+                summary.subnets_updated += 1
+            subnet_obj = existing
+        else:
+            # Let the plugin auto-allocate its own (global) subnet_id; never write Kea's.
+            subnet_obj = Subnet(
+                name=_subnet_name(server, intent),
+                prefix=prefix_obj,
+                dhcp_server=dhcp_server,
+                shared_network=None,
+            )
+            subnet_obj.save()
+            summary.subnets_created += 1
+            if intent.kea_subnet_id is not None:
+                KeaDhcpLink.objects.update_or_create(
+                    object_type=ContentType.objects.get_for_model(Subnet),
+                    object_id=subnet_obj.pk,
+                    defaults={
+                        "server": server,
+                        "family": intent.family,
+                        "kea_subnet_id": intent.kea_subnet_id,
+                    },
+                )
+    except Exception as exc:  # noqa: BLE001 — one bad subnet must not abort the import
+        summary.errors += 1
+        summary.warn(f"subnet {intent.cidr} (id={intent.kea_subnet_id}): {exc}")
+        return None
+
+    if intent.shared_network is not None:
+        summary.shared_networks_deferred += 1
+    if intent.options:
+        summary.options_deferred += len(intent.options)
+
+    return subnet_obj
+
+
+def upsert_pools(subnet_obj, intent: SubnetIntent, server, summary: ImportSummary):
+    """Get/create DHCP-plugin ``Pool`` rows for each Kea pool in *intent*."""
+    Pool = _model("Pool")
+    for pool_intent in intent.pools:
+        range_obj = _ensure_ip_range(pool_intent.pool, intent.cidr, server.sync_vrf)
+        if range_obj is None:
+            summary.warn(f"pool {pool_intent.pool} in {intent.cidr}: unusable range, skipped")
+            continue
+        try:
+            _obj, created = Pool.objects.get_or_create(
+                subnet=subnet_obj,
+                ip_range=range_obj,
+                defaults={"name": _pool_name(subnet_obj, pool_intent)},
+            )
+            if created:
+                summary.pools_created += 1
+        except Exception as exc:  # noqa: BLE001
+            summary.errors += 1
+            summary.warn(f"pool {pool_intent.pool} in {intent.cidr}: {exc}")
+
+
+def _find_reservation(HostReservation, subnet_obj, intent: ReservationIntent, mac_obj):
+    """Find an existing DHCP-plugin reservation in *subnet_obj* matching *intent*'s identifier."""
+    base = HostReservation.objects.filter(subnet=subnet_obj)
+    id_type = intent.identifier_type
+    if id_type == "hw-address":
+        return base.filter(hw_address=mac_obj).first() if mac_obj is not None else None
+    if id_type == "duid":
+        return base.filter(duid=intent.identifier).first()
+    if id_type == "circuit-id":
+        return base.filter(circuit_id=intent.identifier).first()
+    if id_type == "client-id":
+        return base.filter(client_id=intent.identifier).first()
+    if id_type == "flex-id":
+        return base.filter(flex_id=intent.identifier).first()
+    return None
+
+
+def upsert_reservations(subnet_obj, intent: SubnetIntent, summary: ImportSummary):
+    """Get/create DHCP-plugin ``HostReservation`` rows for each Kea reservation in *intent*."""
+    HostReservation = _model("HostReservation")
+
+    for res in intent.reservations:
+        if res.identifier_type is None:
+            summary.warn(f"reservation in {intent.cidr} has no identifier — skipped")
+            continue
+        if res.options:
+            summary.options_deferred += len(res.options)
+
+        ipv4_ip, ipv6_ips, mac_obj = _ensure_reservation_addresses(res, intent.kea_subnet_id, intent.cidr)
+
+        try:
+            obj = _find_reservation(HostReservation, subnet_obj, res, mac_obj)
+            created = obj is None
+            if obj is None:
+                obj = HostReservation(subnet=subnet_obj, dhcp_server=None, name=_reservation_name(subnet_obj, res))
+            obj.hostname = res.hostname or None
+            _apply_reservation_identifier(obj, res, mac_obj)
+            if res.family == 4:
+                obj.ipv4_address = ipv4_ip
+            obj.save()
+            if res.family == 6 and ipv6_ips:
+                obj.ipv6_addresses.set(ipv6_ips)
+            if created:
+                summary.reservations_created += 1
+            else:
+                summary.reservations_updated += 1
+        except Exception as exc:  # noqa: BLE001
+            summary.errors += 1
+            summary.warn(f"reservation {res.identifier} in {intent.cidr}: {exc}")
+
+
+def _apply_reservation_identifier(obj, res: ReservationIntent, mac_obj) -> None:
+    """Set the single Kea identifier on a DHCP-plugin reservation (clearing the others)."""
+    obj.hw_address = mac_obj if res.identifier_type == "hw-address" else None
+    obj.duid = res.identifier if res.identifier_type == "duid" else None
+    obj.circuit_id = res.identifier if res.identifier_type == "circuit-id" else None
+    obj.client_id = res.identifier if res.identifier_type == "client-id" else None
+    obj.flex_id = res.identifier if res.identifier_type == "flex-id" else None
+
+
+def import_server_config(server, config: ServerConfigIntent) -> ImportSummary:
+    """Import one parsed ``(server, family)`` Kea config into the DHCP plugin.
+
+    Idempotent: re-running updates the same rows (subnets via ``KeaDhcpLink``,
+    pools/reservations matched structurally) rather than duplicating them.
+    """
+    summary = ImportSummary()
+    dhcp_server = upsert_dhcp_server(server)
+    for subnet_intent in config.subnets:
+        subnet_obj = upsert_subnet(server, dhcp_server, subnet_intent, summary)
+        if subnet_obj is None:
+            continue
+        upsert_pools(subnet_obj, subnet_intent, server, summary)
+        upsert_reservations(subnet_obj, subnet_intent, summary)
+    return summary
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Stale-cleanup exclusion (so the IPAM sync never GCs rows the plugin references)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def sys4_referenced_ip_ids() -> set[int]:
+    """PKs of ``ipam.IPAddress`` rows referenced by any DHCP-plugin reservation."""
+    if not is_available():
+        return set()
+    HostReservation = _model("HostReservation")
+    ids: set[int] = set()
+    ids.update(HostReservation.objects.exclude(ipv4_address__isnull=True).values_list("ipv4_address_id", flat=True))
+    ids.update(HostReservation.objects.values_list("ipv6_addresses__id", flat=True))
+    ids.discard(None)
+    return ids
+
+
+def sys4_referenced_prefix_ids() -> set[int]:
+    """PKs of ``ipam.Prefix`` rows referenced by DHCP-plugin subnets/shared-networks/reservations."""
+    if not is_available():
+        return set()
+    Subnet = _model("Subnet")
+    SharedNetwork = _model("SharedNetwork")
+    HostReservation = _model("HostReservation")
+    ids: set[int] = set()
+    ids.update(Subnet.objects.values_list("prefix_id", flat=True))
+    ids.update(SharedNetwork.objects.values_list("prefix_id", flat=True))
+    ids.update(HostReservation.objects.values_list("ipv6_prefixes__id", flat=True))
+    ids.update(HostReservation.objects.values_list("excluded_ipv6_prefixes__id", flat=True))
+    ids.discard(None)
+    return ids
+
+
+def sys4_referenced_iprange_ids() -> set[int]:
+    """PKs of ``ipam.IPRange`` rows referenced by any DHCP-plugin pool."""
+    if not is_available():
+        return set()
+    Pool = _model("Pool")
+    ids = set(Pool.objects.values_list("ip_range_id", flat=True))
+    ids.discard(None)
+    return ids

--- a/netbox_kea/integrations/dhcp_plugin.py
+++ b/netbox_kea/integrations/dhcp_plugin.py
@@ -14,6 +14,10 @@ v1 scope (import + diff, read-only against Kea):
   existing IPAM helpers so the DHCP-plugin rows **share** the same
   ``ipam.Prefix``/``IPRange``/``IPAddress`` and ``dcim.MACAddress`` objects the
   IPAM sync maintains.
+* **Host reservations** come from both inline config (``subnetN[].reservations``)
+  and — crucially, when a hosts database is used — the ``host_cmds`` backend via
+  ``reservation-get-page`` (``config.page_reservations``, routed to subnets by
+  Kea subnet-id).  Inline reservations are usually empty on DB-backed servers.
 * Subnet identity is tracked in :class:`netbox_kea.models.KeaDhcpLink` keyed by
   ``(server, family, kea_subnet_id)`` — Kea's subnet-id is unique only per
   ``(server, protocol)`` and cannot live in the plugin's globally-unique
@@ -584,9 +588,9 @@ def _pool_name(subnet_obj, pool_intent) -> str:
     return f"{subnet_obj.name} pool {pool_intent.pool}"[:255]
 
 
-def _reservation_name(subnet_obj, res: ReservationIntent) -> str:
-    """Build a unique reservation name scoped to its parent subnet's (unique) name."""
-    return f"{subnet_obj.name} {res.identifier_type}:{res.identifier}"[:255]
+def _reservation_name(scope_name: str, res: ReservationIntent) -> str:
+    """Build a unique reservation name scoped to its parent's (unique) name."""
+    return f"{scope_name} {res.identifier_type}:{res.identifier}"[:255]
 
 
 def upsert_subnet(server, dhcp_server, intent: SubnetIntent, summary: ImportSummary):
@@ -676,9 +680,8 @@ def upsert_pools(subnet_obj, intent: SubnetIntent, server, summary: ImportSummar
         upsert_options(pool_obj, pool_intent.options, intent.family, dhcp_server, custom_defs, summary)
 
 
-def _find_reservation(HostReservation, subnet_obj, intent: ReservationIntent, mac_obj):
-    """Find an existing DHCP-plugin reservation in *subnet_obj* matching *intent*'s identifier."""
-    base = HostReservation.objects.filter(subnet=subnet_obj)
+def _find_reservation(base, intent: ReservationIntent, mac_obj):
+    """Find an existing reservation in the *base* queryset matching *intent*'s identifier."""
     id_type = intent.identifier_type
     if id_type == "hw-address":
         return base.filter(hw_address=mac_obj).first() if mac_obj is not None else None
@@ -693,38 +696,82 @@ def _find_reservation(HostReservation, subnet_obj, intent: ReservationIntent, ma
     return None
 
 
-def upsert_reservations(subnet_obj, intent: SubnetIntent, summary: ImportSummary, dhcp_server, custom_defs):
-    """Get/create DHCP-plugin ``HostReservation`` rows (and their options) per Kea reservation."""
+def _upsert_reservation(res, subnet_obj, dhcp_server, cidr, kea_subnet_id, family, custom_defs, summary):
+    """Upsert one Kea reservation under a subnet (``subnet_obj``) or globally (``subnet_obj=None``).
+
+    Reservations match within their parent scope by identifier, so re-import updates
+    the same row.  Reuses the IPAM/MAC sync helpers so the plugin reservation shares
+    the same ``ipam.IPAddress``/``dcim.MACAddress`` rows the lease/reservation sync owns.
+    """
     HostReservation = _model("HostReservation")
+    scope = cidr or "global"
+    if res.identifier_type is None:
+        summary.warn(f"reservation in {scope} has no identifier — skipped")
+        return
 
+    ipv4_ip, ipv6_ips, mac_obj = _ensure_reservation_addresses(res, kea_subnet_id, cidr)
+
+    if subnet_obj is not None:
+        base = HostReservation.objects.filter(subnet=subnet_obj)
+        scope_name = subnet_obj.name
+    else:
+        base = HostReservation.objects.filter(dhcp_server=dhcp_server, subnet__isnull=True)
+        scope_name = dhcp_server.name
+
+    try:
+        obj = _find_reservation(base, res, mac_obj)
+        created = obj is None
+        if obj is None:
+            obj = HostReservation(
+                subnet=subnet_obj,
+                dhcp_server=None if subnet_obj is not None else dhcp_server,
+                name=_reservation_name(scope_name, res),
+            )
+        obj.hostname = res.hostname or None
+        _apply_reservation_identifier(obj, res, mac_obj)
+        if res.family == 4:
+            obj.ipv4_address = ipv4_ip
+        obj.save()
+        if res.family == 6 and ipv6_ips:
+            obj.ipv6_addresses.set(ipv6_ips)
+        if created:
+            summary.reservations_created += 1
+        else:
+            summary.reservations_updated += 1
+    except Exception as exc:  # noqa: BLE001
+        summary.errors += 1
+        summary.warn(f"reservation {res.identifier} in {scope}: {exc}")
+        return
+    upsert_options(obj, res.options, family, dhcp_server, custom_defs, summary)
+
+
+def upsert_reservations(subnet_obj, intent: SubnetIntent, summary: ImportSummary, dhcp_server, custom_defs):
+    """Upsert the inline (config-file) reservations of a subnet."""
     for res in intent.reservations:
-        if res.identifier_type is None:
-            summary.warn(f"reservation in {intent.cidr} has no identifier — skipped")
-            continue
+        _upsert_reservation(
+            res, subnet_obj, dhcp_server, intent.cidr, intent.kea_subnet_id, intent.family, custom_defs, summary
+        )
 
-        ipv4_ip, ipv6_ips, mac_obj = _ensure_reservation_addresses(res, intent.kea_subnet_id, intent.cidr)
 
-        try:
-            obj = _find_reservation(HostReservation, subnet_obj, res, mac_obj)
-            created = obj is None
-            if obj is None:
-                obj = HostReservation(subnet=subnet_obj, dhcp_server=None, name=_reservation_name(subnet_obj, res))
-            obj.hostname = res.hostname or None
-            _apply_reservation_identifier(obj, res, mac_obj)
-            if res.family == 4:
-                obj.ipv4_address = ipv4_ip
-            obj.save()
-            if res.family == 6 and ipv6_ips:
-                obj.ipv6_addresses.set(ipv6_ips)
-            if created:
-                summary.reservations_created += 1
-            else:
-                summary.reservations_updated += 1
-        except Exception as exc:  # noqa: BLE001
-            summary.errors += 1
-            summary.warn(f"reservation {res.identifier} in {intent.cidr}: {exc}")
-            continue
-        upsert_options(obj, res.options, res.family, dhcp_server, custom_defs, summary)
+def import_page_reservations(server, dhcp_server, config: ServerConfigIntent, custom_defs, summary: ImportSummary):
+    """Import DB-backed host reservations (``reservation-get-page``) by Kea subnet-id.
+
+    Each group is routed to the previously-linked plugin ``Subnet`` (via ``KeaDhcpLink``);
+    subnet-id 0 (global) reservations are attached to the ``DHCPServer``.  Reservations
+    for a subnet-id with no imported subnet are skipped with a warning.
+    """
+    for sid, reservations in config.page_reservations.items():
+        if sid and sid > 0:
+            subnet_obj = _linked_subnet(server, config.family, sid)
+            if subnet_obj is None:
+                summary.warn(f"{len(reservations)} reservation(s) for unknown subnet-id {sid} skipped")
+                continue
+            cidr = str(subnet_obj.prefix.prefix)
+            for res in reservations:
+                _upsert_reservation(res, subnet_obj, dhcp_server, cidr, sid, config.family, custom_defs, summary)
+        else:
+            for res in reservations:
+                _upsert_reservation(res, None, dhcp_server, "", None, config.family, custom_defs, summary)
 
 
 def _apply_reservation_identifier(obj, res: ReservationIntent, mac_obj) -> None:
@@ -759,6 +806,9 @@ def import_server_config(server, config: ServerConfigIntent) -> ImportSummary:
         upsert_options(subnet_obj, subnet_intent.options, config.family, dhcp_server, custom_defs, summary)
         upsert_pools(subnet_obj, subnet_intent, server, summary, dhcp_server, custom_defs)
         upsert_reservations(subnet_obj, subnet_intent, summary, dhcp_server, custom_defs)
+
+    # DB-backed reservations (reservation-get-page) — routed to subnets via KeaDhcpLink.
+    import_page_reservations(server, dhcp_server, config, custom_defs, summary)
     return summary
 
 

--- a/netbox_kea/integrations/dhcp_plugin.py
+++ b/netbox_kea/integrations/dhcp_plugin.py
@@ -19,9 +19,14 @@ v1 scope (import + diff, read-only against Kea):
   ``(server, protocol)`` and cannot live in the plugin's globally-unique
   ``Subnet.subnet_id``.  Pools and reservations match structurally within their
   resolved parent subnet.
+* DHCP **options** (``option-data``) are imported at every scope we model —
+  ``DHCPServer`` (global), ``Subnet``, ``Pool``, ``HostReservation`` — binding to
+  the sys4-shipped standard ``OptionDefinition`` (by space+code), or to a
+  server-scoped custom definition created from a Kea ``option-def``.  Options
+  whose definition cannot be resolved are skipped (counted), never fatal.
 * **Deferred** (reported, not imported): shared-network grouping (the plugin's
   ``SharedNetwork`` requires a prefix Kea does not model — member subnets are
-  flattened onto the ``DHCPServer``) and per-object DHCP options.
+  flattened onto the ``DHCPServer``).
 """
 
 from __future__ import annotations
@@ -31,7 +36,13 @@ from dataclasses import dataclass, field
 
 from django.apps import apps
 
-from ..mappers.kea_to_dhcp import ReservationIntent, ServerConfigIntent, SubnetIntent
+from ..mappers.kea_to_dhcp import (
+    OptionDefIntent,
+    OptionIntent,
+    ReservationIntent,
+    ServerConfigIntent,
+    SubnetIntent,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -52,8 +63,11 @@ class ImportSummary:
     pools_created: int = 0
     reservations_created: int = 0
     reservations_updated: int = 0
+    options_created: int = 0
+    options_updated: int = 0
+    options_skipped: int = 0
+    option_defs_created: int = 0
     shared_networks_deferred: int = 0
-    options_deferred: int = 0
     errors: int = 0
     warnings: list[str] = field(default_factory=list)
 
@@ -181,6 +195,134 @@ def _resolve_mac(hw_address: str | None):
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# DHCP options (option-data → Option, binding to standard/custom OptionDefinition)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _default_space(family: int) -> str:
+    """Return the Kea/sys4 default option space for a protocol family."""
+    return "dhcp6" if family == 6 else "dhcp4"
+
+
+def _send_option(opt: OptionIntent) -> str | None:
+    """Map Kea ``always-send``/``never-send`` flags to the plugin's single choice."""
+    if opt.always_send:
+        return "always-send"
+    if opt.never_send:
+        return "never-send"
+    return None
+
+
+def _custom_def_index(config: ServerConfigIntent) -> dict[tuple, OptionDefIntent]:
+    """Index a config's custom ``option-def`` entries by ``(space, code)`` for lookup."""
+    index: dict[tuple, OptionDefIntent] = {}
+    for d in config.option_defs:
+        if d.code is None:
+            continue
+        index[(d.space or _default_space(config.family), d.code)] = d
+    return index
+
+
+def _create_custom_option_def(def_intent: OptionDefIntent, family: int, dhcp_server, summary: ImportSummary):
+    """Create a non-standard ``OptionDefinition`` for a Kea custom option, scoped to the server."""
+    OptionDefinition = _model("OptionDefinition")
+    space = def_intent.space or _default_space(family)
+    fam = 6 if space == "dhcp6" else 4
+    try:
+        obj = OptionDefinition(
+            name=def_intent.name or f"option-{def_intent.code}",
+            family=fam,
+            space=space,
+            code=def_intent.code,
+            type=def_intent.type or "string",
+            array=def_intent.array,
+            record_types=list(def_intent.record_types) or None,
+            encapsulate=def_intent.encapsulate,
+            standard=False,
+            dhcp_server=dhcp_server,
+        )
+        obj.save()
+        summary.option_defs_created += 1
+        return obj
+    except Exception as exc:  # noqa: BLE001 — a bad definition must not abort the import
+        summary.warn(f"option-def code={def_intent.code}: {exc}")
+        return None
+
+
+def _resolve_option_definition(opt: OptionIntent, family: int, dhcp_server, custom_defs, summary):
+    """Find (or create) the ``OptionDefinition`` a Kea ``option-data`` entry refers to.
+
+    Prefers the sys4-shipped **standard** definition (by space+code, else space+name);
+    falls back to a server-scoped **custom** definition (existing, or created from a Kea
+    ``option-def``).  Returns ``None`` when the option cannot be resolved.
+    """
+    OptionDefinition = _model("OptionDefinition")
+    space = opt.space or _default_space(family)
+
+    standard = OptionDefinition.objects.filter(standard=True, space=space)
+    if opt.code is not None:
+        found = standard.filter(code=opt.code).first()
+    elif opt.name:
+        found = standard.filter(name=opt.name).first()
+    else:
+        found = None
+    if found is not None:
+        return found
+
+    custom = OptionDefinition.objects.filter(standard=False, dhcp_server=dhcp_server, space=space)
+    if opt.code is not None:
+        found = custom.filter(code=opt.code).first()
+    elif opt.name:
+        found = custom.filter(name=opt.name).first()
+    if found is not None:
+        return found
+
+    if opt.code is not None:
+        def_intent = custom_defs.get((space, opt.code))
+        if def_intent is not None:
+            return _create_custom_option_def(def_intent, family, dhcp_server, summary)
+    return None
+
+
+def upsert_options(parent_obj, options, family: int, dhcp_server, custom_defs, summary: ImportSummary) -> None:
+    """Upsert DHCP-plugin ``Option`` rows for *options* assigned to *parent_obj*.
+
+    Idempotent: one Option per ``(parent, definition)``.  Options whose definition
+    cannot be resolved — or whose data fails the plugin's validators — are skipped
+    with a warning rather than aborting the import.
+    """
+    if not options:
+        return
+    from django.contrib.contenttypes.models import ContentType
+
+    Option = _model("Option")
+    ct = ContentType.objects.get_for_model(type(parent_obj))
+    for opt in options:
+        definition = _resolve_option_definition(opt, family, dhcp_server, custom_defs, summary)
+        if definition is None:
+            summary.options_skipped += 1
+            summary.warn(f"option {opt.match_key}: no matching definition, skipped")
+            continue
+        try:
+            existing = Option.objects.filter(
+                assigned_object_type=ct, assigned_object_id=parent_obj.pk, definition=definition
+            ).first()
+            created = existing is None
+            obj = existing or Option(definition=definition, assigned_object_type=ct, assigned_object_id=parent_obj.pk)
+            obj.data = opt.data or ""
+            obj.csv_format = opt.csv_format
+            obj.send_option = _send_option(opt)
+            obj.save()
+            if created:
+                summary.options_created += 1
+            else:
+                summary.options_updated += 1
+        except Exception as exc:  # noqa: BLE001 — one bad option must not abort the import
+            summary.options_skipped += 1
+            summary.warn(f"option {opt.match_key}: {exc}")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Upserts
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -276,14 +418,12 @@ def upsert_subnet(server, dhcp_server, intent: SubnetIntent, summary: ImportSumm
 
     if intent.shared_network is not None:
         summary.shared_networks_deferred += 1
-    if intent.options:
-        summary.options_deferred += len(intent.options)
 
     return subnet_obj
 
 
-def upsert_pools(subnet_obj, intent: SubnetIntent, server, summary: ImportSummary):
-    """Get/create DHCP-plugin ``Pool`` rows for each Kea pool in *intent*."""
+def upsert_pools(subnet_obj, intent: SubnetIntent, server, summary: ImportSummary, dhcp_server, custom_defs):
+    """Get/create DHCP-plugin ``Pool`` rows (and their options) for each Kea pool in *intent*."""
     Pool = _model("Pool")
     for pool_intent in intent.pools:
         range_obj = _ensure_ip_range(pool_intent.pool, intent.cidr, server.sync_vrf)
@@ -291,7 +431,7 @@ def upsert_pools(subnet_obj, intent: SubnetIntent, server, summary: ImportSummar
             summary.warn(f"pool {pool_intent.pool} in {intent.cidr}: unusable range, skipped")
             continue
         try:
-            _obj, created = Pool.objects.get_or_create(
+            pool_obj, created = Pool.objects.get_or_create(
                 subnet=subnet_obj,
                 ip_range=range_obj,
                 defaults={"name": _pool_name(subnet_obj, pool_intent)},
@@ -301,6 +441,8 @@ def upsert_pools(subnet_obj, intent: SubnetIntent, server, summary: ImportSummar
         except Exception as exc:  # noqa: BLE001
             summary.errors += 1
             summary.warn(f"pool {pool_intent.pool} in {intent.cidr}: {exc}")
+            continue
+        upsert_options(pool_obj, pool_intent.options, intent.family, dhcp_server, custom_defs, summary)
 
 
 def _find_reservation(HostReservation, subnet_obj, intent: ReservationIntent, mac_obj):
@@ -320,16 +462,14 @@ def _find_reservation(HostReservation, subnet_obj, intent: ReservationIntent, ma
     return None
 
 
-def upsert_reservations(subnet_obj, intent: SubnetIntent, summary: ImportSummary):
-    """Get/create DHCP-plugin ``HostReservation`` rows for each Kea reservation in *intent*."""
+def upsert_reservations(subnet_obj, intent: SubnetIntent, summary: ImportSummary, dhcp_server, custom_defs):
+    """Get/create DHCP-plugin ``HostReservation`` rows (and their options) per Kea reservation."""
     HostReservation = _model("HostReservation")
 
     for res in intent.reservations:
         if res.identifier_type is None:
             summary.warn(f"reservation in {intent.cidr} has no identifier — skipped")
             continue
-        if res.options:
-            summary.options_deferred += len(res.options)
 
         ipv4_ip, ipv6_ips, mac_obj = _ensure_reservation_addresses(res, intent.kea_subnet_id, intent.cidr)
 
@@ -352,6 +492,8 @@ def upsert_reservations(subnet_obj, intent: SubnetIntent, summary: ImportSummary
         except Exception as exc:  # noqa: BLE001
             summary.errors += 1
             summary.warn(f"reservation {res.identifier} in {intent.cidr}: {exc}")
+            continue
+        upsert_options(obj, res.options, res.family, dhcp_server, custom_defs, summary)
 
 
 def _apply_reservation_identifier(obj, res: ReservationIntent, mac_obj) -> None:
@@ -371,12 +513,18 @@ def import_server_config(server, config: ServerConfigIntent) -> ImportSummary:
     """
     summary = ImportSummary()
     dhcp_server = upsert_dhcp_server(server)
+    custom_defs = _custom_def_index(config)
+
+    # Global (server-level) options.
+    upsert_options(dhcp_server, config.global_options, config.family, dhcp_server, custom_defs, summary)
+
     for subnet_intent in config.subnets:
         subnet_obj = upsert_subnet(server, dhcp_server, subnet_intent, summary)
         if subnet_obj is None:
             continue
-        upsert_pools(subnet_obj, subnet_intent, server, summary)
-        upsert_reservations(subnet_obj, subnet_intent, summary)
+        upsert_options(subnet_obj, subnet_intent.options, config.family, dhcp_server, custom_defs, summary)
+        upsert_pools(subnet_obj, subnet_intent, server, summary, dhcp_server, custom_defs)
+        upsert_reservations(subnet_obj, subnet_intent, summary, dhcp_server, custom_defs)
     return summary
 
 

--- a/netbox_kea/integrations/dhcp_plugin.py
+++ b/netbox_kea/integrations/dhcp_plugin.py
@@ -24,6 +24,11 @@ v1 scope (import + diff, read-only against Kea):
   the sys4-shipped standard ``OptionDefinition`` (by space+code), or to a
   server-scoped custom definition created from a Kea ``option-def``.  Options
   whose definition cannot be resolved are skipped (counted), never fatal.
+* **Tuning fields** (lifetimes, timers, lease/DDNS/BOOTP/network settings) are
+  imported onto the ``DHCPServer`` (global) and ``Subnet``.  ``config-get`` returns
+  these fully defaulted and inherited, so each subnet field is stored **only when
+  it differs from the DHCPServer parent** (parent-diff suppression) — otherwise it
+  is left blank to inherit, keeping the records minimal and faithful.
 * **Deferred** (reported, not imported): shared-network grouping (the plugin's
   ``SharedNetwork`` requires a prefix Kea does not model — member subnets are
   flattened onto the ``DHCPServer``).
@@ -323,6 +328,174 @@ def upsert_options(parent_obj, options, family: int, dhcp_server, custom_defs, s
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Tuning fields (lifetimes/timers/lease/DDNS/BOOTP/network) — Kea key → sys4 field
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _decimal(value):
+    """Coerce a Kea numeric to ``Decimal`` via ``str`` (avoids float-precision noise)."""
+    from decimal import Decimal
+
+    return None if value is None else Decimal(str(value))
+
+
+def _norm_ddns_replace(value):
+    """Map Kea ``ddns-replace-client-name`` (hyphenated) to the plugin's underscored choice."""
+    return value.replace("-", "_") if isinstance(value, str) else value
+
+
+def _relay_to_str(value):
+    """Flatten a Kea ``relay`` (``{"ip-addresses": [...]}``) to the plugin's CSV string."""
+    if isinstance(value, dict):
+        addrs = value.get("ip-addresses") or []
+    elif isinstance(value, list):
+        addrs = value
+    else:
+        return value or None
+    return ", ".join(addrs) if addrs else None
+
+
+def _server_id_type(value):
+    """Reduce a Kea ``server-id`` dict to its ``type`` (the plugin stores only the type)."""
+    return value.get("type") if isinstance(value, dict) else value
+
+
+def _hr_identifiers(value):
+    """Keep only host-reservation identifier types the plugin's choice set knows."""
+    if not isinstance(value, list):
+        return None
+    valid = {"circuit-id", "hw-address", "duid", "client-id"}
+    return [x for x in value if x in valid] or None
+
+
+# (kea_key, sys4_attr, transform). Fields shared by DHCPServer + Subnet.
+_COMMON_FIELDS: tuple[tuple[str, str, object], ...] = (
+    ("valid-lifetime", "valid_lifetime", None),
+    ("min-valid-lifetime", "min_valid_lifetime", None),
+    ("max-valid-lifetime", "max_valid_lifetime", None),
+    ("preferred-lifetime", "preferred_lifetime", None),
+    ("min-preferred-lifetime", "min_preferred_lifetime", None),
+    ("max-preferred-lifetime", "max_preferred_lifetime", None),
+    ("offer-lifetime", "offer_lifetime", None),
+    ("renew-timer", "renew_timer", None),
+    ("rebind-timer", "rebind_timer", None),
+    ("match-client-id", "match_client_id", None),
+    ("authoritative", "authoritative", None),
+    ("reservations-global", "reservations_global", None),
+    ("reservations-out-of-pool", "reservations_out_of_pool", None),
+    ("reservations-in-subnet", "reservations_in_subnet", None),
+    ("calculate-tee-times", "calculate_tee_times", None),
+    ("t1-percent", "t1_percent", _decimal),
+    ("t2-percent", "t2_percent", _decimal),
+    ("cache-threshold", "cache_threshold", _decimal),
+    ("cache-max-age", "cache_max_age", None),
+    ("store-extended-info", "store_extended_info", None),
+    ("allocator", "allocator", None),
+    ("pd-allocator", "pd_allocator", None),
+    ("ddns-send-updates", "ddns_send_updates", None),
+    ("ddns-override-no-update", "ddns_override_no_update", None),
+    ("ddns-override-client-update", "ddns_override_client_update", None),
+    ("ddns-replace-client-name", "ddns_replace_client_name", _norm_ddns_replace),
+    ("ddns-generated-prefix", "ddns_generated_prefix", None),
+    ("ddns-qualifying-suffix", "ddns_qualifying_suffix", None),
+    ("ddns-update-on-renew", "ddns_update_on_renew", None),
+    ("ddns-conflict-resolution-mode", "ddns_conflict_resolution_mode", None),
+    ("ddns-ttl-percent", "ddns_ttl_percent", _decimal),
+    ("ddns-ttl", "ddns_ttl", None),
+    ("ddns-ttl-min", "ddns_ttl_min", None),
+    ("ddns-ttl-max", "ddns_ttl_max", None),
+    ("hostname-char-set", "hostname_char_set", None),
+    ("hostname-char-replacement", "hostname_char_replacement", None),
+    ("next-server", "next_server", None),
+    ("server-hostname", "server_hostname", None),
+    ("boot-file-name", "boot_file_name", None),
+)
+
+_SUBNET_FIELDS: tuple[tuple[str, str, object], ...] = _COMMON_FIELDS + (
+    ("relay", "relay", _relay_to_str),
+    ("interface-id", "interface_id", None),
+    ("rapid-commit", "rapid_commit", None),
+)
+
+_SERVER_FIELDS: tuple[tuple[str, str, object], ...] = _COMMON_FIELDS + (
+    ("decline-probation-period", "decline_probation_period", None),
+    ("host-reservation-identifiers", "host_reservation_identifiers", _hr_identifiers),
+    ("echo-client-id", "echo_client_id", None),
+    ("relay-supplied-options", "relay_supplied_options", None),
+    ("server-id", "server_id", _server_id_type),
+)
+
+
+def _is_unset(value) -> bool:
+    """Return ``True`` for values treated as 'not configured' (None / empty str / empty list)."""
+    return value is None or value == "" or value == []
+
+
+def _transform_value(transform, raw, kea_key: str, summary: ImportSummary):
+    """Apply a field transform, returning ``None`` (and warning) if it raises."""
+    if transform is None:
+        return raw
+    try:
+        return transform(raw)
+    except Exception as exc:  # noqa: BLE001 — a bad scalar must not abort the import
+        summary.warn(f"setting {kea_key}: {exc}")
+        return None
+
+
+def _apply_global_settings(dhcp_server, settings: dict, summary: ImportSummary) -> None:
+    """Populate ``DHCPServer`` global tuning fields from a Kea config block.
+
+    Only fills fields that are currently unset, so a dual-stack server's first
+    (DHCPv4) import wins shared fields and the DHCPv6 import fills the gaps (e.g.
+    ``preferred-lifetime``, ``pd-allocator``) — netbox_dhcp has a single
+    ``DHCPServer`` row spanning both protocols.
+    """
+    if not settings:
+        return
+    model_fields = {f.name for f in dhcp_server._meta.get_fields()}
+    changed = False
+    for kea_key, attr, transform in _SERVER_FIELDS:
+        if attr not in model_fields or kea_key not in settings:
+            continue
+        if not _is_unset(getattr(dhcp_server, attr, None)):
+            continue  # already set (e.g. by the other protocol) — don't clobber
+        value = _transform_value(transform, settings[kea_key], kea_key, summary)
+        if _is_unset(value):
+            continue
+        setattr(dhcp_server, attr, value)
+        changed = True
+    if changed:
+        try:
+            dhcp_server.save()
+        except Exception as exc:  # noqa: BLE001
+            summary.errors += 1
+            summary.warn(f"DHCPServer settings: {exc}")
+
+
+def _apply_subnet_settings(subnet_obj, dhcp_server, settings: dict, summary: ImportSummary) -> bool:
+    """Set subnet tuning fields only where they differ from the stored DHCPServer parent.
+
+    This is the parent-diff suppression: ``config-get`` returns every value fully
+    inherited, so a subnet value equal to the server's is left blank (it inherits).
+    Returns ``True`` if any field on *subnet_obj* changed.
+    """
+    model_fields = {f.name for f in subnet_obj._meta.get_fields()}
+    changed = False
+    for kea_key, attr, transform in _SUBNET_FIELDS:
+        if attr not in model_fields or kea_key not in settings:
+            continue
+        value = _transform_value(transform, settings[kea_key], kea_key, summary)
+        if _is_unset(value):
+            continue
+        if value == getattr(dhcp_server, attr, None):
+            continue  # inherited from the DHCPServer parent — leave blank
+        if getattr(subnet_obj, attr, None) != value:
+            setattr(subnet_obj, attr, value)
+            changed = True
+    return changed
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Upserts
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -387,6 +560,8 @@ def upsert_subnet(server, dhcp_server, intent: SubnetIntent, summary: ImportSumm
                 existing.dhcp_server = dhcp_server
                 existing.shared_network = None
                 changed = True
+            if _apply_subnet_settings(existing, dhcp_server, intent.settings, summary):
+                changed = True
             if changed:
                 existing.save()
                 summary.subnets_updated += 1
@@ -399,6 +574,7 @@ def upsert_subnet(server, dhcp_server, intent: SubnetIntent, summary: ImportSumm
                 dhcp_server=dhcp_server,
                 shared_network=None,
             )
+            _apply_subnet_settings(subnet_obj, dhcp_server, intent.settings, summary)
             subnet_obj.save()
             summary.subnets_created += 1
             if intent.kea_subnet_id is not None:
@@ -515,7 +691,8 @@ def import_server_config(server, config: ServerConfigIntent) -> ImportSummary:
     dhcp_server = upsert_dhcp_server(server)
     custom_defs = _custom_def_index(config)
 
-    # Global (server-level) options.
+    # Global (server-level) tuning fields + options.
+    _apply_global_settings(dhcp_server, config.global_settings, summary)
     upsert_options(dhcp_server, config.global_options, config.family, dhcp_server, custom_defs, summary)
 
     for subnet_intent in config.subnets:

--- a/netbox_kea/integrations/dhcp_plugin.py
+++ b/netbox_kea/integrations/dhcp_plugin.py
@@ -83,6 +83,9 @@ class ImportSummary:
     client_classes_created: int = 0
     client_classes_updated: int = 0
     shared_networks_deferred: int = 0
+    # True when the DB-backed host reservations could not be read (e.g. host_cmds
+    # hook not loaded), so the reservation counts above may be incomplete.
+    reservations_unread: bool = False
     errors: int = 0
     warnings: list[str] = field(default_factory=list)
 
@@ -143,7 +146,7 @@ def _ensure_ip_range(pool_str: str, subnet_cidr: str, vrf):
     return range_obj
 
 
-def _ensure_reservation_addresses(intent: ReservationIntent, kea_subnet_id: int | None, subnet_cidr: str):
+def _ensure_reservation_addresses(intent: ReservationIntent, kea_subnet_id: int | None, subnet_cidr: str, family: int):
     """Ensure the reservation's IPAM rows exist (status=reserved) and return them.
 
     Reuses :func:`sync_reservation_to_netbox` so the DHCP-plugin reservation shares
@@ -168,8 +171,8 @@ def _ensure_reservation_addresses(intent: ReservationIntent, kea_subnet_id: int 
 
     try:
         prefix_len = IPNetwork(subnet_cidr).prefixlen
-    except Exception:  # noqa: BLE001 — fall back to host mask if subnet CIDR is odd
-        prefix_len = 128 if ":" in subnet_cidr else 32
+    except Exception:  # noqa: BLE001 — no subnet CIDR (global reservation): use the family host mask
+        prefix_len = 128 if family == 6 else 32
     spm = {kea_subnet_id: prefix_len} if kea_subnet_id is not None else None
 
     try:
@@ -452,13 +455,19 @@ def _transform_value(transform, raw, kea_key: str, summary: ImportSummary):
         return None
 
 
-def _apply_global_settings(dhcp_server, settings: dict, summary: ImportSummary) -> None:
+def _apply_global_settings(dhcp_server, settings: dict, summary: ImportSummary, *, primary: bool) -> None:
     """Populate ``DHCPServer`` global tuning fields from a Kea config block.
 
-    Only fills fields that are currently unset, so a dual-stack server's first
-    (DHCPv4) import wins shared fields and the DHCPv6 import fills the gaps (e.g.
-    ``preferred-lifetime``, ``pd-allocator``) — netbox_dhcp has a single
-    ``DHCPServer`` row spanning both protocols.
+    netbox_dhcp has a single ``DHCPServer`` row spanning both protocols, so one
+    family is authoritative.  The *primary* family (DHCPv4, or whichever family is
+    enabled on a single-stack server) **mirrors** its values — re-import re-syncs a
+    changed global value.  The secondary family only **fills gaps** (e.g. the
+    DHCPv6-only ``preferred-lifetime``/``pd-allocator``) so it never clobbers the
+    primary family's shared fields and dual-stack re-imports do not thrash.
+
+    Known limitation: a change to a *secondary-only* field (e.g. DHCPv6
+    ``preferred-lifetime``) on a dual-stack server is not re-synced, since the
+    secondary family is fill-only for an already-set field.
     """
     if not settings:
         return
@@ -467,13 +476,19 @@ def _apply_global_settings(dhcp_server, settings: dict, summary: ImportSummary) 
     for kea_key, attr, transform in _SERVER_FIELDS:
         if attr not in model_fields or kea_key not in settings:
             continue
-        if not _is_unset(getattr(dhcp_server, attr, None)):
-            continue  # already set (e.g. by the other protocol) — don't clobber
         value = _transform_value(transform, settings[kea_key], kea_key, summary)
         if _is_unset(value):
             continue
-        setattr(dhcp_server, attr, value)
-        changed = True
+        current = getattr(dhcp_server, attr, None)
+        if primary:
+            # This family owns the global config — mirror changed values on re-import.
+            if current != value:
+                setattr(dhcp_server, attr, value)
+                changed = True
+        elif _is_unset(current):
+            # Secondary protocol only fills gaps the primary family did not set.
+            setattr(dhcp_server, attr, value)
+            changed = True
     if changed:
         try:
             dhcp_server.save()
@@ -483,26 +498,33 @@ def _apply_global_settings(dhcp_server, settings: dict, summary: ImportSummary) 
 
 
 def _apply_inherited_settings(obj, parent, settings: dict, field_map, summary: ImportSummary) -> bool:
-    """Set *obj* tuning fields only where they differ from the stored *parent*.
+    """Mirror *obj*'s tuning fields to Kea, storing only genuine overrides.
 
-    This is the parent-diff suppression: ``config-get`` returns every value fully
-    inherited, so a child value equal to its parent's is left blank (it inherits).
-    The ``model_fields`` guard skips fields *obj* does not have, so a single field
-    map can serve models with different mixins (e.g. ``Subnet`` vs ``ClientClass``).
+    ``config-get`` returns every value fully inherited, so a field is stored on the
+    child only when it is present and **differs** from the stored *parent*
+    (parent-diff suppression).  A value equal to the parent — or one Kea no longer
+    reports — is **cleared**, so a removed Kea override does not linger as stale data
+    on re-import.  The ``model_fields`` guard skips fields *obj* does not have, so one
+    field map serves models with different mixins (e.g. ``Subnet`` vs ``ClientClass``).
     Returns ``True`` if any field on *obj* changed.
     """
     model_fields = {f.name for f in obj._meta.get_fields()}
     changed = False
     for kea_key, attr, transform in field_map:
-        if attr not in model_fields or kea_key not in settings:
+        if attr not in model_fields:
             continue
-        value = _transform_value(transform, settings[kea_key], kea_key, summary)
-        if _is_unset(value):
-            continue
-        if value == getattr(parent, attr, None):
-            continue  # inherited from the parent — leave blank
-        if getattr(obj, attr, None) != value:
-            setattr(obj, attr, value)
+        value = _transform_value(transform, settings[kea_key], kea_key, summary) if kea_key in settings else None
+        # Store only a genuine override (present and differing from the parent);
+        # otherwise clear it so the child inherits (and stale overrides don't linger).
+        if not _is_unset(value) and value != getattr(parent, attr, None):
+            desired = value
+        else:
+            # "Cleared" value: None for nullable fields, the field's empty default
+            # (e.g. "" for a non-null CharField like hostname_char_set) otherwise.
+            db_field = obj._meta.get_field(attr)
+            desired = None if db_field.null else db_field.get_default()
+        if getattr(obj, attr, None) != desired:
+            setattr(obj, attr, desired)
             changed = True
     return changed
 
@@ -523,7 +545,13 @@ def upsert_dhcp_server(server):
 
 
 def _client_class_name(server, kea_name: str) -> str:
-    """Namespace a Kea class name to this server (NetBoxDHCPModelMixin needs a unique name)."""
+    """Namespace a Kea class name to this server (NetBoxDHCPModelMixin needs a unique name).
+
+    Note: this namespaced name will NOT match the bare Kea class name referenced from
+    a subnet's ``client-classes`` list or another class's ``test`` expression.  That is
+    fine for the v1 import (those references are not imported), but a future push-back /
+    reference-resolution phase must map the bare Kea name back to this namespaced row.
+    """
     return f"{server.name}: {kea_name}"[:255]
 
 
@@ -709,7 +737,7 @@ def _upsert_reservation(res, subnet_obj, dhcp_server, cidr, kea_subnet_id, famil
         summary.warn(f"reservation in {scope} has no identifier — skipped")
         return
 
-    ipv4_ip, ipv6_ips, mac_obj = _ensure_reservation_addresses(res, kea_subnet_id, cidr)
+    ipv4_ip, ipv6_ips, mac_obj = _ensure_reservation_addresses(res, kea_subnet_id, cidr, family)
 
     if subnet_obj is not None:
         base = HostReservation.objects.filter(subnet=subnet_obj)
@@ -790,11 +818,14 @@ def import_server_config(server, config: ServerConfigIntent) -> ImportSummary:
     pools/reservations matched structurally) rather than duplicating them.
     """
     summary = ImportSummary()
+    summary.reservations_unread = config.reservations_unavailable
     dhcp_server = upsert_dhcp_server(server)
     custom_defs = _custom_def_index(config)
 
-    # Global (server-level) tuning fields + options + client classes.
-    _apply_global_settings(dhcp_server, config.global_settings, summary)
+    # Global (server-level) tuning fields + options + client classes. DHCPv4 (or the
+    # only enabled family) is authoritative for the shared, single DHCPServer row.
+    primary = config.family == 4 or not server.dhcp4
+    _apply_global_settings(dhcp_server, config.global_settings, summary, primary=primary)
     upsert_options(dhcp_server, config.global_options, config.family, dhcp_server, custom_defs, summary)
     for cc_intent in config.client_classes:
         upsert_client_class(server, dhcp_server, cc_intent, custom_defs, summary)

--- a/netbox_kea/integrations/dhcp_plugin.py
+++ b/netbox_kea/integrations/dhcp_plugin.py
@@ -631,13 +631,13 @@ def upsert_subnet(server, dhcp_server, intent: SubnetIntent, summary: ImportSumm
     Subnet = _model("Subnet")
     KeaDhcpLink = _link_model()
 
-    prefix_obj = _ensure_prefix(intent.cidr, server.sync_vrf)
-
     existing = None
     if intent.kea_subnet_id is not None:
         existing = _linked_subnet(server, intent.family, intent.kea_subnet_id)
 
     try:
+        # Inside the try so one bad CIDR is counted as a per-subnet error, not fatal.
+        prefix_obj = _ensure_prefix(intent.cidr, server.sync_vrf)
         if existing is not None:
             changed = False
             if existing.prefix_id != prefix_obj.pk:
@@ -665,13 +665,17 @@ def upsert_subnet(server, dhcp_server, intent: SubnetIntent, summary: ImportSumm
             subnet_obj.save()
             summary.subnets_created += 1
             if intent.kea_subnet_id is not None:
+                # Key on the authoritative Kea identity, not the sys4 object: a stale
+                # link (its subnet deleted out from under it) must be *relinked* to the
+                # new subnet, not collide with the keadhcplink_unique_subnet_identity
+                # constraint as a fresh (object_type, object_id) create would.
                 KeaDhcpLink.objects.update_or_create(
-                    object_type=ContentType.objects.get_for_model(Subnet),
-                    object_id=subnet_obj.pk,
+                    server=server,
+                    family=intent.family,
+                    kea_subnet_id=intent.kea_subnet_id,
                     defaults={
-                        "server": server,
-                        "family": intent.family,
-                        "kea_subnet_id": intent.kea_subnet_id,
+                        "object_type": ContentType.objects.get_for_model(Subnet),
+                        "object_id": subnet_obj.pk,
                     },
                 )
     except Exception as exc:  # noqa: BLE001 — one bad subnet must not abort the import
@@ -737,8 +741,6 @@ def _upsert_reservation(res, subnet_obj, dhcp_server, cidr, kea_subnet_id, famil
         summary.warn(f"reservation in {scope} has no identifier — skipped")
         return
 
-    ipv4_ip, ipv6_ips, mac_obj = _ensure_reservation_addresses(res, kea_subnet_id, cidr, family)
-
     if subnet_obj is not None:
         base = HostReservation.objects.filter(subnet=subnet_obj)
         scope_name = subnet_obj.name
@@ -747,6 +749,8 @@ def _upsert_reservation(res, subnet_obj, dhcp_server, cidr, kea_subnet_id, famil
         scope_name = dhcp_server.name
 
     try:
+        # Inside the try so a resolver failure is counted per-reservation, not fatal.
+        ipv4_ip, ipv6_ips, mac_obj = _ensure_reservation_addresses(res, kea_subnet_id, cidr, family)
         obj = _find_reservation(base, res, mac_obj)
         created = obj is None
         if obj is None:
@@ -760,7 +764,9 @@ def _upsert_reservation(res, subnet_obj, dhcp_server, cidr, kea_subnet_id, famil
         if res.family == 4:
             obj.ipv4_address = ipv4_ip
         obj.save()
-        if res.family == 6 and ipv6_ips:
+        if res.family == 6:
+            # set() unconditionally so re-importing a reservation that dropped its
+            # IPv6 addresses clears the stale M2M relations (empty list = clear).
             obj.ipv6_addresses.set(ipv6_ips)
         if created:
             summary.reservations_created += 1

--- a/netbox_kea/jobs.py
+++ b/netbox_kea/jobs.py
@@ -69,35 +69,22 @@ def _prefetch_reservation_ips(server: Server, version: int) -> frozenset[str] | 
     the fetch fails (e.g. host_cmds hook not loaded or network error) — callers
     should fall back to single-pass mode when ``None`` is returned.
     """
-    from .kea import KeaException
+    from .kea import KeaException, iter_reservations
 
     service = f"dhcp{version}"
-    from_index = 0
-    source_index = 0
     ips: set[str] = set()
 
     try:
         client = server.get_client(version=version)
-        while True:
-            page, next_from, next_source = client.reservation_get_page(
-                service,
-                source_index=source_index,
-                from_index=from_index,
-                limit=100,
-            )
-            for r in page:
-                if not isinstance(r, dict):
-                    continue
-                ip = r.get("ip-address")
-                if ip:
-                    ips.add(ip)
-                for addr in r.get("ip-addresses") or []:
-                    if addr:
-                        ips.add(addr)
-            if next_from == 0 and next_source == 0:
-                break
-            from_index = next_from
-            source_index = next_source
+        for r in iter_reservations(client, service):
+            if not isinstance(r, dict):
+                continue
+            ip = r.get("ip-address")
+            if ip:
+                ips.add(ip)
+            for addr in r.get("ip-addresses") or []:
+                if addr:
+                    ips.add(addr)
     except KeaException as exc:
         if exc.response.get("result") == 2:
             logger.debug(
@@ -216,12 +203,10 @@ def _sync_server_reservations(
     A ``False`` return means *all_synced* may be incomplete and cleanup must be
     skipped.
     """
-    from .kea import KeaException
+    from .kea import KeaException, iter_reservations
     from .sync import sync_reservation_to_netbox
 
     service = f"dhcp{version}"
-    from_index = 0
-    source_index = 0
     processed = 0
     had_errors = False
     # Foreign (manually-curated) NetBox IPs skipped to avoid overwriting them.
@@ -229,42 +214,31 @@ def _sync_server_reservations(
 
     try:
         client = server.get_client(version=version)
-        while True:
-            page, next_from, next_source = client.reservation_get_page(
-                service,
-                source_index=source_index,
-                from_index=from_index,
-                limit=100,
-            )
-            for reservation in page:
-                try:
-                    _ip, created, changed = sync_reservation_to_netbox(
-                        reservation,
-                        cleanup=False,
-                        lease_ips=lease_ips,
-                        subnet_prefix_map=subnet_prefix_map,
-                        conflicts=conflicts,
-                    )
-                    all_synced.append(reservation)
-                    processed += 1
-                    if created:
-                        stats["created"] += 1
-                    elif changed:
-                        stats["updated"] += 1
-                except Exception:  # noqa: BLE001, PERF203
-                    ip = reservation.get("ip-address") or (reservation.get("ip-addresses") or ["?"])[0] or "?"
-                    logger.debug(
-                        "Failed to sync reservation %s from server %s",
-                        ip,
-                        server.name,
-                        exc_info=True,
-                    )
-                    stats["errors"] += 1
-                    had_errors = True
-            if next_from == 0 and next_source == 0:
-                break
-            from_index = next_from
-            source_index = next_source
+        for reservation in iter_reservations(client, service):
+            try:
+                _ip, created, changed = sync_reservation_to_netbox(
+                    reservation,
+                    cleanup=False,
+                    lease_ips=lease_ips,
+                    subnet_prefix_map=subnet_prefix_map,
+                    conflicts=conflicts,
+                )
+                all_synced.append(reservation)
+                processed += 1
+                if created:
+                    stats["created"] += 1
+                elif changed:
+                    stats["updated"] += 1
+            except Exception:  # noqa: BLE001, PERF203
+                ip = reservation.get("ip-address") or (reservation.get("ip-addresses") or ["?"])[0] or "?"
+                logger.debug(
+                    "Failed to sync reservation %s from server %s",
+                    ip,
+                    server.name,
+                    exc_info=True,
+                )
+                stats["errors"] += 1
+                had_errors = True
     except KeaException as exc:
         if exc.response.get("result") == 2:
             logger.warning(

--- a/netbox_kea/kea.py
+++ b/netbox_kea/kea.py
@@ -1,7 +1,7 @@
 import copy
 import ipaddress
 import logging
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from typing import Any, TypedDict
 
 import requests
@@ -1493,3 +1493,36 @@ def check_response(resp: list[KeaResponse], ok_codes: Sequence[int]) -> None:
     for idx, kr in enumerate(resp):
         if kr["result"] not in ok_codes:
             raise KeaException(kr, index=idx)
+
+
+def iter_reservations(client: "KeaClient", service: str, limit: int = 100) -> Iterator[dict[str, Any]]:
+    """Yield every host reservation for *service*, paging through ``reservation-get-page``.
+
+    The single home for the ``(from, source-index)`` cursor loop so callers never
+    re-implement it.  Defined as a function (not a method) so it drives whatever
+    ``client.reservation_get_page`` is in play — including the mocks the test suite
+    configures on the client.  Propagates :class:`KeaException` on a Kea error (e.g.
+    ``host_cmds`` not loaded), exactly as ``reservation_get_page`` does; callers wrap
+    the iteration in a ``try``/``except``.
+
+    Args:
+        client: A :class:`KeaClient` (or compatible) exposing ``reservation_get_page``.
+        service: Target service (``"dhcp4"`` or ``"dhcp6"``).
+        limit: Page size requested from Kea.
+
+    Yields:
+        Each host-reservation dict, across all sources/pages.
+
+    """
+    from_index = 0
+    source_index = 0
+    while True:
+        page, next_from, next_source = client.reservation_get_page(
+            service, source_index=source_index, from_index=from_index, limit=limit
+        )
+        yield from page
+        # Stop when Kea's cursor resets, or an empty page (guards against a loop).
+        if not page or (next_from == 0 and next_source == 0):
+            break
+        from_index = next_from
+        source_index = next_source

--- a/netbox_kea/kea.py
+++ b/netbox_kea/kea.py
@@ -1524,5 +1524,12 @@ def iter_reservations(client: "KeaClient", service: str, limit: int = 100) -> It
         # Stop when Kea's cursor resets, or an empty page (guards against a loop).
         if not page or (next_from == 0 and next_source == 0):
             break
+        # Guard against a stalled cursor: a non-empty page whose cursor did not
+        # advance would otherwise loop forever and hang the worker.
+        if next_from == from_index and next_source == source_index:
+            raise RuntimeError(
+                f"reservation-get-page cursor did not advance for {service}: "
+                f"source-index={next_source}, from={next_from}"
+            )
         from_index = next_from
         source_index = next_source

--- a/netbox_kea/mappers/__init__.py
+++ b/netbox_kea/mappers/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2025 Marcin Zieba <marcinpsk@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+"""Pure (Django-free) transforms from Kea API payloads to normalized intent."""

--- a/netbox_kea/mappers/kea_to_dhcp.py
+++ b/netbox_kea/mappers/kea_to_dhcp.py
@@ -234,6 +234,9 @@ class ServerConfigIntent:
     # DB-backed host reservations (from reservation-get-page), grouped by Kea subnet-id
     # (0 = global). These never appear in config-get when a hosts database is used.
     page_reservations: dict[int, tuple[ReservationIntent, ...]] = field(default_factory=dict)
+    # True when reservation-get-page could not be read (e.g. host_cmds not loaded);
+    # lets the importer report that DB-backed reservations may be missing.
+    reservations_unavailable: bool = False
 
 
 def _option_intent(raw: dict) -> OptionIntent | None:

--- a/netbox_kea/mappers/kea_to_dhcp.py
+++ b/netbox_kea/mappers/kea_to_dhcp.py
@@ -47,10 +47,29 @@ class OptionIntent:
     data: str
     csv_format: bool | None
     always_send: bool | None
+    never_send: bool | None = None
 
     @property
     def match_key(self) -> tuple:
         """Identity within a parent: (space, code) — or (space, name) when code is absent."""
+        return (self.space, self.code if self.code is not None else self.name)
+
+
+@dataclass(frozen=True)
+class OptionDefIntent:
+    """A Kea custom ``option-def`` entry (defines a non-standard option code)."""
+
+    code: int | None
+    name: str | None
+    space: str | None
+    type: str | None
+    array: bool | None
+    record_types: tuple[str, ...]
+    encapsulate: str | None
+
+    @property
+    def match_key(self) -> tuple:
+        """Identity: (space, code) — or (space, name) when code is absent."""
         return (self.space, self.code if self.code is not None else self.name)
 
 
@@ -89,6 +108,7 @@ class PoolIntent:
     """A Kea pool string (``start-end`` range or ``CIDR``) within a subnet."""
 
     pool: str
+    options: tuple[OptionIntent, ...] = ()
 
     @property
     def match_key(self) -> str:
@@ -125,6 +145,8 @@ class ServerConfigIntent:
     family: int
     shared_networks: list[SharedNetworkIntent] = field(default_factory=list)
     subnets: list[SubnetIntent] = field(default_factory=list)
+    global_options: tuple[OptionIntent, ...] = ()
+    option_defs: tuple[OptionDefIntent, ...] = ()
 
 
 def _option_intent(raw: dict) -> OptionIntent | None:
@@ -143,6 +165,7 @@ def _option_intent(raw: dict) -> OptionIntent | None:
         data=raw.get("data", "") or "",
         csv_format=raw.get("csv-format"),
         always_send=raw.get("always-send"),
+        never_send=raw.get("never-send"),
     )
 
 
@@ -151,6 +174,36 @@ def _options(raw_list) -> tuple[OptionIntent, ...]:
     if not isinstance(raw_list, list):
         return ()
     out = [_option_intent(o) for o in raw_list]
+    return tuple(o for o in out if o is not None)
+
+
+def _option_def_intent(raw: dict) -> OptionDefIntent | None:
+    """Normalize one Kea ``option-def`` dict; return ``None`` if not a dict."""
+    if not isinstance(raw, dict):
+        return None
+    code = raw.get("code")
+    try:
+        code = int(code) if code is not None else None
+    except (TypeError, ValueError):
+        code = None
+    record_types = raw.get("record-types")
+    record_types = tuple(str(r) for r in record_types) if isinstance(record_types, list) else ()
+    return OptionDefIntent(
+        code=code,
+        name=raw.get("name"),
+        space=raw.get("space"),
+        type=raw.get("type"),
+        array=raw.get("array"),
+        record_types=record_types,
+        encapsulate=raw.get("encapsulate") or None,
+    )
+
+
+def _option_defs(raw_list) -> tuple[OptionDefIntent, ...]:
+    """Normalize an ``option-def`` list, dropping non-dict entries."""
+    if not isinstance(raw_list, list):
+        return ()
+    out = [_option_def_intent(o) for o in raw_list]
     return tuple(o for o in out if o is not None)
 
 
@@ -185,14 +238,16 @@ def _reservation_intent(raw: dict, family: int) -> ReservationIntent | None:
 
 
 def _pools(raw_list) -> tuple[PoolIntent, ...]:
-    """Normalize a subnet's ``pools`` list to non-empty pool strings."""
+    """Normalize a subnet's ``pools`` list to non-empty pool strings (with options)."""
     if not isinstance(raw_list, list):
         return ()
     out: list[PoolIntent] = []
     for entry in raw_list:
-        pool = entry.get("pool") if isinstance(entry, dict) else None
+        if not isinstance(entry, dict):
+            continue
+        pool = entry.get("pool")
         if pool:
-            out.append(PoolIntent(pool=pool))
+            out.append(PoolIntent(pool=pool, options=_options(entry.get("option-data"))))
     return tuple(out)
 
 
@@ -238,6 +293,9 @@ def parse_dhcp_config(conf: dict, version: int) -> ServerConfigIntent:
 
     if not isinstance(conf, dict):
         return result
+
+    result.global_options = _options(conf.get("option-data"))
+    result.option_defs = _option_defs(conf.get("option-def"))
 
     for raw in conf.get(subnet_key) or []:
         subnet = _subnet_intent(raw, family, shared_network=None)

--- a/netbox_kea/mappers/kea_to_dhcp.py
+++ b/netbox_kea/mappers/kea_to_dhcp.py
@@ -231,6 +231,9 @@ class ServerConfigIntent:
     global_options: tuple[OptionIntent, ...] = ()
     option_defs: tuple[OptionDefIntent, ...] = ()
     global_settings: dict = field(default_factory=dict)
+    # DB-backed host reservations (from reservation-get-page), grouped by Kea subnet-id
+    # (0 = global). These never appear in config-get when a hosts database is used.
+    page_reservations: dict[int, tuple[ReservationIntent, ...]] = field(default_factory=dict)
 
 
 def _option_intent(raw: dict) -> OptionIntent | None:
@@ -360,6 +363,31 @@ def _subnet_intent(raw: dict, family: int, shared_network: str | None) -> Subnet
         options=_options(raw.get("option-data")),
         settings=_settings(raw),
     )
+
+
+def parse_reservations_page(hosts, family: int) -> dict[int, tuple[ReservationIntent, ...]]:
+    """Group ``reservation-get-page`` host dicts into ReservationIntents by Kea subnet-id.
+
+    Each host carries a ``subnet-id`` (0 for a global reservation).  The host dicts
+    have the same shape as inline subnet reservations, so :func:`_reservation_intent`
+    parses them directly.  Malformed/identifier-less entries are dropped.
+    """
+    grouped: dict[int, list[ReservationIntent]] = {}
+    if not isinstance(hosts, list):
+        return {}
+    for raw in hosts:
+        if not isinstance(raw, dict):
+            continue
+        res = _reservation_intent(raw, family)
+        if res is None:
+            continue
+        sid = raw.get("subnet-id")
+        try:
+            sid = int(sid) if sid is not None else 0
+        except (TypeError, ValueError):
+            sid = 0
+        grouped.setdefault(sid, []).append(res)
+    return {sid: tuple(reservations) for sid, reservations in grouped.items()}
 
 
 def _client_class_intent(raw: dict, family: int) -> ClientClassIntent | None:

--- a/netbox_kea/mappers/kea_to_dhcp.py
+++ b/netbox_kea/mappers/kea_to_dhcp.py
@@ -36,6 +36,74 @@ RESERVATION_IDENTIFIER_TYPES: tuple[str, ...] = (
     "flex-id",
 )
 
+# Scalar Kea config keys that map onto netbox_dhcp tuning fields (lifetimes, timers,
+# lease/DDNS/BOOTP/network settings, and server-level globals).  ``config-get``
+# returns these fully defaulted+inherited at both the global and subnet scope; the
+# adapter decides which apply to which model and suppresses values inherited from
+# the parent.  Captured verbatim here (the Kea→sys4 field mapping lives in the adapter).
+KEA_SETTINGS_KEYS: tuple[str, ...] = (
+    # lifetimes / timers
+    "valid-lifetime",
+    "min-valid-lifetime",
+    "max-valid-lifetime",
+    "preferred-lifetime",
+    "min-preferred-lifetime",
+    "max-preferred-lifetime",
+    "offer-lifetime",
+    "renew-timer",
+    "rebind-timer",
+    # lease behaviour
+    "match-client-id",
+    "authoritative",
+    "reservations-global",
+    "reservations-out-of-pool",
+    "reservations-in-subnet",
+    "calculate-tee-times",
+    "t1-percent",
+    "t2-percent",
+    "cache-threshold",
+    "cache-max-age",
+    "store-extended-info",
+    "allocator",
+    "pd-allocator",
+    # DDNS
+    "ddns-send-updates",
+    "ddns-override-no-update",
+    "ddns-override-client-update",
+    "ddns-replace-client-name",
+    "ddns-generated-prefix",
+    "ddns-qualifying-suffix",
+    "ddns-update-on-renew",
+    "ddns-conflict-resolution-mode",
+    "ddns-ttl-percent",
+    "ddns-ttl",
+    "ddns-ttl-min",
+    "ddns-ttl-max",
+    "hostname-char-set",
+    "hostname-char-replacement",
+    # BOOTP
+    "next-server",
+    "server-hostname",
+    "boot-file-name",
+    # network (subnet)
+    "relay",
+    "interface-id",
+    "rapid-commit",
+    # server-level globals
+    "decline-probation-period",
+    "host-reservation-identifiers",
+    "echo-client-id",
+    "relay-supplied-options",
+    "server-id",
+)
+
+
+def _settings(raw: dict) -> dict:
+    """Extract the subset of :data:`KEA_SETTINGS_KEYS` present in a Kea config dict."""
+    if not isinstance(raw, dict):
+        return {}
+    return {k: raw[k] for k in KEA_SETTINGS_KEYS if k in raw}
+
 
 @dataclass(frozen=True)
 class OptionIntent:
@@ -127,6 +195,7 @@ class SubnetIntent:
     pools: tuple[PoolIntent, ...]
     reservations: tuple[ReservationIntent, ...]
     options: tuple[OptionIntent, ...]
+    settings: dict = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -147,6 +216,7 @@ class ServerConfigIntent:
     subnets: list[SubnetIntent] = field(default_factory=list)
     global_options: tuple[OptionIntent, ...] = ()
     option_defs: tuple[OptionDefIntent, ...] = ()
+    global_settings: dict = field(default_factory=dict)
 
 
 def _option_intent(raw: dict) -> OptionIntent | None:
@@ -274,6 +344,7 @@ def _subnet_intent(raw: dict, family: int, shared_network: str | None) -> Subnet
         pools=_pools(raw.get("pools")),
         reservations=reservations,
         options=_options(raw.get("option-data")),
+        settings=_settings(raw),
     )
 
 
@@ -296,6 +367,7 @@ def parse_dhcp_config(conf: dict, version: int) -> ServerConfigIntent:
 
     result.global_options = _options(conf.get("option-data"))
     result.option_defs = _option_defs(conf.get("option-def"))
+    result.global_settings = _settings(conf)
 
     for raw in conf.get(subnet_key) or []:
         subnet = _subnet_intent(raw, family, shared_network=None)

--- a/netbox_kea/mappers/kea_to_dhcp.py
+++ b/netbox_kea/mappers/kea_to_dhcp.py
@@ -207,6 +207,19 @@ class SharedNetworkIntent:
     options: tuple[OptionIntent, ...]
 
 
+@dataclass(frozen=True)
+class ClientClassIntent:
+    """A Kea client-class (classification rule + per-class settings/options)."""
+
+    name: str
+    family: int
+    test: str
+    template_test: str
+    only_in_additional_list: bool | None
+    options: tuple[OptionIntent, ...]
+    settings: dict = field(default_factory=dict)
+
+
 @dataclass
 class ServerConfigIntent:
     """Everything importable from one ``(server, family)`` Kea config block."""
@@ -214,6 +227,7 @@ class ServerConfigIntent:
     family: int
     shared_networks: list[SharedNetworkIntent] = field(default_factory=list)
     subnets: list[SubnetIntent] = field(default_factory=list)
+    client_classes: list[ClientClassIntent] = field(default_factory=list)
     global_options: tuple[OptionIntent, ...] = ()
     option_defs: tuple[OptionDefIntent, ...] = ()
     global_settings: dict = field(default_factory=dict)
@@ -348,6 +362,28 @@ def _subnet_intent(raw: dict, family: int, shared_network: str | None) -> Subnet
     )
 
 
+def _client_class_intent(raw: dict, family: int) -> ClientClassIntent | None:
+    """Normalize one Kea ``client-classes`` entry; return ``None`` if unusable."""
+    if not isinstance(raw, dict):
+        return None
+    name = raw.get("name")
+    if not name:
+        return None
+    # Kea renamed ``only-if-required`` → ``only-in-additional-list`` (2.7.4); accept either.
+    only = raw.get("only-in-additional-list")
+    if only is None:
+        only = raw.get("only-if-required")
+    return ClientClassIntent(
+        name=name,
+        family=family,
+        test=raw.get("test", "") or "",
+        template_test=raw.get("template-test", "") or "",
+        only_in_additional_list=only,
+        options=_options(raw.get("option-data")),
+        settings=_settings(raw),
+    )
+
+
 def parse_dhcp_config(conf: dict, version: int) -> ServerConfigIntent:
     """Parse a Kea ``Dhcp4``/``Dhcp6`` config block into a :class:`ServerConfigIntent`.
 
@@ -368,6 +404,11 @@ def parse_dhcp_config(conf: dict, version: int) -> ServerConfigIntent:
     result.global_options = _options(conf.get("option-data"))
     result.option_defs = _option_defs(conf.get("option-def"))
     result.global_settings = _settings(conf)
+
+    for raw_cc in conf.get("client-classes") or []:
+        cc = _client_class_intent(raw_cc, family)
+        if cc is not None:
+            result.client_classes.append(cc)
 
     for raw in conf.get(subnet_key) or []:
         subnet = _subnet_intent(raw, family, shared_network=None)

--- a/netbox_kea/mappers/kea_to_dhcp.py
+++ b/netbox_kea/mappers/kea_to_dhcp.py
@@ -1,0 +1,261 @@
+# SPDX-FileCopyrightText: 2025 Marcin Zieba <marcinpsk@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+"""Pure transforms: a Kea ``DhcpN`` config block → normalized DHCP-plugin intent.
+
+This module is deliberately free of Django, the ORM, and ``netbox_dhcp``: it
+only reshapes the dicts that :meth:`KeaClient.command` returns for ``config-get``
+into small dataclasses, plus the match keys used to upsert ``netbox_dhcp`` rows
+idempotently.  Keeping it pure means it is fully unit-testable in CI, where the
+optional DHCP plugin is not installed.
+
+Input shape (the ``Dhcp4``/``Dhcp6`` object from ``config-get``)::
+
+    {
+        "subnet4": [{"id": 1, "subnet": "10.0.0.0/24",
+                     "pools": [{"pool": "10.0.0.10-10.0.0.200"}],
+                     "option-data": [...],
+                     "reservations": [{"hw-address": "...", "ip-address": "...",
+                                       "hostname": "...", "option-data": [...]}]}],
+        "shared-networks": [{"name": "office", "subnet4": [ ...same shape... ]}],
+    }
+
+DHCPv6 uses ``subnet6`` and reservations carry ``ip-addresses``/``prefixes``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+# Kea host-reservation identifier types, in the priority order Kea itself documents
+# (host-reservation-identifiers). The first present on a reservation is its identity.
+RESERVATION_IDENTIFIER_TYPES: tuple[str, ...] = (
+    "hw-address",
+    "duid",
+    "circuit-id",
+    "client-id",
+    "flex-id",
+)
+
+
+@dataclass(frozen=True)
+class OptionIntent:
+    """A single Kea ``option-data`` entry, normalized."""
+
+    code: int | None
+    name: str | None
+    space: str | None
+    data: str
+    csv_format: bool | None
+    always_send: bool | None
+
+    @property
+    def match_key(self) -> tuple:
+        """Identity within a parent: (space, code) — or (space, name) when code is absent."""
+        return (self.space, self.code if self.code is not None else self.name)
+
+
+@dataclass(frozen=True)
+class ReservationIntent:
+    """A Kea host reservation, normalized to a single identifier + its addresses."""
+
+    family: int
+    identifier_type: str | None
+    identifier: str | None
+    ip_address: str | None
+    ip_addresses: tuple[str, ...]
+    prefixes: tuple[str, ...]
+    hostname: str
+    options: tuple[OptionIntent, ...]
+
+    @property
+    def match_key(self) -> tuple:
+        """Identity within a parent subnet: (identifier_type, identifier)."""
+        return (self.identifier_type, self.identifier)
+
+    @property
+    def all_addresses(self) -> tuple[str, ...]:
+        """Every host IP (v4 single + v6 list), de-duplicated, order-preserving."""
+        seen: dict[str, None] = {}
+        if self.ip_address:
+            seen.setdefault(self.ip_address, None)
+        for addr in self.ip_addresses:
+            if addr:
+                seen.setdefault(addr, None)
+        return tuple(seen)
+
+
+@dataclass(frozen=True)
+class PoolIntent:
+    """A Kea pool string (``start-end`` range or ``CIDR``) within a subnet."""
+
+    pool: str
+
+    @property
+    def match_key(self) -> str:
+        """Identity within a subnet: the normalized pool string."""
+        return self.pool.strip()
+
+
+@dataclass(frozen=True)
+class SubnetIntent:
+    """A Kea subnet, with its parent shared-network (if any) and children."""
+
+    kea_subnet_id: int | None
+    cidr: str
+    family: int
+    shared_network: str | None
+    pools: tuple[PoolIntent, ...]
+    reservations: tuple[ReservationIntent, ...]
+    options: tuple[OptionIntent, ...]
+
+
+@dataclass(frozen=True)
+class SharedNetworkIntent:
+    """A Kea shared-network (groups subnets)."""
+
+    name: str
+    family: int
+    options: tuple[OptionIntent, ...]
+
+
+@dataclass
+class ServerConfigIntent:
+    """Everything importable from one ``(server, family)`` Kea config block."""
+
+    family: int
+    shared_networks: list[SharedNetworkIntent] = field(default_factory=list)
+    subnets: list[SubnetIntent] = field(default_factory=list)
+
+
+def _option_intent(raw: dict) -> OptionIntent | None:
+    """Normalize one ``option-data`` dict; return ``None`` if it is not a dict."""
+    if not isinstance(raw, dict):
+        return None
+    code = raw.get("code")
+    try:
+        code = int(code) if code is not None else None
+    except (TypeError, ValueError):
+        code = None
+    return OptionIntent(
+        code=code,
+        name=raw.get("name"),
+        space=raw.get("space"),
+        data=raw.get("data", "") or "",
+        csv_format=raw.get("csv-format"),
+        always_send=raw.get("always-send"),
+    )
+
+
+def _options(raw_list) -> tuple[OptionIntent, ...]:
+    """Normalize an ``option-data`` list, dropping non-dict entries."""
+    if not isinstance(raw_list, list):
+        return ()
+    out = [_option_intent(o) for o in raw_list]
+    return tuple(o for o in out if o is not None)
+
+
+def _reservation_identifier(raw: dict) -> tuple[str | None, str | None]:
+    """Return ``(identifier_type, identifier)`` using Kea's priority order."""
+    for id_type in RESERVATION_IDENTIFIER_TYPES:
+        value = raw.get(id_type)
+        if value:
+            return id_type, str(value)
+    return None, None
+
+
+def _reservation_intent(raw: dict, family: int) -> ReservationIntent | None:
+    """Normalize one Kea reservation dict; return ``None`` if not a dict."""
+    if not isinstance(raw, dict):
+        return None
+    id_type, identifier = _reservation_identifier(raw)
+    ip_addresses = raw.get("ip-addresses")
+    ip_addresses = tuple(a for a in ip_addresses if a) if isinstance(ip_addresses, list) else ()
+    prefixes = raw.get("prefixes")
+    prefixes = tuple(p for p in prefixes if p) if isinstance(prefixes, list) else ()
+    return ReservationIntent(
+        family=family,
+        identifier_type=id_type,
+        identifier=identifier,
+        ip_address=raw.get("ip-address") or None,
+        ip_addresses=ip_addresses,
+        prefixes=prefixes,
+        hostname=raw.get("hostname", "") or "",
+        options=_options(raw.get("option-data")),
+    )
+
+
+def _pools(raw_list) -> tuple[PoolIntent, ...]:
+    """Normalize a subnet's ``pools`` list to non-empty pool strings."""
+    if not isinstance(raw_list, list):
+        return ()
+    out: list[PoolIntent] = []
+    for entry in raw_list:
+        pool = entry.get("pool") if isinstance(entry, dict) else None
+        if pool:
+            out.append(PoolIntent(pool=pool))
+    return tuple(out)
+
+
+def _subnet_intent(raw: dict, family: int, shared_network: str | None) -> SubnetIntent | None:
+    """Normalize one Kea subnet dict; return ``None`` when it has no CIDR."""
+    if not isinstance(raw, dict):
+        return None
+    cidr = raw.get("subnet")
+    if not cidr:
+        return None
+    sid = raw.get("id")
+    try:
+        sid = int(sid) if sid is not None else None
+    except (TypeError, ValueError):
+        sid = None
+    reservations = tuple(
+        r for r in (_reservation_intent(x, family) for x in raw.get("reservations") or []) if r is not None
+    )
+    return SubnetIntent(
+        kea_subnet_id=sid,
+        cidr=cidr,
+        family=family,
+        shared_network=shared_network,
+        pools=_pools(raw.get("pools")),
+        reservations=reservations,
+        options=_options(raw.get("option-data")),
+    )
+
+
+def parse_dhcp_config(conf: dict, version: int) -> ServerConfigIntent:
+    """Parse a Kea ``Dhcp4``/``Dhcp6`` config block into a :class:`ServerConfigIntent`.
+
+    Standalone subnets (under ``subnetN``) carry ``shared_network=None``; subnets
+    nested in a ``shared-networks`` entry carry that network's name.  Malformed
+    entries (non-dicts, subnets without a CIDR) are skipped rather than raising,
+    so a partially-malformed live config still imports what it can.
+    """
+    if version not in (4, 6):
+        raise ValueError(f"version must be 4 or 6, got {version!r}")
+    family = version
+    subnet_key = f"subnet{version}"
+    result = ServerConfigIntent(family=family)
+
+    if not isinstance(conf, dict):
+        return result
+
+    for raw in conf.get(subnet_key) or []:
+        subnet = _subnet_intent(raw, family, shared_network=None)
+        if subnet is not None:
+            result.subnets.append(subnet)
+
+    for raw_net in conf.get("shared-networks") or []:
+        if not isinstance(raw_net, dict):
+            continue
+        name = raw_net.get("name")
+        if not name:
+            continue
+        result.shared_networks.append(
+            SharedNetworkIntent(name=name, family=family, options=_options(raw_net.get("option-data")))
+        )
+        for raw in raw_net.get(subnet_key) or []:
+            subnet = _subnet_intent(raw, family, shared_network=name)
+            if subnet is not None:
+                result.subnets.append(subnet)
+
+    return result

--- a/netbox_kea/migrations/0013_server_sync_dhcp_plugin_enabled_keadhcplink.py
+++ b/netbox_kea/migrations/0013_server_sync_dhcp_plugin_enabled_keadhcplink.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: 2025 Marcin Zieba <marcinpsk@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+"""Add Server.sync_dhcp_plugin_enabled toggle and the KeaDhcpLink mapping model.
+
+KeaDhcpLink maps a Kea ``(server, family, subnet-id)`` identity to the imported
+netbox_dhcp object via a GenericForeignKey, so there is no migration dependency on
+the optional netbox_dhcp plugin.
+"""
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("contenttypes", "0002_remove_content_type_name"),
+        ("netbox_kea", "0012_syncconfig_backfill_applied"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="server",
+            name="sync_dhcp_plugin_enabled",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.CreateModel(
+            name="KeaDhcpLink",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False)),
+                ("family", models.PositiveSmallIntegerField()),
+                ("kea_subnet_id", models.PositiveIntegerField(blank=True, null=True)),
+                ("object_id", models.PositiveBigIntegerField()),
+                ("created", models.DateTimeField(auto_now_add=True)),
+                ("last_synced", models.DateTimeField(auto_now=True)),
+                (
+                    "object_type",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, related_name="+", to="contenttypes.contenttype"
+                    ),
+                ),
+                (
+                    "server",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="dhcp_plugin_links",
+                        to="netbox_kea.server",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Kea DHCP-plugin link",
+                "constraints": [
+                    models.UniqueConstraint(fields=("object_type", "object_id"), name="keadhcplink_unique_sys4_object"),
+                    models.UniqueConstraint(
+                        condition=models.Q(("kea_subnet_id__isnull", False)),
+                        fields=("server", "family", "kea_subnet_id"),
+                        name="keadhcplink_unique_subnet_identity",
+                    ),
+                ],
+            },
+        ),
+    ]

--- a/netbox_kea/models.py
+++ b/netbox_kea/models.py
@@ -161,8 +161,10 @@ class Server(JobsMixin, NetBoxModel):
         default=False,
         help_text=(
             "When the NetBox DHCP plugin (netbox_dhcp) is installed, allow importing this "
-            "server's Kea data-tier config (subnets, shared networks, pools, reservations, "
-            "options) into the DHCP plugin's models. Has no effect if the plugin is absent."
+            "server's Kea data tier (subnets, pools, host reservations) into the DHCP plugin's "
+            "models. Note: Kea shared-networks are a different concept and are NOT imported as "
+            "DHCP-plugin Shared Networks (their member subnets are imported individually); DHCP "
+            "options are not imported. Has no effect if the plugin is absent."
         ),
     )
     persist_config = models.BooleanField(

--- a/netbox_kea/models.py
+++ b/netbox_kea/models.py
@@ -5,6 +5,7 @@ from typing import Literal
 
 import requests
 from django.conf import settings
+from django.contrib.contenttypes.fields import GenericForeignKey
 from django.core.exceptions import ValidationError
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
@@ -154,6 +155,15 @@ class Server(JobsMixin, NetBoxModel):
         verbose_name="Sync IP Ranges",
         default=True,
         help_text="Sync Kea pools as NetBox IP Ranges for this server.",
+    )
+    sync_dhcp_plugin_enabled = models.BooleanField(
+        verbose_name="Sync to DHCP plugin",
+        default=False,
+        help_text=(
+            "When the NetBox DHCP plugin (netbox_dhcp) is installed, allow importing this "
+            "server's Kea data-tier config (subnets, shared networks, pools, reservations, "
+            "options) into the DHCP plugin's models. Has no effect if the plugin is absent."
+        ),
     )
     persist_config = models.BooleanField(
         verbose_name="Persist configuration",
@@ -409,3 +419,58 @@ class SyncConfig(models.Model):
                     to_save.append(f)
             obj.save(update_fields=to_save)
         return obj
+
+
+class KeaDhcpLink(models.Model):
+    """Maps a Kea object identity to the netbox-plugin-dhcp (``netbox_dhcp``) record imported from it.
+
+    Kea's ``subnet-id`` is unique only per ``(server, protocol)`` — overlaps across
+    servers and between the v4/v6 daemons are normal — but ``netbox_dhcp``'s
+    ``Subnet.subnet_id`` is a single *global* unique namespace (and its auto-allocator
+    hands out a global ``max+1``).  Kea's id therefore cannot be stored there.  This
+    link holds the authoritative ``(server, family, kea_subnet_id)`` identity and points
+    — via a ``GenericForeignKey`` so there is no hard migration dependency on
+    ``netbox_dhcp`` being installed — at the imported DHCP-plugin object.  It is the
+    match key for idempotent re-import and the future home for accept/lock + drift state.
+    """
+
+    server = models.ForeignKey(
+        to="netbox_kea.Server",
+        on_delete=models.CASCADE,
+        related_name="dhcp_plugin_links",
+    )
+    family = models.PositiveSmallIntegerField(
+        help_text="IP family of the linked object (4 or 6).",
+    )
+    kea_subnet_id = models.PositiveIntegerField(
+        null=True,
+        blank=True,
+        help_text="Kea subnet-id for subnet links; null for objects without a Kea subnet-id.",
+    )
+    object_type = models.ForeignKey(
+        to="contenttypes.ContentType",
+        on_delete=models.CASCADE,
+        related_name="+",
+    )
+    object_id = models.PositiveBigIntegerField()
+    sys4_object = GenericForeignKey("object_type", "object_id")
+    created = models.DateTimeField(auto_now_add=True)
+    last_synced = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        app_label = "netbox_kea"
+        verbose_name = "Kea DHCP-plugin link"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["object_type", "object_id"],
+                name="keadhcplink_unique_sys4_object",
+            ),
+            models.UniqueConstraint(
+                fields=["server", "family", "kea_subnet_id"],
+                name="keadhcplink_unique_subnet_identity",
+                condition=models.Q(kea_subnet_id__isnull=False),
+            ),
+        ]
+
+    def __str__(self) -> str:
+        return f"{self.server} v{self.family} subnet-id={self.kea_subnet_id} → {self.object_type_id}:{self.object_id}"

--- a/netbox_kea/sync.py
+++ b/netbox_kea/sync.py
@@ -292,6 +292,16 @@ def _cleanup_stale_ips(
     else:
         stale_qs = stale_qs.exclude(address__contains=":")
 
+    # Never touch IPs the NetBox DHCP plugin references: deleting one would violate
+    # its PROTECT FKs and deprecating/blanking one would corrupt an authored
+    # reservation (its ipv4_address/ipv6_addresses FK is SET_NULL).
+    from .integrations import dhcp_plugin
+
+    if dhcp_plugin.is_available():
+        protected_ids = dhcp_plugin.sys4_referenced_ip_ids()
+        if protected_ids:
+            stale_qs = stale_qs.exclude(pk__in=protected_ids)
+
     count = stale_qs.count()
     if count == 0:
         return 0

--- a/netbox_kea/sync.py
+++ b/netbox_kea/sync.py
@@ -246,6 +246,7 @@ def _cleanup_stale_ips(
     *,
     mode: str = "remove",
     exclude_ips: frozenset[str] | None = None,
+    protected_ids: set[int] | None = None,
 ) -> int:
     """Remove or deprecate old Kea-synced IPs that have the same hostname but a different address.
 
@@ -267,6 +268,11 @@ def _cleanup_stale_ips(
                      status to ``deprecated``; ``"none"`` skips cleanup entirely.
         exclude_ips: Additional IP strings to exclude (e.g. all IPs in a multi-address
                      DHCPv6 reservation so sibling addresses are not cleaned up).
+        protected_ids: Pre-computed set of ``ipam.IPAddress`` PKs referenced by the
+                     NetBox DHCP plugin, to exclude from cleanup. Pass this once per
+                     sync run (see :func:`cleanup_stale_ips_batch`) to avoid the
+                     full-table scan :func:`dhcp_plugin.sys4_referenced_ip_ids`
+                     performs on every call. When ``None`` it is computed on demand.
 
     Returns the number of IPs cleaned up.
 
@@ -295,12 +301,12 @@ def _cleanup_stale_ips(
     # Never touch IPs the NetBox DHCP plugin references: deleting one would violate
     # its PROTECT FKs and deprecating/blanking one would corrupt an authored
     # reservation (its ipv4_address/ipv6_addresses FK is SET_NULL).
-    from .integrations import dhcp_plugin
+    if protected_ids is None:
+        from .integrations import dhcp_plugin
 
-    if dhcp_plugin.is_available():
-        protected_ids = dhcp_plugin.sys4_referenced_ip_ids()
-        if protected_ids:
-            stale_qs = stale_qs.exclude(pk__in=protected_ids)
+        protected_ids = dhcp_plugin.sys4_referenced_ip_ids() if dhcp_plugin.is_available() else set()
+    if protected_ids:
+        stale_qs = stale_qs.exclude(pk__in=protected_ids)
 
     count = stale_qs.count()
     if count == 0:
@@ -721,6 +727,12 @@ def cleanup_stale_ips_batch(synced_records: list[dict]) -> int:
             family = 6 if ":" in ip else 4
             hostname_ips.setdefault((hostname, family), set()).add(ip)
 
+    # Compute the DHCP-plugin protected-IP set once for the whole batch instead of
+    # rescanning the reservation tables inside every per-hostname cleanup call.
+    from .integrations import dhcp_plugin
+
+    protected_ids = dhcp_plugin.sys4_referenced_ip_ids() if dhcp_plugin.is_available() else set()
+
     total_cleaned = 0
     for (hostname, _family), all_ips in hostname_ips.items():
         primary_ip = next(iter(all_ips))
@@ -729,6 +741,7 @@ def cleanup_stale_ips_batch(synced_records: list[dict]) -> int:
             hostname,
             mode=mode,
             exclude_ips=frozenset(all_ips),
+            protected_ids=protected_ids,
         )
 
     return total_cleaned

--- a/netbox_kea/sync.py
+++ b/netbox_kea/sync.py
@@ -727,6 +727,11 @@ def cleanup_stale_ips_batch(synced_records: list[dict]) -> int:
             family = 6 if ":" in ip else 4
             hostname_ips.setdefault((hostname, family), set()).add(ip)
 
+    # No cleanup candidates → skip the protected-ID lookup entirely. Computing it
+    # here would trigger a full reservation-table scan for a no-op batch.
+    if not hostname_ips:
+        return 0
+
     # Compute the DHCP-plugin protected-IP set once for the whole batch instead of
     # rescanning the reservation tables inside every per-hostname cleanup call.
     from .integrations import dhcp_plugin

--- a/netbox_kea/templates/netbox_kea/server_dhcp_plugin.html
+++ b/netbox_kea/templates/netbox_kea/server_dhcp_plugin.html
@@ -1,0 +1,92 @@
+{# SPDX-FileCopyrightText: 2025 Marcin Zieba <marcinpsk@gmail.com> #}
+{# SPDX-License-Identifier: Apache-2.0 #}
+{% extends "generic/object.html" %}
+{% load helpers %}
+
+{% block content %}
+<div class="row">
+  <div class="col-md-12">
+
+    {% if not plugin_available %}
+      <div class="alert alert-warning" role="alert">
+        <i class="mdi mdi-alert-outline" aria-hidden="true"></i>
+        The NetBox DHCP plugin (<code>netbox_dhcp</code>) is not installed. This tab has no effect.
+      </div>
+    {% else %}
+
+      <div class="card mb-3">
+        <h5 class="card-header">Sync to DHCP plugin</h5>
+        <div class="card-body">
+          <p class="small text-muted mb-2">
+            Import this server's live Kea data-tier configuration (subnets, pools, reservations)
+            into the NetBox DHCP plugin. Reads Kea read-only; idempotent. Shared-network grouping
+            and DHCP options are not imported yet.
+          </p>
+          {% if can_sync %}
+            <form method="post" action="{% url 'plugins:netbox_kea:server_dhcp_plugin_sync' object.pk %}">
+              {% csrf_token %}
+              <button type="submit" class="btn btn-sm btn-primary">
+                <i class="mdi mdi-database-import-outline" aria-hidden="true"></i> Sync to DHCP plugin now
+              </button>
+            </form>
+          {% else %}
+            <span class="text-muted small">You need server change + IPAM add/change permissions to run this.</span>
+          {% endif %}
+        </div>
+      </div>
+
+      <div class="card">
+        <h5 class="card-header">Drift &mdash; live Kea vs. imported records</h5>
+        <div class="card-body p-0">
+          {% if drift.kea_unreachable %}
+            <div class="alert alert-warning m-3" role="alert">
+              <i class="mdi mdi-alert-outline" aria-hidden="true"></i>
+              Could not read live configuration from Kea for one or more versions; showing last-imported records where available.
+            </div>
+          {% endif %}
+          {% for v in drift.versions %}
+            <h6 class="px-3 pt-3">DHCPv{{ v.version }}</h6>
+            <table class="table table-hover">
+              <thead>
+                <tr>
+                  <th>Kea subnet-id</th>
+                  <th>Prefix</th>
+                  <th>Status</th>
+                  <th>Pools</th>
+                  <th>Reservations</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for row in v.rows %}
+                  <tr>
+                    <td>{{ row.kea_subnet_id|placeholder }}</td>
+                    <td>{{ row.cidr|placeholder }}</td>
+                    <td>
+                      {% if row.status == "imported" %}
+                        <span class="badge text-bg-success">Imported</span>
+                      {% elif row.status == "new" %}
+                        <span class="badge text-bg-info">New in Kea</span>
+                      {% elif row.status == "orphaned" %}
+                        <span class="badge text-bg-warning">Orphaned (gone from Kea)</span>
+                      {% else %}
+                        <span class="badge text-bg-secondary">Unknown</span>
+                      {% endif %}
+                    </td>
+                    <td>{{ row.pools }}</td>
+                    <td>{{ row.reservations }}</td>
+                  </tr>
+                {% empty %}
+                  <tr><td colspan="5" class="text-muted">No subnets.</td></tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          {% empty %}
+            <p class="text-muted p-3 mb-0">No DHCP versions enabled on this server.</p>
+          {% endfor %}
+        </div>
+      </div>
+
+    {% endif %}
+  </div>
+</div>
+{% endblock %}

--- a/netbox_kea/templates/netbox_kea/server_dhcp_plugin.html
+++ b/netbox_kea/templates/netbox_kea/server_dhcp_plugin.html
@@ -19,9 +19,14 @@
         <div class="card-body">
           <p class="small text-muted mb-2">
             Import this server's live Kea data-tier configuration (subnets, pools, reservations)
-            into the NetBox DHCP plugin. Reads Kea read-only; idempotent. Shared-network grouping
-            and DHCP options are not imported yet.
+            into the NetBox DHCP plugin. Reads Kea read-only; idempotent.
           </p>
+          <div class="alert alert-warning py-2 px-3 small mb-2" role="alert">
+            <i class="mdi mdi-alert-outline" aria-hidden="true"></i>
+            Kea <strong>shared-networks</strong> are a different concept from the DHCP plugin's
+            <em>Shared Networks</em> and are <strong>not</strong> imported as such — a shared-network's
+            member subnets are imported individually. DHCP <strong>options</strong> are not imported.
+          </div>
           {% if can_sync %}
             <form method="post" action="{% url 'plugins:netbox_kea:server_dhcp_plugin_sync' object.pk %}">
               {% csrf_token %}

--- a/netbox_kea/tests/test_integration_dhcp_plugin.py
+++ b/netbox_kea/tests/test_integration_dhcp_plugin.py
@@ -403,6 +403,88 @@ class DhcpPluginTuningImportTest(TestCase):
 
 @tag("dhcp_plugin")
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
+class DhcpPluginClientClassImportTest(TestCase):
+    """Importing Kea ``client-classes`` into netbox_dhcp ``ClientClass`` rows."""
+
+    @classmethod
+    def setUpClass(cls):
+        if not apps.is_installed(DHCP_PLUGIN):
+            raise cls.skipException(f"{DHCP_PLUGIN} not installed")
+        super().setUpClass()
+
+    def setUp(self):
+        self.server = _make_db_server(name=f"kea-cc-{timezone.now().timestamp()}")
+        from netbox_kea.integrations import dhcp_plugin
+
+        self.adapter = dhcp_plugin
+
+    def _conf(self):
+        return {
+            "next-server": "0.0.0.0",
+            "client-classes": [
+                {
+                    "name": "voip",
+                    "test": "substring(option[60].hex,0,6) == 'Aastra'",
+                    "next-server": "192.0.2.254",
+                    "boot-file-name": "/dev/null",
+                    "server-hostname": "hal9000",
+                    "option-data": [{"code": 3, "name": "routers", "data": "10.0.0.1", "space": "dhcp4"}],
+                }
+            ],
+            "subnet4": [],
+        }
+
+    def test_client_class_created_with_settings_and_options(self):
+        from django.contrib.contenttypes.models import ContentType
+
+        ClientClass = apps.get_model(DHCP_PLUGIN, "ClientClass")
+        Option = apps.get_model(DHCP_PLUGIN, "Option")
+        DHCPServer = apps.get_model(DHCP_PLUGIN, "DHCPServer")
+
+        summary = self.adapter.import_server_config(self.server, parse_dhcp_config(self._conf(), 4))
+        self.assertEqual(summary.errors, 0, summary.warnings)
+        self.assertEqual(summary.client_classes_created, 1)
+        self.assertEqual(summary.options_created, 1)  # the class's routers option
+
+        cc = ClientClass.objects.get(name=f"{self.server.name}: voip")
+        self.assertEqual(cc.dhcp_server, DHCPServer.objects.get(name=self.server.name))
+        self.assertEqual(cc.test, "substring(option[60].hex,0,6) == 'Aastra'")
+        # BOOTP settings differ from the server baseline → stored on the class.
+        self.assertEqual(cc.next_server, "192.0.2.254")
+        self.assertEqual(cc.boot_file_name, "/dev/null")
+        self.assertEqual(cc.server_hostname, "hal9000")
+        # The class's option was imported and assigned to the ClientClass.
+        ct = ContentType.objects.get_for_model(ClientClass)
+        self.assertTrue(Option.objects.filter(assigned_object_type=ct, assigned_object_id=cc.pk).exists())
+
+    def test_client_class_name_is_namespaced_to_server(self):
+        ClientClass = apps.get_model(DHCP_PLUGIN, "ClientClass")
+        self.adapter.import_server_config(self.server, parse_dhcp_config(self._conf(), 4))
+        # Namespaced so two servers' identically-named Kea classes don't collide.
+        self.assertTrue(ClientClass.objects.filter(name=f"{self.server.name}: voip").exists())
+        self.assertFalse(ClientClass.objects.filter(name="voip").exists())
+
+    def test_reimport_is_idempotent(self):
+        ClientClass = apps.get_model(DHCP_PLUGIN, "ClientClass")
+        self.adapter.import_server_config(self.server, parse_dhcp_config(self._conf(), 4))
+        second = self.adapter.import_server_config(self.server, parse_dhcp_config(self._conf(), 4))
+        self.assertEqual(second.client_classes_created, 0)
+        self.assertEqual(second.client_classes_updated, 0)
+        self.assertEqual(ClientClass.objects.filter(name=f"{self.server.name}: voip").count(), 1)
+
+    def test_changed_test_expression_reported_as_updated(self):
+        ClientClass = apps.get_model(DHCP_PLUGIN, "ClientClass")
+        conf = self._conf()
+        self.adapter.import_server_config(self.server, parse_dhcp_config(conf, 4))
+        conf["client-classes"][0]["test"] = "substring(option[60].hex,0,4) == 'Cisco'"
+        second = self.adapter.import_server_config(self.server, parse_dhcp_config(conf, 4))
+        self.assertEqual(second.client_classes_updated, 1)
+        cc = ClientClass.objects.get(name=f"{self.server.name}: voip")
+        self.assertEqual(cc.test, "substring(option[60].hex,0,4) == 'Cisco'")
+
+
+@tag("dhcp_plugin")
+@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class DhcpPluginStaleCleanupGuardTest(TestCase):
     """Stale-IP cleanup must never remove an IP a netbox_dhcp reservation references."""
 

--- a/netbox_kea/tests/test_integration_dhcp_plugin.py
+++ b/netbox_kea/tests/test_integration_dhcp_plugin.py
@@ -294,6 +294,115 @@ class DhcpPluginOptionImportTest(TestCase):
 
 @tag("dhcp_plugin")
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
+class DhcpPluginTuningImportTest(TestCase):
+    """Tuning fields land on DHCPServer/Subnet with parent-diff suppression (real ORM)."""
+
+    @classmethod
+    def setUpClass(cls):
+        if not apps.is_installed(DHCP_PLUGIN):
+            raise cls.skipException(f"{DHCP_PLUGIN} not installed")
+        super().setUpClass()
+
+    def setUp(self):
+        self.server = _make_db_server(name=f"kea-tune-{timezone.now().timestamp()}")
+        from netbox_kea.integrations import dhcp_plugin
+
+        self.adapter = dhcp_plugin
+
+    def test_global_settings_applied_to_dhcp_server(self):
+        from decimal import Decimal
+
+        DHCPServer = apps.get_model(DHCP_PLUGIN, "DHCPServer")
+        conf = {
+            "valid-lifetime": 3600,
+            "renew-timer": 900,
+            "allocator": "iterative",
+            "t1-percent": 0.5,
+            "decline-probation-period": 86400,
+            "ddns-replace-client-name": "when-not-present",
+            "server-id": {"type": "LLT", "enterprise-id": 0},
+            "host-reservation-identifiers": ["hw-address", "duid", "circuit-id", "client-id"],
+            "subnet4": [],
+        }
+        self.adapter.import_server_config(self.server, parse_dhcp_config(conf, 4))
+
+        srv = DHCPServer.objects.get(name=self.server.name)
+        self.assertEqual(srv.valid_lifetime, 3600)
+        self.assertEqual(srv.renew_timer, 900)
+        self.assertEqual(srv.allocator, "iterative")
+        self.assertEqual(srv.t1_percent, Decimal("0.5"))
+        self.assertEqual(srv.decline_probation_period, 86400)
+        # hyphenated Kea value normalized to the plugin's underscored choice
+        self.assertEqual(srv.ddns_replace_client_name, "when_not_present")
+        # server-id dict reduced to its type
+        self.assertEqual(srv.server_id, "LLT")
+        self.assertEqual(srv.host_reservation_identifiers, ["hw-address", "duid", "circuit-id", "client-id"])
+
+    def test_subnet_value_equal_to_global_is_suppressed(self):
+        Subnet = apps.get_model(DHCP_PLUGIN, "Subnet")
+        conf = {
+            "valid-lifetime": 3600,
+            "subnet4": [
+                # subnet repeats the (inherited) global value — must NOT be stored on the subnet
+                {"id": 1, "subnet": "10.30.0.0/24", "valid-lifetime": 3600},
+            ],
+        }
+        self.adapter.import_server_config(self.server, parse_dhcp_config(conf, 4))
+        subnet = Subnet.objects.get(prefix__prefix="10.30.0.0/24")
+        self.assertIsNone(subnet.valid_lifetime)  # inherits from the DHCPServer parent
+
+    def test_subnet_value_differing_from_global_is_stored(self):
+        Subnet = apps.get_model(DHCP_PLUGIN, "Subnet")
+        conf = {
+            "valid-lifetime": 3600,
+            "subnet4": [
+                {"id": 1, "subnet": "10.31.0.0/24", "valid-lifetime": 7200, "relay": {"ip-addresses": ["10.31.0.3"]}},
+            ],
+        }
+        self.adapter.import_server_config(self.server, parse_dhcp_config(conf, 4))
+        subnet = Subnet.objects.get(prefix__prefix="10.31.0.0/24")
+        self.assertEqual(subnet.valid_lifetime, 7200)  # genuine per-subnet override stored
+        self.assertEqual(subnet.relay, "10.31.0.3")  # relay dict flattened to CSV
+
+    def test_v6_style_decimal_does_not_raise(self):
+        # 0.8 has no exact float repr; the str-based Decimal coercion must keep it clean.
+        from decimal import Decimal
+
+        Subnet = apps.get_model(DHCP_PLUGIN, "Subnet")
+        conf = {
+            "t2-percent": 0.5,
+            "subnet6": [{"id": 1, "subnet": "2001:db8:30::/64", "t2-percent": 0.8}],
+        }
+        summary = self.adapter.import_server_config(self.server, parse_dhcp_config(conf, 6))
+        self.assertEqual(summary.errors, 0, summary.warnings)
+        subnet = Subnet.objects.get(prefix__prefix="2001:db8:30::/64")
+        self.assertEqual(subnet.t2_percent, Decimal("0.8"))
+
+    def test_dualstack_global_first_family_wins_shared_fields(self):
+        DHCPServer = apps.get_model(DHCP_PLUGIN, "DHCPServer")
+        # v4 sets shared valid-lifetime; v6 supplies preferred-lifetime and a *different*
+        # valid-lifetime that must NOT clobber v4's (single DHCPServer spans both).
+        self.adapter.import_server_config(self.server, parse_dhcp_config({"valid-lifetime": 3600, "subnet4": []}, 4))
+        self.adapter.import_server_config(
+            self.server, parse_dhcp_config({"valid-lifetime": 4000, "preferred-lifetime": 3000, "subnet6": []}, 6)
+        )
+        srv = DHCPServer.objects.get(name=self.server.name)
+        self.assertEqual(srv.valid_lifetime, 3600)  # v4 (first) wins the shared field
+        self.assertEqual(srv.preferred_lifetime, 3000)  # v6 fills the gap
+
+    def test_tuning_reimport_is_idempotent(self):
+        conf = {
+            "valid-lifetime": 3600,
+            "subnet4": [{"id": 1, "subnet": "10.32.0.0/24", "valid-lifetime": 7200}],
+        }
+        self.adapter.import_server_config(self.server, parse_dhcp_config(conf, 4))
+        second = self.adapter.import_server_config(self.server, parse_dhcp_config(conf, 4))
+        self.assertEqual(second.subnets_created, 0)
+        self.assertEqual(second.subnets_updated, 0)  # nothing changed → not reported as updated
+
+
+@tag("dhcp_plugin")
+@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class DhcpPluginStaleCleanupGuardTest(TestCase):
     """Stale-IP cleanup must never remove an IP a netbox_dhcp reservation references."""
 

--- a/netbox_kea/tests/test_integration_dhcp_plugin.py
+++ b/netbox_kea/tests/test_integration_dhcp_plugin.py
@@ -11,6 +11,7 @@ directly; the ORM, IPAM/DCIM models, and the ``netbox_dhcp`` models are all real
 from __future__ import annotations
 
 import unittest
+from unittest.mock import patch
 
 from django.apps import apps
 from django.test import TestCase, override_settings, tag
@@ -172,6 +173,117 @@ class DhcpPluginAdapterTest(TestCase):
         # Flattened onto the DHCPServer, not a (prefix-requiring) SharedNetwork.
         self.assertIsNotNone(subnet.dhcp_server)
         self.assertIsNone(subnet.shared_network)
+
+    # ── per-object error isolation ───────────────────────────────────────────
+
+    def test_bad_cidr_is_per_subnet_error_not_fatal(self):
+        """One unparseable subnet CIDR is counted as an error; other subnets still import."""
+        Subnet = apps.get_model(DHCP_PLUGIN, "Subnet")
+        conf = {
+            "subnet4": [
+                {"id": 1, "subnet": "not-a-cidr"},  # _ensure_prefix raises → caught per-subnet
+                {"id": 2, "subnet": "10.51.0.0/24"},
+            ]
+        }
+        summary = self.adapter.import_server_config(self.server, parse_dhcp_config(conf, 4))
+        self.assertGreaterEqual(summary.errors, 1)
+        # The bad subnet did not abort the import: the good one is present.
+        self.assertTrue(Subnet.objects.filter(prefix__prefix="10.51.0.0/24").exists())
+        self.assertEqual(summary.subnets_created, 1)
+
+    def test_reservation_resolver_failure_is_per_reservation(self):
+        """A resolver error on one reservation does not stop the others in the subnet."""
+        HostReservation = apps.get_model(DHCP_PLUGIN, "HostReservation")
+        conf = {
+            "subnet4": [
+                {
+                    "id": 3,
+                    "subnet": "10.53.0.0/24",
+                    "reservations": [
+                        {"hw-address": "aa:bb:cc:dd:ee:a1", "ip-address": "10.53.0.10", "hostname": "r1"},
+                        {"hw-address": "aa:bb:cc:dd:ee:a2", "ip-address": "10.53.0.11", "hostname": "r2"},
+                    ],
+                }
+            ]
+        }
+        real = self.adapter._ensure_reservation_addresses
+        calls = {"n": 0}
+
+        def flaky(res, *args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("resolver boom")
+            return real(res, *args, **kwargs)
+
+        with patch.object(self.adapter, "_ensure_reservation_addresses", side_effect=flaky):
+            summary = self.adapter.import_server_config(self.server, parse_dhcp_config(conf, 4))
+
+        self.assertGreaterEqual(summary.errors, 1)
+        self.assertEqual(summary.reservations_created, 1)
+        self.assertTrue(HostReservation.objects.filter(hostname="r2").exists())
+
+    # ── idempotency edge cases ────────────────────────────────────────────────
+
+    def test_stale_link_is_relinked_not_collided(self):
+        """A dangling KeaDhcpLink (its subnet deleted) is relinked on re-import."""
+        from netbox_kea.models import KeaDhcpLink
+
+        Subnet = apps.get_model(DHCP_PLUGIN, "Subnet")
+        conf = {"subnet4": [{"id": 1, "subnet": "10.52.0.0/24"}]}  # bare: deletable without children
+
+        self.adapter.import_server_config(self.server, parse_dhcp_config(conf, 4))
+        link = KeaDhcpLink.objects.get(server=self.server, family=4, kea_subnet_id=1)
+        old_pk = link.sys4_object.pk
+
+        # Subnet deleted out from under the link; the link row survives, dangling.
+        Subnet.objects.filter(pk=old_pk).delete()
+        link.refresh_from_db()
+        self.assertIsNone(link.sys4_object)
+
+        # Re-import must relink the stale identity row, not violate the
+        # keadhcplink_unique_subnet_identity constraint by creating a duplicate.
+        summary = self.adapter.import_server_config(self.server, parse_dhcp_config(conf, 4))
+        self.assertEqual(summary.errors, 0, summary.warnings)
+        links = KeaDhcpLink.objects.filter(server=self.server, family=4, kea_subnet_id=1)
+        self.assertEqual(links.count(), 1)
+        new_subnet = links.first().sys4_object
+        self.assertIsNotNone(new_subnet)
+        self.assertNotEqual(new_subnet.pk, old_pk)
+
+    def test_reimport_clears_dropped_ipv6_addresses(self):
+        """Re-importing a v6 reservation that lost its addresses clears the stale M2M relations."""
+        HostReservation = apps.get_model(DHCP_PLUGIN, "HostReservation")
+        with_addrs = {
+            "subnet6": [
+                {
+                    "id": 4,
+                    "subnet": "2001:db8:53::/64",
+                    "reservations": [
+                        {
+                            "duid": "0a:0b:0c",
+                            "ip-addresses": ["2001:db8:53::10", "2001:db8:53::11"],
+                            "hostname": "v6r",
+                        }
+                    ],
+                }
+            ]
+        }
+        self.adapter.import_server_config(self.server, parse_dhcp_config(with_addrs, 6))
+        res = HostReservation.objects.get(hostname="v6r")
+        self.assertEqual(res.ipv6_addresses.count(), 2)
+
+        without_addrs = {
+            "subnet6": [
+                {
+                    "id": 4,
+                    "subnet": "2001:db8:53::/64",
+                    "reservations": [{"duid": "0a:0b:0c", "ip-addresses": [], "hostname": "v6r"}],
+                }
+            ]
+        }
+        self.adapter.import_server_config(self.server, parse_dhcp_config(without_addrs, 6))
+        res.refresh_from_db()
+        self.assertEqual(res.ipv6_addresses.count(), 0)
 
 
 @tag("dhcp_plugin")

--- a/netbox_kea/tests/test_integration_dhcp_plugin.py
+++ b/netbox_kea/tests/test_integration_dhcp_plugin.py
@@ -174,6 +174,126 @@ class DhcpPluginAdapterTest(TestCase):
 
 @tag("dhcp_plugin")
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
+class DhcpPluginOptionImportTest(TestCase):
+    """Importing Kea ``option-data`` into netbox_dhcp ``Option`` rows (real ORM + defs)."""
+
+    @classmethod
+    def setUpClass(cls):
+        if not apps.is_installed(DHCP_PLUGIN):
+            raise cls.skipException(f"{DHCP_PLUGIN} not installed")
+        super().setUpClass()
+
+    def setUp(self):
+        self.server = _make_db_server(name=f"kea-opt-{timezone.now().timestamp()}")
+        from netbox_kea.integrations import dhcp_plugin
+
+        self.adapter = dhcp_plugin
+
+    def _ct(self, model):
+        from django.contrib.contenttypes.models import ContentType
+
+        return ContentType.objects.get_for_model(model)
+
+    def test_standard_subnet_option_binds_to_shipped_definition(self):
+        Subnet = apps.get_model(DHCP_PLUGIN, "Subnet")
+        Option = apps.get_model(DHCP_PLUGIN, "Option")
+        conf = {
+            "subnet4": [
+                {
+                    "id": 1,
+                    "subnet": "10.21.0.0/24",
+                    "option-data": [
+                        {"code": 3, "name": "routers", "data": "10.21.0.1", "space": "dhcp4", "always-send": True}
+                    ],
+                }
+            ]
+        }
+        summary = self.adapter.import_server_config(self.server, parse_dhcp_config(conf, 4))
+        self.assertEqual(summary.errors, 0, summary.warnings)
+        self.assertEqual(summary.options_created, 1, summary.warnings)
+        self.assertEqual(summary.options_skipped, 0, summary.warnings)
+
+        subnet = Subnet.objects.get(prefix__prefix="10.21.0.0/24")
+        opt = Option.objects.get(assigned_object_type=self._ct(Subnet), assigned_object_id=subnet.pk)
+        self.assertEqual(opt.definition.code, 3)
+        self.assertTrue(opt.definition.standard)  # bound to the sys4-shipped standard def
+        self.assertEqual(opt.data, "10.21.0.1")
+        self.assertEqual(opt.send_option, "always-send")
+
+    def test_global_option_assigned_to_dhcp_server(self):
+        DHCPServer = apps.get_model(DHCP_PLUGIN, "DHCPServer")
+        Option = apps.get_model(DHCP_PLUGIN, "Option")
+        conf = {
+            "option-data": [{"code": 6, "name": "domain-name-servers", "data": "1.1.1.1", "space": "dhcp4"}],
+            "subnet4": [],
+        }
+        summary = self.adapter.import_server_config(self.server, parse_dhcp_config(conf, 4))
+        self.assertEqual(summary.options_created, 1, summary.warnings)
+        srv = DHCPServer.objects.get(name=self.server.name)
+        opt = Option.objects.get(assigned_object_type=self._ct(DHCPServer), assigned_object_id=srv.pk)
+        self.assertEqual(opt.definition.code, 6)
+
+    def test_custom_option_def_is_created_and_bound(self):
+        OptionDefinition = apps.get_model(DHCP_PLUGIN, "OptionDefinition")
+        Option = apps.get_model(DHCP_PLUGIN, "Option")
+        conf = {
+            "option-def": [{"code": 224, "name": "my-custom", "space": "dhcp4", "type": "string"}],
+            "subnet4": [
+                {
+                    "id": 1,
+                    "subnet": "10.22.0.0/24",
+                    "option-data": [{"code": 224, "name": "my-custom", "data": "hello", "space": "dhcp4"}],
+                }
+            ],
+        }
+        summary = self.adapter.import_server_config(self.server, parse_dhcp_config(conf, 4))
+        self.assertEqual(summary.errors, 0, summary.warnings)
+        self.assertEqual(summary.option_defs_created, 1, summary.warnings)
+        self.assertEqual(summary.options_created, 1, summary.warnings)
+
+        definition = OptionDefinition.objects.get(code=224, standard=False)
+        self.assertEqual(definition.name, "my-custom")
+        self.assertEqual(definition.dhcp_server.name, self.server.name)
+        self.assertTrue(Option.objects.filter(definition=definition).exists())
+
+    def test_unresolvable_option_is_skipped_not_fatal(self):
+        # Custom code with no option-def → no definition to bind → skipped, import still ok.
+        conf = {
+            "subnet4": [
+                {
+                    "id": 1,
+                    "subnet": "10.23.0.0/24",
+                    "option-data": [{"code": 231, "data": "x", "space": "dhcp4"}],
+                }
+            ]
+        }
+        summary = self.adapter.import_server_config(self.server, parse_dhcp_config(conf, 4))
+        self.assertEqual(summary.errors, 0)
+        self.assertEqual(summary.options_created, 0)
+        self.assertEqual(summary.options_skipped, 1, summary.warnings)
+        self.assertEqual(summary.subnets_created, 1)  # subnet still imported
+
+    def test_reimport_updates_option_not_duplicated(self):
+        Subnet = apps.get_model(DHCP_PLUGIN, "Subnet")
+        Option = apps.get_model(DHCP_PLUGIN, "Option")
+        conf = {
+            "subnet4": [
+                {"id": 1, "subnet": "10.24.0.0/24", "option-data": [{"code": 3, "data": "10.24.0.1", "space": "dhcp4"}]}
+            ]
+        }
+        self.adapter.import_server_config(self.server, parse_dhcp_config(conf, 4))
+        conf["subnet4"][0]["option-data"][0]["data"] = "10.24.0.254"
+        second = self.adapter.import_server_config(self.server, parse_dhcp_config(conf, 4))
+
+        self.assertEqual(second.options_created, 0)
+        self.assertEqual(second.options_updated, 1)
+        subnet = Subnet.objects.get(prefix__prefix="10.24.0.0/24")
+        opt = Option.objects.get(assigned_object_type=self._ct(Subnet), assigned_object_id=subnet.pk)
+        self.assertEqual(opt.data, "10.24.0.254")
+
+
+@tag("dhcp_plugin")
+@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class DhcpPluginStaleCleanupGuardTest(TestCase):
     """Stale-IP cleanup must never remove an IP a netbox_dhcp reservation references."""
 

--- a/netbox_kea/tests/test_integration_dhcp_plugin.py
+++ b/netbox_kea/tests/test_integration_dhcp_plugin.py
@@ -400,6 +400,29 @@ class DhcpPluginTuningImportTest(TestCase):
         self.assertEqual(second.subnets_created, 0)
         self.assertEqual(second.subnets_updated, 0)  # nothing changed → not reported as updated
 
+    def test_subnet_override_cleared_when_value_returns_to_inherited(self):
+        # Finding 1: a removed Kea override must not linger as stale data on re-import.
+        Subnet = apps.get_model(DHCP_PLUGIN, "Subnet")
+        conf1 = {"valid-lifetime": 3600, "subnet4": [{"id": 7, "subnet": "10.42.0.0/24", "valid-lifetime": 7200}]}
+        self.adapter.import_server_config(self.server, parse_dhcp_config(conf1, 4))
+        subnet = Subnet.objects.get(prefix__prefix="10.42.0.0/24")
+        self.assertEqual(subnet.valid_lifetime, 7200)
+
+        # Override removed in Kea (subnet value now equals the global) → must be cleared.
+        conf2 = {"valid-lifetime": 3600, "subnet4": [{"id": 7, "subnet": "10.42.0.0/24", "valid-lifetime": 3600}]}
+        second = self.adapter.import_server_config(self.server, parse_dhcp_config(conf2, 4))
+        subnet.refresh_from_db()
+        self.assertIsNone(subnet.valid_lifetime)  # inherits again, not stale 7200
+        self.assertEqual(second.subnets_updated, 1)
+
+    def test_global_setting_change_resyncs_on_reimport(self):
+        # Finding 2: a changed global value must re-sync (was write-once before).
+        DHCPServer = apps.get_model(DHCP_PLUGIN, "DHCPServer")
+        self.adapter.import_server_config(self.server, parse_dhcp_config({"valid-lifetime": 3600, "subnet4": []}, 4))
+        self.adapter.import_server_config(self.server, parse_dhcp_config({"valid-lifetime": 7200, "subnet4": []}, 4))
+        srv = DHCPServer.objects.get(name=self.server.name)
+        self.assertEqual(srv.valid_lifetime, 7200)
+
 
 @tag("dhcp_plugin")
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
@@ -560,6 +583,18 @@ class DhcpPluginPageReservationImportTest(TestCase):
         second = self.adapter.import_server_config(self.server, self._intent(conf, hosts))
         self.assertEqual(second.reservations_created, 0)
         self.assertEqual(HostReservation.objects.count(), 1)
+
+    def test_global_v6_reservation_gets_host_mask(self):
+        # Finding 3: a global (subnet-less) IPv6 reservation must get a /128, not /32.
+        from ipam.models import IPAddress
+
+        intent = parse_dhcp_config({"subnet6": []}, 6)
+        hosts = [{"subnet-id": 0, "duid": "01:02:03:0a", "ip-addresses": ["2001:db8:aa::5"], "hostname": "g6"}]
+        intent.page_reservations = self._parse_page(hosts, 6)
+        summary = self.adapter.import_server_config(self.server, intent)
+
+        self.assertEqual(summary.errors, 0, summary.warnings)
+        self.assertTrue(IPAddress.objects.filter(address="2001:db8:aa::5/128").exists())
 
 
 @tag("dhcp_plugin")

--- a/netbox_kea/tests/test_integration_dhcp_plugin.py
+++ b/netbox_kea/tests/test_integration_dhcp_plugin.py
@@ -10,6 +10,8 @@ directly; the ORM, IPAM/DCIM models, and the ``netbox_dhcp`` models are all real
 
 from __future__ import annotations
 
+import unittest
+
 from django.apps import apps
 from django.test import TestCase, override_settings, tag
 from django.utils import timezone
@@ -58,7 +60,7 @@ class DhcpPluginAdapterTest(TestCase):
     @classmethod
     def setUpClass(cls):
         if not apps.is_installed(DHCP_PLUGIN):
-            raise cls.skipException(f"{DHCP_PLUGIN} not installed")
+            raise unittest.SkipTest(f"{DHCP_PLUGIN} not installed")
         super().setUpClass()
 
     def setUp(self):
@@ -180,7 +182,7 @@ class DhcpPluginOptionImportTest(TestCase):
     @classmethod
     def setUpClass(cls):
         if not apps.is_installed(DHCP_PLUGIN):
-            raise cls.skipException(f"{DHCP_PLUGIN} not installed")
+            raise unittest.SkipTest(f"{DHCP_PLUGIN} not installed")
         super().setUpClass()
 
     def setUp(self):
@@ -300,7 +302,7 @@ class DhcpPluginTuningImportTest(TestCase):
     @classmethod
     def setUpClass(cls):
         if not apps.is_installed(DHCP_PLUGIN):
-            raise cls.skipException(f"{DHCP_PLUGIN} not installed")
+            raise unittest.SkipTest(f"{DHCP_PLUGIN} not installed")
         super().setUpClass()
 
     def setUp(self):
@@ -432,7 +434,7 @@ class DhcpPluginClientClassImportTest(TestCase):
     @classmethod
     def setUpClass(cls):
         if not apps.is_installed(DHCP_PLUGIN):
-            raise cls.skipException(f"{DHCP_PLUGIN} not installed")
+            raise unittest.SkipTest(f"{DHCP_PLUGIN} not installed")
         super().setUpClass()
 
     def setUp(self):
@@ -514,7 +516,7 @@ class DhcpPluginPageReservationImportTest(TestCase):
     @classmethod
     def setUpClass(cls):
         if not apps.is_installed(DHCP_PLUGIN):
-            raise cls.skipException(f"{DHCP_PLUGIN} not installed")
+            raise unittest.SkipTest(f"{DHCP_PLUGIN} not installed")
         super().setUpClass()
 
     def setUp(self):
@@ -605,7 +607,7 @@ class DhcpPluginStaleCleanupGuardTest(TestCase):
     @classmethod
     def setUpClass(cls):
         if not apps.is_installed(DHCP_PLUGIN):
-            raise cls.skipException(f"{DHCP_PLUGIN} not installed")
+            raise unittest.SkipTest(f"{DHCP_PLUGIN} not installed")
         super().setUpClass()
 
     def setUp(self):

--- a/netbox_kea/tests/test_integration_dhcp_plugin.py
+++ b/netbox_kea/tests/test_integration_dhcp_plugin.py
@@ -485,6 +485,85 @@ class DhcpPluginClientClassImportTest(TestCase):
 
 @tag("dhcp_plugin")
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
+class DhcpPluginPageReservationImportTest(TestCase):
+    """DB-backed reservations (reservation-get-page) import into the right subnet/server."""
+
+    @classmethod
+    def setUpClass(cls):
+        if not apps.is_installed(DHCP_PLUGIN):
+            raise cls.skipException(f"{DHCP_PLUGIN} not installed")
+        super().setUpClass()
+
+    def setUp(self):
+        self.server = _make_db_server(name=f"kea-pageres-{timezone.now().timestamp()}")
+        from netbox_kea.integrations import dhcp_plugin
+        from netbox_kea.mappers.kea_to_dhcp import parse_reservations_page
+
+        self.adapter = dhcp_plugin
+        self._parse_page = parse_reservations_page
+
+    def _intent(self, conf, hosts):
+        intent = parse_dhcp_config(conf, 4)
+        intent.page_reservations = self._parse_page(hosts, 4)
+        return intent
+
+    def test_db_reservation_imported_into_linked_subnet(self):
+        from ipam.models import IPAddress
+
+        Subnet = apps.get_model(DHCP_PLUGIN, "Subnet")
+        HostReservation = apps.get_model(DHCP_PLUGIN, "HostReservation")
+
+        # Subnet is in config-get; the reservation is ONLY in the hosts DB (subnet-id 7).
+        conf = {"subnet4": [{"id": 7, "subnet": "10.40.0.0/24"}]}
+        hosts = [{"subnet-id": 7, "hw-address": "aa:bb:cc:dd:ee:40", "ip-address": "10.40.0.50", "hostname": "db-host"}]
+        summary = self.adapter.import_server_config(self.server, self._intent(conf, hosts))
+
+        self.assertEqual(summary.errors, 0, summary.warnings)
+        self.assertEqual(summary.reservations_created, 1, summary.warnings)
+        subnet = Subnet.objects.get(prefix__prefix="10.40.0.0/24")
+        res = HostReservation.objects.get(subnet=subnet)
+        self.assertEqual(res.hostname, "db-host")
+        # Shares the same IPAM IPAddress the reservation sync maintains.
+        self.assertEqual(res.ipv4_address, IPAddress.objects.get(address="10.40.0.50/24"))
+
+    def test_global_reservation_attached_to_dhcp_server(self):
+        HostReservation = apps.get_model(DHCP_PLUGIN, "HostReservation")
+        DHCPServer = apps.get_model(DHCP_PLUGIN, "DHCPServer")
+
+        conf = {"subnet4": []}
+        hosts = [
+            {"subnet-id": 0, "hw-address": "aa:bb:cc:dd:ee:00", "ip-address": "10.0.0.9", "hostname": "global-host"}
+        ]
+        summary = self.adapter.import_server_config(self.server, self._intent(conf, hosts))
+
+        self.assertEqual(summary.errors, 0, summary.warnings)
+        res = HostReservation.objects.get(hostname="global-host")
+        self.assertIsNone(res.subnet)  # global → attached to the DHCPServer, not a subnet
+        self.assertEqual(res.dhcp_server, DHCPServer.objects.get(name=self.server.name))
+
+    def test_unknown_subnet_id_skipped_with_warning(self):
+        HostReservation = apps.get_model(DHCP_PLUGIN, "HostReservation")
+        conf = {"subnet4": []}  # subnet-id 99 was never imported
+        hosts = [{"subnet-id": 99, "hw-address": "aa:bb:cc:dd:ee:99", "ip-address": "10.99.0.5"}]
+        summary = self.adapter.import_server_config(self.server, self._intent(conf, hosts))
+
+        self.assertEqual(summary.reservations_created, 0)
+        self.assertFalse(HostReservation.objects.exists())
+        self.assertTrue(any("unknown subnet-id 99" in w for w in summary.warnings), summary.warnings)
+
+    def test_reimport_is_idempotent(self):
+        HostReservation = apps.get_model(DHCP_PLUGIN, "HostReservation")
+        conf = {"subnet4": [{"id": 7, "subnet": "10.41.0.0/24"}]}
+        hosts = [{"subnet-id": 7, "hw-address": "aa:bb:cc:dd:ee:41", "ip-address": "10.41.0.50"}]
+
+        self.adapter.import_server_config(self.server, self._intent(conf, hosts))
+        second = self.adapter.import_server_config(self.server, self._intent(conf, hosts))
+        self.assertEqual(second.reservations_created, 0)
+        self.assertEqual(HostReservation.objects.count(), 1)
+
+
+@tag("dhcp_plugin")
+@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class DhcpPluginStaleCleanupGuardTest(TestCase):
     """Stale-IP cleanup must never remove an IP a netbox_dhcp reservation references."""
 

--- a/netbox_kea/tests/test_integration_dhcp_plugin.py
+++ b/netbox_kea/tests/test_integration_dhcp_plugin.py
@@ -1,0 +1,224 @@
+# SPDX-FileCopyrightText: 2025 Marcin Zieba <marcinpsk@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+"""Integration tests for the optional netbox_dhcp adapter (real DB + real plugin).
+
+Gated on the plugin being installed: netbox-kea's own CI matrix does not install
+``netbox_dhcp``, so these run only where it is present (e.g. the dev container).
+Only the Kea HTTP boundary is bypassed — we feed a ``config-get``-shaped dict
+directly; the ORM, IPAM/DCIM models, and the ``netbox_dhcp`` models are all real.
+"""
+
+from __future__ import annotations
+
+from django.apps import apps
+from django.test import TestCase, override_settings, tag
+from django.utils import timezone
+
+from netbox_kea.mappers.kea_to_dhcp import parse_dhcp_config
+
+from .utils import _make_db_server
+
+DHCP_PLUGIN = "netbox_dhcp"
+_PLUGINS_CONFIG = {"netbox_kea": {"kea_timeout": 30}}
+
+
+def _conf_v4():
+    return {
+        "subnet4": [
+            {
+                "id": 1,
+                "subnet": "10.99.0.0/24",
+                "pools": [{"pool": "10.99.0.10-10.99.0.100"}],
+                "reservations": [
+                    {"hw-address": "aa:bb:cc:dd:ee:01", "ip-address": "10.99.0.50", "hostname": "res-host"}
+                ],
+            }
+        ]
+    }
+
+
+def _conf_v6():
+    return {
+        "subnet6": [
+            {
+                "id": 1,
+                "subnet": "2001:db8:99::/64",
+                "pools": [{"pool": "2001:db8:99::10-2001:db8:99::100"}],
+                "reservations": [{"duid": "01:02:03:04:05", "ip-addresses": ["2001:db8:99::50"], "hostname": "res6"}],
+            }
+        ]
+    }
+
+
+@tag("dhcp_plugin")
+@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
+class DhcpPluginAdapterTest(TestCase):
+    """Importing a Kea config into netbox_dhcp via the guarded adapter."""
+
+    @classmethod
+    def setUpClass(cls):
+        if not apps.is_installed(DHCP_PLUGIN):
+            raise cls.skipException(f"{DHCP_PLUGIN} not installed")
+        super().setUpClass()
+
+    def setUp(self):
+        self.server = _make_db_server(name=f"kea-int-{timezone.now().timestamp()}")
+        from netbox_kea.integrations import dhcp_plugin
+
+        self.adapter = dhcp_plugin
+
+    # ── basic import ────────────────────────────────────────────────────────
+
+    def test_v4_import_creates_subnet_pool_reservation_sharing_ipam(self):
+        from dcim.models import MACAddress
+        from ipam.models import IPAddress, IPRange, Prefix
+
+        from netbox_kea.models import KeaDhcpLink
+
+        Subnet = apps.get_model(DHCP_PLUGIN, "Subnet")
+        Pool = apps.get_model(DHCP_PLUGIN, "Pool")
+        HostReservation = apps.get_model(DHCP_PLUGIN, "HostReservation")
+
+        summary = self.adapter.import_server_config(self.server, parse_dhcp_config(_conf_v4(), 4))
+
+        self.assertEqual(summary.errors, 0, summary.warnings)
+        self.assertEqual(summary.subnets_created, 1)
+        self.assertEqual(summary.pools_created, 1)
+        self.assertEqual(summary.reservations_created, 1)
+
+        # Subnet linked by Kea identity, sharing the IPAM Prefix the sync owns.
+        link = KeaDhcpLink.objects.get(server=self.server, family=4, kea_subnet_id=1)
+        subnet = link.sys4_object
+        self.assertIsInstance(subnet, Subnet)
+        self.assertEqual(str(subnet.prefix.prefix), "10.99.0.0/24")
+        self.assertEqual(subnet.prefix, Prefix.objects.get(prefix="10.99.0.0/24"))
+        self.assertIsNone(subnet.shared_network)
+
+        # Pool shares the IPAM IPRange.
+        pool = Pool.objects.get(subnet=subnet)
+        self.assertEqual(pool.ip_range, IPRange.objects.get(start_address="10.99.0.10/24"))
+
+        # Reservation shares the same IPAddress (status reserved) + MACAddress the sync made.
+        res = HostReservation.objects.get(subnet=subnet)
+        shared_ip = IPAddress.objects.get(address="10.99.0.50/24")
+        self.assertEqual(res.ipv4_address, shared_ip)
+        self.assertEqual(res.hostname, "res-host")
+        self.assertEqual(res.hw_address, MACAddress.objects.get(mac_address="aa:bb:cc:dd:ee:01"))
+
+    def test_v6_import_uses_ipv6_addresses_m2m(self):
+        from ipam.models import IPAddress
+
+        Subnet = apps.get_model(DHCP_PLUGIN, "Subnet")
+        HostReservation = apps.get_model(DHCP_PLUGIN, "HostReservation")
+
+        summary = self.adapter.import_server_config(self.server, parse_dhcp_config(_conf_v6(), 6))
+        self.assertEqual(summary.errors, 0, summary.warnings)
+
+        subnet = Subnet.objects.get(prefix__prefix="2001:db8:99::/64")
+        res = HostReservation.objects.get(subnet=subnet)
+        self.assertEqual(res.duid, "01:02:03:04:05")
+        self.assertIsNone(res.ipv4_address)
+        self.assertIn(IPAddress.objects.get(address="2001:db8:99::50/64"), res.ipv6_addresses.all())
+
+    # ── the subnet_id decoupling (decision 5) ────────────────────────────────
+
+    def test_dualstack_v4_and_v6_subnet_id_1_both_import_without_collision(self):
+        from netbox_kea.models import KeaDhcpLink
+
+        self.adapter.import_server_config(self.server, parse_dhcp_config(_conf_v4(), 4))
+        self.adapter.import_server_config(self.server, parse_dhcp_config(_conf_v6(), 6))
+
+        link4 = KeaDhcpLink.objects.get(server=self.server, family=4, kea_subnet_id=1)
+        link6 = KeaDhcpLink.objects.get(server=self.server, family=6, kea_subnet_id=1)
+        # Same Kea subnet-id (1) for both families, but distinct plugin Subnets +
+        # distinct globally-unique plugin subnet_ids — no UniqueConstraint collision.
+        self.assertNotEqual(link4.object_id, link6.object_id)
+        self.assertNotEqual(link4.sys4_object.subnet_id, link6.sys4_object.subnet_id)
+
+    # ── idempotency ──────────────────────────────────────────────────────────
+
+    def test_reimport_is_idempotent(self):
+        from netbox_kea.models import KeaDhcpLink
+
+        Subnet = apps.get_model(DHCP_PLUGIN, "Subnet")
+        Pool = apps.get_model(DHCP_PLUGIN, "Pool")
+        HostReservation = apps.get_model(DHCP_PLUGIN, "HostReservation")
+
+        self.adapter.import_server_config(self.server, parse_dhcp_config(_conf_v4(), 4))
+        second = self.adapter.import_server_config(self.server, parse_dhcp_config(_conf_v4(), 4))
+
+        self.assertEqual(second.subnets_created, 0)
+        self.assertEqual(second.pools_created, 0)
+        self.assertEqual(second.reservations_created, 0)
+        self.assertEqual(KeaDhcpLink.objects.filter(server=self.server, family=4, kea_subnet_id=1).count(), 1)
+        self.assertEqual(Subnet.objects.filter(prefix__prefix="10.99.0.0/24").count(), 1)
+        self.assertEqual(Pool.objects.count(), 1)
+        self.assertEqual(HostReservation.objects.count(), 1)
+
+    # ── deferred reporting ────────────────────────────────────────────────────
+
+    def test_shared_network_subnets_flattened_and_reported(self):
+        conf = {
+            "shared-networks": [
+                {"name": "office", "subnet4": [{"id": 5, "subnet": "10.50.0.0/24"}]},
+            ]
+        }
+        Subnet = apps.get_model(DHCP_PLUGIN, "Subnet")
+        summary = self.adapter.import_server_config(self.server, parse_dhcp_config(conf, 4))
+        self.assertEqual(summary.shared_networks_deferred, 1)
+        subnet = Subnet.objects.get(prefix__prefix="10.50.0.0/24")
+        # Flattened onto the DHCPServer, not a (prefix-requiring) SharedNetwork.
+        self.assertIsNotNone(subnet.dhcp_server)
+        self.assertIsNone(subnet.shared_network)
+
+
+@tag("dhcp_plugin")
+@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
+class DhcpPluginStaleCleanupGuardTest(TestCase):
+    """Stale-IP cleanup must never remove an IP a netbox_dhcp reservation references."""
+
+    @classmethod
+    def setUpClass(cls):
+        if not apps.is_installed(DHCP_PLUGIN):
+            raise cls.skipException(f"{DHCP_PLUGIN} not installed")
+        super().setUpClass()
+
+    def setUp(self):
+        self.server = _make_db_server(name=f"kea-clean-{timezone.now().timestamp()}")
+
+    def test_cleanup_skips_sys4_referenced_ip(self):
+        from ipam.models import IPAddress
+
+        from netbox_kea.integrations import dhcp_plugin
+        from netbox_kea.sync import _cleanup_stale_ips
+
+        # Two Kea-synced IPs share one hostname; one will be referenced by a reservation.
+        conf = {
+            "subnet4": [
+                {
+                    "id": 1,
+                    "subnet": "10.77.0.0/24",
+                    "reservations": [
+                        {"hw-address": "aa:bb:cc:dd:ee:77", "ip-address": "10.77.0.50", "hostname": "mover"}
+                    ],
+                }
+            ]
+        }
+        dhcp_plugin.import_server_config(self.server, parse_dhcp_config(conf, 4))
+        referenced = IPAddress.objects.get(address="10.77.0.50/24")
+
+        # An unreferenced, same-hostname Kea-synced IP (the kind cleanup is meant to remove).
+        unreferenced = IPAddress.objects.create(
+            address="10.77.0.51/24",
+            status="dhcp",
+            dns_name="mover",
+            description="Synced from Kea DHCP lease",
+        )
+
+        # Device "moved" to a third IP → cleanup runs for hostname "mover".
+        cleaned = _cleanup_stale_ips("10.77.0.99", "mover", mode="remove")
+
+        self.assertEqual(cleaned, 1)  # only the unreferenced one
+        self.assertFalse(IPAddress.objects.filter(pk=unreferenced.pk).exists())
+        self.assertTrue(IPAddress.objects.filter(pk=referenced.pk).exists())
+        self.assertIn(referenced.pk, dhcp_plugin.sys4_referenced_ip_ids())

--- a/netbox_kea/tests/test_kea_client.py
+++ b/netbox_kea/tests/test_kea_client.py
@@ -18,6 +18,7 @@ from netbox_kea.kea import (
     KeaException,
     PartialPersistError,
     check_response,
+    iter_reservations,
 )
 
 
@@ -423,6 +424,56 @@ class TestReservationGetPage(TestCase):
         with self._patched_post(resp):
             with self.assertRaises(KeaException):
                 self.client.reservation_get_page("dhcp4")
+
+
+class TestIterReservations(TestCase):
+    """The module-level ``iter_reservations`` pages until Kea's cursor resets — and bails on a stall."""
+
+    class _ScriptedClient:
+        """Minimal stand-in exposing ``reservation_get_page`` with scripted pages.
+
+        Each page is ``(hosts, next_from, next_source)``; ``iter_reservations`` only
+        calls ``reservation_get_page``, so a tiny fake exercises the real loop logic.
+        """
+
+        def __init__(self, pages):
+            self._pages = pages
+            self.calls = 0
+
+        def reservation_get_page(self, service, *, source_index=0, from_index=0, limit=100):
+            page = self._pages[self.calls]
+            self.calls += 1
+            return page
+
+    def test_pages_until_cursor_resets(self):
+        client = self._ScriptedClient(
+            [
+                ([{"id": 1}], 1, 0),  # full page → advance
+                ([{"id": 2}], 0, 0),  # cursor reset → stop after yielding
+            ]
+        )
+        hosts = list(iter_reservations(client, "dhcp4"))
+        self.assertEqual([h["id"] for h in hosts], [1, 2])
+        self.assertEqual(client.calls, 2)
+
+    def test_empty_page_terminates(self):
+        client = self._ScriptedClient([([], 0, 0)])
+        self.assertEqual(list(iter_reservations(client, "dhcp4")), [])
+        self.assertEqual(client.calls, 1)
+
+    def test_stalled_cursor_raises_instead_of_looping(self):
+        # A non-empty page whose cursor never advances would loop forever without
+        # the guard. The script is capped so an unfixed (looping) impl raises
+        # IndexError rather than hanging; the fixed impl raises RuntimeError first.
+        client = self._ScriptedClient(
+            [
+                ([{"id": 1}], 5, 2),  # advance to (from=5, source=2)
+                ([{"id": 2}], 5, 2),  # SAME cursor → stall → must raise
+                ([{"id": 3}], 5, 2),  # only reached by a buggy looping impl
+            ]
+        )
+        with self.assertRaises(RuntimeError):
+            list(iter_reservations(client, "dhcp4"))
 
 
 class TestReservationAdd(TestCase):

--- a/netbox_kea/tests/test_mappers_kea_to_dhcp.py
+++ b/netbox_kea/tests/test_mappers_kea_to_dhcp.py
@@ -12,6 +12,7 @@ from django.test import SimpleTestCase
 
 from netbox_kea.mappers.kea_to_dhcp import (
     RESERVATION_IDENTIFIER_TYPES,
+    OptionDefIntent,
     OptionIntent,
     parse_dhcp_config,
 )
@@ -211,6 +212,91 @@ class TestParseDhcpConfigOptions(SimpleTestCase):
             ]
         }
         self.assertEqual(parse_dhcp_config(conf, 4).shared_networks[0].options[0].code, 6)
+
+    def test_global_options_captured(self):
+        conf = {
+            "option-data": [
+                {"code": 6, "name": "domain-name-servers", "data": "1.1.1.1", "space": "dhcp4", "always-send": False}
+            ],
+            "subnet4": [],
+        }
+        opts = parse_dhcp_config(conf, 4).global_options
+        self.assertEqual(len(opts), 1)
+        self.assertEqual(opts[0].code, 6)
+        self.assertEqual(opts[0].name, "domain-name-servers")
+
+    def test_never_send_flag_captured(self):
+        conf = {"option-data": [{"code": 6, "data": "1.1.1.1", "space": "dhcp4", "never-send": True}]}
+        self.assertIs(parse_dhcp_config(conf, 4).global_options[0].never_send, True)
+
+    def test_pool_options_captured(self):
+        conf = {
+            "subnet4": [
+                {
+                    "id": 1,
+                    "subnet": "10.0.0.0/24",
+                    "pools": [
+                        {
+                            "pool": "10.0.0.10-10.0.0.99",
+                            "option-data": [{"code": 3, "data": "10.0.0.1", "space": "dhcp4"}],
+                        }
+                    ],
+                }
+            ]
+        }
+        pool = parse_dhcp_config(conf, 4).subnets[0].pools[0]
+        self.assertEqual(pool.pool, "10.0.0.10-10.0.0.99")
+        self.assertEqual(pool.options[0].code, 3)
+
+
+class TestParseDhcpConfigOptionDefs(SimpleTestCase):
+    """Custom ``option-def`` entries are parsed into OptionDefIntent."""
+
+    def test_option_def_parsed(self):
+        conf = {
+            "option-def": [
+                {
+                    "code": 222,
+                    "name": "my-opt",
+                    "space": "dhcp4",
+                    "type": "string",
+                    "array": False,
+                    "record-types": [],
+                    "encapsulate": "",
+                }
+            ]
+        }
+        defs = parse_dhcp_config(conf, 4).option_defs
+        self.assertEqual(len(defs), 1)
+        self.assertEqual(
+            defs[0],
+            OptionDefIntent(
+                code=222,
+                name="my-opt",
+                space="dhcp4",
+                type="string",
+                array=False,
+                record_types=(),
+                encapsulate=None,
+            ),
+        )
+        self.assertEqual(defs[0].match_key, ("dhcp4", 222))
+
+    def test_record_types_captured(self):
+        conf = {
+            "option-def": [
+                {"code": 223, "name": "r", "space": "dhcp4", "type": "record", "record-types": ["uint8", "string"]}
+            ]
+        }
+        self.assertEqual(parse_dhcp_config(conf, 4).option_defs[0].record_types, ("uint8", "string"))
+
+    def test_non_dict_option_def_skipped(self):
+        conf = {"option-def": ["nope", None, {"code": 224, "name": "ok", "space": "dhcp4", "type": "string"}]}
+        defs = parse_dhcp_config(conf, 4).option_defs
+        self.assertEqual([d.code for d in defs], [224])
+
+    def test_no_option_def_yields_empty(self):
+        self.assertEqual(parse_dhcp_config({"subnet4": []}, 4).option_defs, ())
 
 
 class TestParseDhcpConfigRobustness(SimpleTestCase):

--- a/netbox_kea/tests/test_mappers_kea_to_dhcp.py
+++ b/netbox_kea/tests/test_mappers_kea_to_dhcp.py
@@ -344,6 +344,48 @@ class TestParseDhcpConfigSettings(SimpleTestCase):
         self.assertEqual(result.subnets[0].settings, {})
 
 
+class TestParseDhcpConfigClientClasses(SimpleTestCase):
+    """Kea ``client-classes`` are parsed into ClientClassIntent."""
+
+    def test_client_class_parsed(self):
+        conf = {
+            "client-classes": [
+                {
+                    "name": "voip",
+                    "test": "substring(option[60].hex,0,6) == 'Aastra'",
+                    "next-server": "192.0.2.254",
+                    "boot-file-name": "/dev/null",
+                    "server-hostname": "hal9000",
+                    "option-data": [{"code": 3, "data": "10.0.0.1", "space": "dhcp4"}],
+                }
+            ],
+            "subnet4": [],
+        }
+        cc = parse_dhcp_config(conf, 4).client_classes[0]
+        self.assertEqual(cc.name, "voip")
+        self.assertEqual(cc.family, 4)
+        self.assertEqual(cc.test, "substring(option[60].hex,0,6) == 'Aastra'")
+        self.assertEqual(cc.settings["next-server"], "192.0.2.254")
+        self.assertEqual(cc.settings["boot-file-name"], "/dev/null")
+        self.assertEqual(cc.options[0].code, 3)
+
+    def test_only_if_required_falls_back_to_additional_list(self):
+        conf = {"client-classes": [{"name": "c1", "only-if-required": True}]}
+        self.assertIs(parse_dhcp_config(conf, 4).client_classes[0].only_in_additional_list, True)
+
+    def test_only_in_additional_list_preferred(self):
+        conf = {"client-classes": [{"name": "c1", "only-in-additional-list": True, "only-if-required": False}]}
+        self.assertIs(parse_dhcp_config(conf, 4).client_classes[0].only_in_additional_list, True)
+
+    def test_class_without_name_and_non_dict_skipped(self):
+        conf = {"client-classes": [{"test": "x"}, "garbage", None, {"name": "ok"}]}
+        ccs = parse_dhcp_config(conf, 4).client_classes
+        self.assertEqual([c.name for c in ccs], ["ok"])
+
+    def test_no_client_classes_yields_empty(self):
+        self.assertEqual(parse_dhcp_config({"subnet4": []}, 4).client_classes, [])
+
+
 class TestParseDhcpConfigRobustness(SimpleTestCase):
     def test_subnet_without_cidr_is_skipped(self):
         conf = {"subnet4": [{"id": 1}, {"id": 2, "subnet": "10.0.0.0/24"}]}

--- a/netbox_kea/tests/test_mappers_kea_to_dhcp.py
+++ b/netbox_kea/tests/test_mappers_kea_to_dhcp.py
@@ -299,6 +299,51 @@ class TestParseDhcpConfigOptionDefs(SimpleTestCase):
         self.assertEqual(parse_dhcp_config({"subnet4": []}, 4).option_defs, ())
 
 
+class TestParseDhcpConfigSettings(SimpleTestCase):
+    """Scalar tuning keys are captured verbatim at global + subnet scope."""
+
+    def test_global_settings_captured(self):
+        conf = {
+            "valid-lifetime": 3600,
+            "allocator": "iterative",
+            "t1-percent": 0.5,
+            "server-id": {"type": "LLT", "enterprise-id": 0},
+            "host-reservation-identifiers": ["hw-address", "duid"],
+            "not-a-tuning-key": "ignored",
+            "subnet4": [],
+        }
+        gs = parse_dhcp_config(conf, 4).global_settings
+        self.assertEqual(gs["valid-lifetime"], 3600)
+        self.assertEqual(gs["allocator"], "iterative")
+        self.assertEqual(gs["t1-percent"], 0.5)
+        self.assertEqual(gs["server-id"], {"type": "LLT", "enterprise-id": 0})
+        self.assertEqual(gs["host-reservation-identifiers"], ["hw-address", "duid"])
+        self.assertNotIn("not-a-tuning-key", gs)
+
+    def test_subnet_settings_captured(self):
+        conf = {
+            "subnet4": [
+                {
+                    "id": 1,
+                    "subnet": "10.0.0.0/24",
+                    "valid-lifetime": 7200,
+                    "relay": {"ip-addresses": ["10.0.0.3"]},
+                    "rapid-commit": False,
+                }
+            ]
+        }
+        settings = parse_dhcp_config(conf, 4).subnets[0].settings
+        self.assertEqual(settings["valid-lifetime"], 7200)
+        self.assertEqual(settings["relay"], {"ip-addresses": ["10.0.0.3"]})
+        self.assertIs(settings["rapid-commit"], False)
+
+    def test_settings_default_empty(self):
+        conf = {"subnet4": [{"id": 1, "subnet": "10.0.0.0/24"}]}
+        result = parse_dhcp_config(conf, 4)
+        self.assertEqual(result.global_settings, {})
+        self.assertEqual(result.subnets[0].settings, {})
+
+
 class TestParseDhcpConfigRobustness(SimpleTestCase):
     def test_subnet_without_cidr_is_skipped(self):
         conf = {"subnet4": [{"id": 1}, {"id": 2, "subnet": "10.0.0.0/24"}]}

--- a/netbox_kea/tests/test_mappers_kea_to_dhcp.py
+++ b/netbox_kea/tests/test_mappers_kea_to_dhcp.py
@@ -1,0 +1,240 @@
+# SPDX-FileCopyrightText: 2025 Marcin Zieba <marcinpsk@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the pure Kea-config → DHCP-plugin intent mapper.
+
+These exercise only ``netbox_kea.mappers.kea_to_dhcp`` — no DB, no ORM, and no
+``netbox_dhcp``; they run wherever NetBox is importable (CI + devcontainer).
+"""
+
+from __future__ import annotations
+
+from django.test import SimpleTestCase
+
+from netbox_kea.mappers.kea_to_dhcp import (
+    RESERVATION_IDENTIFIER_TYPES,
+    OptionIntent,
+    parse_dhcp_config,
+)
+
+
+class TestParseDhcpConfigStructure(SimpleTestCase):
+    """Subnet / shared-network grouping and basic field extraction."""
+
+    def test_standalone_subnet_has_no_shared_network(self):
+        conf = {"subnet4": [{"id": 1, "subnet": "10.0.0.0/24"}]}
+        result = parse_dhcp_config(conf, 4)
+        self.assertEqual(len(result.subnets), 1)
+        subnet = result.subnets[0]
+        self.assertEqual(subnet.kea_subnet_id, 1)
+        self.assertEqual(subnet.cidr, "10.0.0.0/24")
+        self.assertEqual(subnet.family, 4)
+        self.assertIsNone(subnet.shared_network)
+        self.assertEqual(result.shared_networks, [])
+
+    def test_shared_network_subnet_carries_network_name(self):
+        conf = {
+            "subnet4": [{"id": 1, "subnet": "10.0.0.0/24"}],
+            "shared-networks": [
+                {"name": "office", "subnet4": [{"id": 2, "subnet": "10.0.1.0/24"}]},
+            ],
+        }
+        result = parse_dhcp_config(conf, 4)
+        self.assertEqual({sn.name for sn in result.shared_networks}, {"office"})
+        by_id = {s.kea_subnet_id: s for s in result.subnets}
+        self.assertIsNone(by_id[1].shared_network)
+        self.assertEqual(by_id[2].shared_network, "office")
+
+    def test_v6_uses_subnet6_key_and_family_6(self):
+        conf = {"subnet6": [{"id": 7, "subnet": "2001:db8::/64"}]}
+        result = parse_dhcp_config(conf, 6)
+        self.assertEqual(len(result.subnets), 1)
+        self.assertEqual(result.subnets[0].family, 6)
+        self.assertEqual(result.subnets[0].kea_subnet_id, 7)
+
+    def test_subnet4_key_ignored_when_parsing_v6(self):
+        conf = {"subnet4": [{"id": 1, "subnet": "10.0.0.0/24"}]}
+        self.assertEqual(parse_dhcp_config(conf, 6).subnets, [])
+
+    def test_string_subnet_id_is_coerced_to_int(self):
+        conf = {"subnet4": [{"id": "5", "subnet": "10.0.0.0/24"}]}
+        self.assertEqual(parse_dhcp_config(conf, 4).subnets[0].kea_subnet_id, 5)
+
+    def test_unparseable_subnet_id_becomes_none(self):
+        conf = {"subnet4": [{"id": "abc", "subnet": "10.0.0.0/24"}]}
+        self.assertIsNone(parse_dhcp_config(conf, 4).subnets[0].kea_subnet_id)
+
+
+class TestParseDhcpConfigPools(SimpleTestCase):
+    def test_pools_extracted_in_order(self):
+        conf = {
+            "subnet4": [
+                {
+                    "id": 1,
+                    "subnet": "10.0.0.0/24",
+                    "pools": [{"pool": "10.0.0.10-10.0.0.99"}, {"pool": "10.0.0.128/25"}],
+                }
+            ]
+        }
+        pools = parse_dhcp_config(conf, 4).subnets[0].pools
+        self.assertEqual([p.pool for p in pools], ["10.0.0.10-10.0.0.99", "10.0.0.128/25"])
+
+    def test_pool_match_key_is_stripped(self):
+        conf = {"subnet4": [{"id": 1, "subnet": "10.0.0.0/24", "pools": [{"pool": "  10.0.0.10-10.0.0.99 "}]}]}
+        self.assertEqual(parse_dhcp_config(conf, 4).subnets[0].pools[0].match_key, "10.0.0.10-10.0.0.99")
+
+    def test_empty_and_non_dict_pool_entries_skipped(self):
+        conf = {"subnet4": [{"id": 1, "subnet": "10.0.0.0/24", "pools": [{"pool": ""}, "garbage", {}]}]}
+        self.assertEqual(parse_dhcp_config(conf, 4).subnets[0].pools, ())
+
+
+class TestParseDhcpConfigReservations(SimpleTestCase):
+    def test_v4_reservation_hw_address_and_ip(self):
+        conf = {
+            "subnet4": [
+                {
+                    "id": 1,
+                    "subnet": "10.0.0.0/24",
+                    "reservations": [
+                        {"hw-address": "00:11:22:33:44:55", "ip-address": "10.0.0.50", "hostname": "host-a"}
+                    ],
+                }
+            ]
+        }
+        res = parse_dhcp_config(conf, 4).subnets[0].reservations[0]
+        self.assertEqual(res.identifier_type, "hw-address")
+        self.assertEqual(res.identifier, "00:11:22:33:44:55")
+        self.assertEqual(res.ip_address, "10.0.0.50")
+        self.assertEqual(res.hostname, "host-a")
+        self.assertEqual(res.all_addresses, ("10.0.0.50",))
+        self.assertEqual(res.match_key, ("hw-address", "00:11:22:33:44:55"))
+
+    def test_v6_reservation_duid_addresses_and_prefixes(self):
+        conf = {
+            "subnet6": [
+                {
+                    "id": 1,
+                    "subnet": "2001:db8::/64",
+                    "reservations": [
+                        {
+                            "duid": "01:02:03:04",
+                            "ip-addresses": ["2001:db8::5", "2001:db8::6"],
+                            "prefixes": ["2001:db8:1::/48"],
+                            "hostname": "host-v6",
+                        }
+                    ],
+                }
+            ]
+        }
+        res = parse_dhcp_config(conf, 6).subnets[0].reservations[0]
+        self.assertEqual(res.identifier_type, "duid")
+        self.assertIsNone(res.ip_address)
+        self.assertEqual(res.ip_addresses, ("2001:db8::5", "2001:db8::6"))
+        self.assertEqual(res.prefixes, ("2001:db8:1::/48",))
+        self.assertEqual(res.all_addresses, ("2001:db8::5", "2001:db8::6"))
+
+    def test_identifier_priority_prefers_hw_address_over_others(self):
+        # hw-address comes first in Kea's priority order even if others are present.
+        conf = {
+            "subnet4": [
+                {
+                    "id": 1,
+                    "subnet": "10.0.0.0/24",
+                    "reservations": [
+                        {"client-id": "aa:bb", "hw-address": "00:11:22:33:44:55", "ip-address": "10.0.0.9"}
+                    ],
+                }
+            ]
+        }
+        res = parse_dhcp_config(conf, 4).subnets[0].reservations[0]
+        self.assertEqual(res.identifier_type, "hw-address")
+
+    def test_identifier_priority_order_matches_constant(self):
+        # circuit-id wins only when hw-address and duid are absent.
+        conf = {
+            "subnet4": [
+                {
+                    "id": 1,
+                    "subnet": "10.0.0.0/24",
+                    "reservations": [{"flex-id": "f", "circuit-id": "c", "ip-address": "10.0.0.9"}],
+                }
+            ]
+        }
+        res = parse_dhcp_config(conf, 4).subnets[0].reservations[0]
+        # circuit-id precedes flex-id in the documented order.
+        self.assertLess(
+            RESERVATION_IDENTIFIER_TYPES.index("circuit-id"),
+            RESERVATION_IDENTIFIER_TYPES.index("flex-id"),
+        )
+        self.assertEqual(res.identifier_type, "circuit-id")
+
+    def test_reservation_without_identifier_has_none_key(self):
+        conf = {
+            "subnet4": [
+                {"id": 1, "subnet": "10.0.0.0/24", "reservations": [{"ip-address": "10.0.0.9", "hostname": "h"}]}
+            ]
+        }
+        res = parse_dhcp_config(conf, 4).subnets[0].reservations[0]
+        self.assertEqual(res.match_key, (None, None))
+
+
+class TestParseDhcpConfigOptions(SimpleTestCase):
+    def test_subnet_options_normalized(self):
+        conf = {
+            "subnet4": [
+                {
+                    "id": 1,
+                    "subnet": "10.0.0.0/24",
+                    "option-data": [
+                        {"code": 3, "name": "routers", "data": "10.0.0.1", "space": "dhcp4", "always-send": True}
+                    ],
+                }
+            ]
+        }
+        opt = parse_dhcp_config(conf, 4).subnets[0].options[0]
+        self.assertEqual(
+            opt, OptionIntent(code=3, name="routers", space="dhcp4", data="10.0.0.1", csv_format=None, always_send=True)
+        )
+        self.assertEqual(opt.match_key, ("dhcp4", 3))
+
+    def test_option_match_key_falls_back_to_name_without_code(self):
+        conf = {
+            "subnet4": [
+                {"id": 1, "subnet": "10.0.0.0/24", "option-data": [{"name": "custom", "data": "x", "space": "dhcp4"}]}
+            ]
+        }
+        self.assertEqual(parse_dhcp_config(conf, 4).subnets[0].options[0].match_key, ("dhcp4", "custom"))
+
+    def test_shared_network_options_captured(self):
+        conf = {
+            "shared-networks": [
+                {"name": "n", "subnet4": [], "option-data": [{"code": 6, "data": "1.1.1.1", "space": "dhcp4"}]}
+            ]
+        }
+        self.assertEqual(parse_dhcp_config(conf, 4).shared_networks[0].options[0].code, 6)
+
+
+class TestParseDhcpConfigRobustness(SimpleTestCase):
+    def test_subnet_without_cidr_is_skipped(self):
+        conf = {"subnet4": [{"id": 1}, {"id": 2, "subnet": "10.0.0.0/24"}]}
+        result = parse_dhcp_config(conf, 4)
+        self.assertEqual([s.kea_subnet_id for s in result.subnets], [2])
+
+    def test_non_dict_subnet_entries_skipped(self):
+        conf = {"subnet4": ["nope", None, {"id": 1, "subnet": "10.0.0.0/24"}]}
+        self.assertEqual(len(parse_dhcp_config(conf, 4).subnets), 1)
+
+    def test_shared_network_without_name_skipped(self):
+        conf = {"shared-networks": [{"subnet4": [{"id": 1, "subnet": "10.0.0.0/24"}]}]}
+        result = parse_dhcp_config(conf, 4)
+        self.assertEqual(result.shared_networks, [])
+        # Its subnets are dropped too (no parent name to attach them to).
+        self.assertEqual(result.subnets, [])
+
+    def test_non_dict_conf_returns_empty(self):
+        result = parse_dhcp_config("not a dict", 4)
+        self.assertEqual(result.subnets, [])
+        self.assertEqual(result.shared_networks, [])
+
+    def test_invalid_version_raises(self):
+        with self.assertRaises(ValueError):
+            parse_dhcp_config({}, 5)

--- a/netbox_kea/tests/test_mappers_kea_to_dhcp.py
+++ b/netbox_kea/tests/test_mappers_kea_to_dhcp.py
@@ -15,6 +15,7 @@ from netbox_kea.mappers.kea_to_dhcp import (
     OptionDefIntent,
     OptionIntent,
     parse_dhcp_config,
+    parse_reservations_page,
 )
 
 
@@ -384,6 +385,46 @@ class TestParseDhcpConfigClientClasses(SimpleTestCase):
 
     def test_no_client_classes_yields_empty(self):
         self.assertEqual(parse_dhcp_config({"subnet4": []}, 4).client_classes, [])
+
+
+class TestParseReservationsPage(SimpleTestCase):
+    """DB-backed reservation pages (reservation-get-page) group by Kea subnet-id."""
+
+    def test_groups_by_subnet_id(self):
+        hosts = [
+            {"subnet-id": 1, "hw-address": "aa:bb:cc:dd:ee:01", "ip-address": "10.0.0.5", "hostname": "h1"},
+            {"subnet-id": 1, "hw-address": "aa:bb:cc:dd:ee:02", "ip-address": "10.0.0.6"},
+            {"subnet-id": 2, "hw-address": "aa:bb:cc:dd:ee:03", "ip-address": "10.0.1.5"},
+        ]
+        grouped = parse_reservations_page(hosts, 4)
+        self.assertEqual(set(grouped), {1, 2})
+        self.assertEqual(len(grouped[1]), 2)
+        self.assertEqual(grouped[1][0].identifier, "aa:bb:cc:dd:ee:01")
+        self.assertEqual(grouped[1][0].ip_address, "10.0.0.5")
+        self.assertEqual(grouped[1][0].family, 4)
+
+    def test_missing_subnet_id_groups_as_global_zero(self):
+        hosts = [{"hw-address": "aa:bb:cc:dd:ee:01", "ip-address": "10.0.0.5"}]
+        self.assertEqual(set(parse_reservations_page(hosts, 4)), {0})
+
+    def test_unparseable_subnet_id_groups_as_zero(self):
+        hosts = [{"subnet-id": "x", "hw-address": "aa:bb:cc:dd:ee:01", "ip-address": "10.0.0.5"}]
+        self.assertEqual(set(parse_reservations_page(hosts, 4)), {0})
+
+    def test_non_dict_entries_skipped(self):
+        hosts = ["nope", None, {"subnet-id": 1, "hw-address": "aa:bb:cc:dd:ee:01", "ip-address": "10.0.0.5"}]
+        grouped = parse_reservations_page(hosts, 4)
+        self.assertEqual(set(grouped), {1})
+        self.assertEqual(len(grouped[1]), 1)
+
+    def test_non_list_returns_empty(self):
+        self.assertEqual(parse_reservations_page("nope", 4), {})
+
+    def test_v6_addresses_parsed(self):
+        hosts = [{"subnet-id": 3, "duid": "01:02:03", "ip-addresses": ["2001:db8::5"], "hostname": "h6"}]
+        res = parse_reservations_page(hosts, 6)[3][0]
+        self.assertEqual(res.identifier_type, "duid")
+        self.assertEqual(res.ip_addresses, ("2001:db8::5",))
 
 
 class TestParseDhcpConfigRobustness(SimpleTestCase):

--- a/netbox_kea/tests/test_sync.py
+++ b/netbox_kea/tests/test_sync.py
@@ -2071,3 +2071,39 @@ class TestResolvePrefixLengthSubnetIdNormalization(TestCase):
 
         # No matching NetBox Prefix → default /32 (not a TypeError on int()).
         self.assertEqual(_resolve_prefix_length("10.88.0.9", "not-a-number", {1: 24}), 32)
+
+
+@override_settings(PLUGINS_CONFIG=_STALE_PLUGINS_CONFIG)
+class TestCleanupBatchProtectedIdsComputedOnce(TestCase):
+    """cleanup_stale_ips_batch resolves the DHCP-plugin protected-IP set once per run.
+
+    Previously each per-hostname ``_cleanup_stale_ips`` re-scanned the reservation
+    tables via ``sys4_referenced_ip_ids`` — an N× full-table scan during large syncs.
+    """
+
+    _KEA_DESC = "Synced from Kea DHCP lease"
+
+    def _make_stale(self, host, ip):
+        from ipam.models import IPAddress as NbIP
+
+        NbIP.objects.create(address=f"{ip}/32", status="dhcp", dns_name=host, description=self._KEA_DESC)
+
+    def test_protected_ids_resolved_once_for_many_hostnames(self):
+        from unittest.mock import patch
+
+        from netbox_kea.sync import cleanup_stale_ips_batch
+
+        for i in range(3):
+            self._make_stale(f"host{i}.example.com", f"10.40.0.{10 + i}")
+        records = [{"hostname": f"host{i}.example.com", "ip-address": f"10.40.0.{100 + i}"} for i in range(3)]
+
+        # The plugin boundary isn't installed in CI, so stand it in: force "available"
+        # and count how often the referenced-IP set is resolved across the batch.
+        with (
+            patch("netbox_kea.integrations.dhcp_plugin.is_available", return_value=True),
+            patch("netbox_kea.integrations.dhcp_plugin.sys4_referenced_ip_ids", return_value=set()) as spy,
+        ):
+            cleanup_stale_ips_batch(records)
+
+        # One resolve for the whole batch — not one per (hostname, family) group.
+        self.assertEqual(spy.call_count, 1)

--- a/netbox_kea/tests/test_sync.py
+++ b/netbox_kea/tests/test_sync.py
@@ -2107,3 +2107,21 @@ class TestCleanupBatchProtectedIdsComputedOnce(TestCase):
 
         # One resolve for the whole batch — not one per (hostname, family) group.
         self.assertEqual(spy.call_count, 1)
+
+    def test_protected_ids_not_resolved_when_no_candidates(self):
+        from unittest.mock import patch
+
+        from netbox_kea.sync import cleanup_stale_ips_batch
+
+        # Records with no usable hostname/IP yield an empty candidate set, so the
+        # protected-ID lookup (a full reservation-table scan) must be skipped.
+        records = [{"hostname": "", "ip-address": "10.40.0.200"}, {"ip-address": "10.40.0.201"}]
+
+        with (
+            patch("netbox_kea.integrations.dhcp_plugin.is_available", return_value=True),
+            patch("netbox_kea.integrations.dhcp_plugin.sys4_referenced_ip_ids", return_value=set()) as spy,
+        ):
+            result = cleanup_stale_ips_batch(records)
+
+        self.assertEqual(result, 0)
+        self.assertEqual(spy.call_count, 0)

--- a/netbox_kea/tests/test_views_dhcp_plugin.py
+++ b/netbox_kea/tests/test_views_dhcp_plugin.py
@@ -16,7 +16,7 @@ from django.test import SimpleTestCase, TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 
-from netbox_kea.kea import KeaClient
+from netbox_kea.kea import KeaClient, KeaException
 from netbox_kea.views import dhcp_plugin_sync as dps
 
 from .utils import _make_db_server
@@ -33,15 +33,24 @@ class _FakeKeaClient(KeaClient):
     faked ``command`` — only the Kea HTTP boundary is replaced, never the ORM.
     """
 
-    def __init__(self, conf_by_version: dict[int, dict], hosts_by_version: dict[int, list] | None = None):
+    def __init__(
+        self,
+        conf_by_version: dict[int, dict],
+        hosts_by_version: dict[int, list] | None = None,
+        reservations_available: bool = True,
+    ):
         self._conf = conf_by_version
         self._hosts = hosts_by_version or {}
+        self._reservations_available = reservations_available
 
     def command(self, command, service=None, arguments=None, check=(0,)):
         version = 6 if service and service[0] == "dhcp6" else 4
         if command == "config-get":
             return [{"result": 0, "arguments": {f"Dhcp{version}": self._conf.get(version, {})}}]
         if command == "reservation-get-page":
+            if not self._reservations_available:
+                # Simulate host_cmds not loaded (Kea result code 2).
+                raise KeaException({"result": 2, "text": "command not supported", "arguments": None})
             hosts = self._hosts.get(version, [])
             return [{"result": 0, "arguments": {"hosts": hosts, "next": {"from": 0, "source-index": 0}}}]
         return [{"result": 0, "arguments": {}}]
@@ -178,6 +187,14 @@ class SyncNowEndToEndTest(TestCase):
         HostReservation = apps.get_model(DHCP_PLUGIN, "HostReservation")
         subnet = Subnet.objects.get(prefix__prefix="10.89.0.0/24")
         self.assertTrue(HostReservation.objects.filter(subnet=subnet, hostname="db-res").exists())
+
+    def test_post_warns_when_reservations_unreadable(self):
+        # Finding 4: host_cmds absent → the import must say reservations couldn't be read.
+        conf = {4: {"subnet4": [{"id": 1, "subnet": "10.90.0.0/24"}]}}
+        fake = _FakeKeaClient(conf, reservations_available=False)
+        with patch("netbox_kea.models.Server.get_client", return_value=fake):
+            resp = self.client.post(self.url, follow=True)
+        self.assertContains(resp, "could not be read")
 
     def test_drift_view_renders_imported_status(self):
         conf = {4: {"subnet4": [{"id": 1, "subnet": "10.88.0.0/24"}]}}

--- a/netbox_kea/tests/test_views_dhcp_plugin.py
+++ b/netbox_kea/tests/test_views_dhcp_plugin.py
@@ -9,6 +9,7 @@ gated on ``netbox_dhcp`` being installed.  Only the Kea HTTP boundary is faked
 
 from __future__ import annotations
 
+import unittest
 from unittest.mock import patch
 
 from django.apps import apps
@@ -126,7 +127,7 @@ class SyncNowEndToEndTest(TestCase):
     @classmethod
     def setUpClass(cls):
         if not apps.is_installed(DHCP_PLUGIN):
-            raise cls.skipException(f"{DHCP_PLUGIN} not installed")
+            raise unittest.SkipTest(f"{DHCP_PLUGIN} not installed")
         super().setUpClass()
 
     def setUp(self):

--- a/netbox_kea/tests/test_views_dhcp_plugin.py
+++ b/netbox_kea/tests/test_views_dhcp_plugin.py
@@ -128,7 +128,12 @@ class SyncNowEndToEndTest(TestCase):
         conf = {
             4: {
                 "subnet4": [
-                    {"id": 1, "subnet": "10.88.0.0/24", "pools": [{"pool": "10.88.0.10-10.88.0.99"}]},
+                    {
+                        "id": 1,
+                        "subnet": "10.88.0.0/24",
+                        "pools": [{"pool": "10.88.0.10-10.88.0.99"}],
+                        "option-data": [{"code": 3, "name": "routers", "data": "10.88.0.1", "space": "dhcp4"}],
+                    },
                 ]
             }
         }
@@ -137,8 +142,15 @@ class SyncNowEndToEndTest(TestCase):
             resp = self.client.post(self.url, follow=True)
 
         self.assertContains(resp, "1 subnets created")
+        self.assertContains(resp, "1 options created")
         Subnet = apps.get_model(DHCP_PLUGIN, "Subnet")
         self.assertTrue(Subnet.objects.filter(prefix__prefix="10.88.0.0/24").exists())
+        Option = apps.get_model(DHCP_PLUGIN, "Option")
+        subnet = Subnet.objects.get(prefix__prefix="10.88.0.0/24")
+        from django.contrib.contenttypes.models import ContentType
+
+        ct = ContentType.objects.get_for_model(Subnet)
+        self.assertTrue(Option.objects.filter(assigned_object_type=ct, assigned_object_id=subnet.pk).exists())
 
     def test_drift_view_renders_imported_status(self):
         conf = {4: {"subnet4": [{"id": 1, "subnet": "10.88.0.0/24"}]}}

--- a/netbox_kea/tests/test_views_dhcp_plugin.py
+++ b/netbox_kea/tests/test_views_dhcp_plugin.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: 2025 Marcin Zieba <marcinpsk@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the "Sync to DHCP plugin" views (tab, sync-now action, drift).
+
+Helper/guard tests run anywhere; the end-to-end import-through-the-view tests are
+gated on ``netbox_dhcp`` being installed.  Only the Kea HTTP boundary is faked
+(a small fake client), never the ORM or the DHCP-plugin models.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from django.apps import apps
+from django.test import SimpleTestCase, TestCase, override_settings
+from django.urls import reverse
+from django.utils import timezone
+
+from netbox_kea.views import dhcp_plugin_sync as dps
+
+from .utils import _make_db_server
+
+DHCP_PLUGIN = "netbox_dhcp"
+_PLUGINS_CONFIG = {"netbox_kea": {"kea_timeout": 30}}
+
+
+class _FakeKeaClient:
+    """Minimal stand-in for KeaClient that answers ``config-get`` only."""
+
+    def __init__(self, conf_by_version: dict[int, dict]):
+        self._conf = conf_by_version
+
+    def command(self, cmd, service=None, arguments=None):
+        if cmd == "config-get":
+            version = 6 if service and service[0] == "dhcp6" else 4
+            return [{"result": 0, "arguments": {f"Dhcp{version}": self._conf.get(version, {})}}]
+        return [{"result": 0, "arguments": {}}]
+
+
+class ExtractDhcpConfTest(SimpleTestCase):
+    """`_extract_dhcp_conf` pulls the right block and rejects malformed shapes."""
+
+    def test_extracts_dhcp4_block(self):
+        resp = [{"result": 0, "arguments": {"Dhcp4": {"subnet4": []}}}]
+        self.assertEqual(dps._extract_dhcp_conf(resp, 4), {"subnet4": []})
+
+    def test_wrong_result_code_returns_none(self):
+        self.assertIsNone(dps._extract_dhcp_conf([{"result": 1, "arguments": {"Dhcp4": {}}}], 4))
+
+    def test_non_list_returns_none(self):
+        self.assertIsNone(dps._extract_dhcp_conf({"not": "a list"}, 4))
+
+    def test_missing_block_returns_none(self):
+        self.assertIsNone(dps._extract_dhcp_conf([{"result": 0, "arguments": {}}], 6))
+
+
+@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
+class TabVisibilityTest(TestCase):
+    """The DHCP-plugin tab hides itself unless the plugin is installed AND opted in."""
+
+    def test_tab_hidden_when_plugin_unavailable(self):
+        server = _make_db_server(sync_dhcp_plugin_enabled=True)
+        with patch.object(dps.dhcp_plugin, "is_available", return_value=False):
+            self.assertFalse(dps._tab_enabled(server))
+
+    def test_tab_hidden_when_not_opted_in(self):
+        server = _make_db_server(sync_dhcp_plugin_enabled=False)
+        with patch.object(dps.dhcp_plugin, "is_available", return_value=True):
+            self.assertFalse(dps._tab_enabled(server))
+
+    def test_tab_shown_when_available_and_opted_in(self):
+        server = _make_db_server(sync_dhcp_plugin_enabled=True)
+        with patch.object(dps.dhcp_plugin, "is_available", return_value=True):
+            self.assertTrue(dps._tab_enabled(server))
+
+
+@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
+class SyncNowGuardTest(TestCase):
+    """The sync-now action refuses when the plugin is absent or not opted in."""
+
+    def setUp(self):
+        from django.contrib.auth import get_user_model
+
+        User = get_user_model()
+        self.user = User.objects.create_superuser("dps-user", "dps@example.com", "pw")
+        self.client.force_login(self.user)
+        self.server = _make_db_server(sync_dhcp_plugin_enabled=True)
+        self.url = reverse("plugins:netbox_kea:server_dhcp_plugin_sync", args=[self.server.pk])
+
+    def test_refuses_when_plugin_unavailable(self):
+        with patch.object(dps.dhcp_plugin, "is_available", return_value=False):
+            resp = self.client.post(self.url, follow=True)
+        self.assertContains(resp, "not installed")
+
+    def test_refuses_when_not_opted_in(self):
+        self.server.sync_dhcp_plugin_enabled = False
+        self.server.save(update_fields=["sync_dhcp_plugin_enabled"])
+        with patch.object(dps.dhcp_plugin, "is_available", return_value=True):
+            resp = self.client.post(self.url, follow=True)
+        self.assertContains(resp, "Enable &#x27;Sync to DHCP plugin&#x27;")
+
+
+@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
+class SyncNowEndToEndTest(TestCase):
+    """Full path: POST sync-now → read (faked) Kea config → real DHCP-plugin rows."""
+
+    @classmethod
+    def setUpClass(cls):
+        if not apps.is_installed(DHCP_PLUGIN):
+            raise cls.skipException(f"{DHCP_PLUGIN} not installed")
+        super().setUpClass()
+
+    def setUp(self):
+        from django.contrib.auth import get_user_model
+
+        User = get_user_model()
+        self.user = User.objects.create_superuser("dps-e2e", "e2e@example.com", "pw")
+        self.client.force_login(self.user)
+        self.server = _make_db_server(
+            name=f"kea-dps-{timezone.now().timestamp()}",
+            sync_dhcp_plugin_enabled=True,
+            dhcp4=True,
+            dhcp6=False,
+        )
+        self.url = reverse("plugins:netbox_kea:server_dhcp_plugin_sync", args=[self.server.pk])
+
+    def test_post_imports_and_reports(self):
+        conf = {
+            4: {
+                "subnet4": [
+                    {"id": 1, "subnet": "10.88.0.0/24", "pools": [{"pool": "10.88.0.10-10.88.0.99"}]},
+                ]
+            }
+        }
+        fake = _FakeKeaClient(conf)
+        with patch("netbox_kea.models.Server.get_client", return_value=fake):
+            resp = self.client.post(self.url, follow=True)
+
+        self.assertContains(resp, "1 subnets created")
+        Subnet = apps.get_model(DHCP_PLUGIN, "Subnet")
+        self.assertTrue(Subnet.objects.filter(prefix__prefix="10.88.0.0/24").exists())
+
+    def test_drift_view_renders_imported_status(self):
+        conf = {4: {"subnet4": [{"id": 1, "subnet": "10.88.0.0/24"}]}}
+        fake = _FakeKeaClient(conf)
+        with patch("netbox_kea.models.Server.get_client", return_value=fake):
+            self.client.post(self.url, follow=True)
+            tab_url = reverse("plugins:netbox_kea:server_dhcp_plugin", args=[self.server.pk])
+            resp = self.client.get(tab_url)
+        self.assertContains(resp, "Imported")
+        self.assertContains(resp, "10.88.0.0/24")

--- a/netbox_kea/tests/test_views_dhcp_plugin.py
+++ b/netbox_kea/tests/test_views_dhcp_plugin.py
@@ -16,6 +16,7 @@ from django.test import SimpleTestCase, TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 
+from netbox_kea.kea import KeaClient
 from netbox_kea.views import dhcp_plugin_sync as dps
 
 from .utils import _make_db_server
@@ -24,16 +25,25 @@ DHCP_PLUGIN = "netbox_dhcp"
 _PLUGINS_CONFIG = {"netbox_kea": {"kea_timeout": 30}}
 
 
-class _FakeKeaClient:
-    """Minimal stand-in for KeaClient that answers ``config-get`` only."""
+class _FakeKeaClient(KeaClient):
+    """Stand-in for KeaClient that answers ``config-get`` and ``reservation-get-page``.
 
-    def __init__(self, conf_by_version: dict[int, dict]):
+    Subclasses the real client (and skips its session setup) so the genuine
+    ``reservation_get_page``/``iter_reservations`` pagination logic runs against the
+    faked ``command`` — only the Kea HTTP boundary is replaced, never the ORM.
+    """
+
+    def __init__(self, conf_by_version: dict[int, dict], hosts_by_version: dict[int, list] | None = None):
         self._conf = conf_by_version
+        self._hosts = hosts_by_version or {}
 
-    def command(self, cmd, service=None, arguments=None):
-        if cmd == "config-get":
-            version = 6 if service and service[0] == "dhcp6" else 4
+    def command(self, command, service=None, arguments=None, check=(0,)):
+        version = 6 if service and service[0] == "dhcp6" else 4
+        if command == "config-get":
             return [{"result": 0, "arguments": {f"Dhcp{version}": self._conf.get(version, {})}}]
+        if command == "reservation-get-page":
+            hosts = self._hosts.get(version, [])
+            return [{"result": 0, "arguments": {"hosts": hosts, "next": {"from": 0, "source-index": 0}}}]
         return [{"result": 0, "arguments": {}}]
 
 
@@ -151,6 +161,23 @@ class SyncNowEndToEndTest(TestCase):
 
         ct = ContentType.objects.get_for_model(Subnet)
         self.assertTrue(Option.objects.filter(assigned_object_type=ct, assigned_object_id=subnet.pk).exists())
+
+    def test_post_imports_db_backed_reservations(self):
+        # Subnet is in config-get; the reservation lives ONLY in the hosts DB
+        # (reservation-get-page) — the case config-get-only import was missing.
+        conf = {4: {"subnet4": [{"id": 1, "subnet": "10.89.0.0/24"}]}}
+        hosts = {
+            4: [{"subnet-id": 1, "hw-address": "aa:bb:cc:dd:ee:89", "ip-address": "10.89.0.50", "hostname": "db-res"}]
+        }
+        fake = _FakeKeaClient(conf, hosts)
+        with patch("netbox_kea.models.Server.get_client", return_value=fake):
+            resp = self.client.post(self.url, follow=True)
+
+        self.assertContains(resp, "1 reservations created")
+        Subnet = apps.get_model(DHCP_PLUGIN, "Subnet")
+        HostReservation = apps.get_model(DHCP_PLUGIN, "HostReservation")
+        subnet = Subnet.objects.get(prefix__prefix="10.89.0.0/24")
+        self.assertTrue(HostReservation.objects.filter(subnet=subnet, hostname="db-res").exists())
 
     def test_drift_view_renders_imported_status(self):
         conf = {4: {"subnet4": [{"id": 1, "subnet": "10.88.0.0/24"}]}}

--- a/netbox_kea/tests/test_views_dhcp_plugin.py
+++ b/netbox_kea/tests/test_views_dhcp_plugin.py
@@ -58,20 +58,36 @@ class _FakeKeaClient(KeaClient):
 
 
 class ExtractDhcpConfTest(SimpleTestCase):
-    """`_extract_dhcp_conf` pulls the right block and rejects malformed shapes."""
+    """`_extract_dhcp_conf` pulls the right block and *raises* on malformed shapes."""
 
     def test_extracts_dhcp4_block(self):
         resp = [{"result": 0, "arguments": {"Dhcp4": {"subnet4": []}}}]
         self.assertEqual(dps._extract_dhcp_conf(resp, 4), {"subnet4": []})
 
     def test_wrong_result_code_returns_none(self):
+        # A non-zero Kea result is a legitimate "no config", not a contract failure.
         self.assertIsNone(dps._extract_dhcp_conf([{"result": 1, "arguments": {"Dhcp4": {}}}], 4))
 
-    def test_non_list_returns_none(self):
-        self.assertIsNone(dps._extract_dhcp_conf({"not": "a list"}, 4))
-
     def test_missing_block_returns_none(self):
+        # The version's block simply being absent is legitimate "no config".
         self.assertIsNone(dps._extract_dhcp_conf([{"result": 0, "arguments": {}}], 6))
+
+    def test_non_list_raises(self):
+        # Malformed *shape* must surface, not be silently downgraded to "no config".
+        with self.assertRaises(RuntimeError):
+            dps._extract_dhcp_conf({"not": "a list"}, 4)
+
+    def test_empty_list_raises(self):
+        with self.assertRaises(RuntimeError):
+            dps._extract_dhcp_conf([], 4)
+
+    def test_non_dict_item_raises(self):
+        with self.assertRaises(RuntimeError):
+            dps._extract_dhcp_conf(["not-a-dict"], 4)
+
+    def test_non_dict_arguments_raises(self):
+        with self.assertRaises(RuntimeError):
+            dps._extract_dhcp_conf([{"result": 0, "arguments": ["not", "a", "dict"]}], 4)
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
@@ -208,3 +224,68 @@ class SyncNowEndToEndTest(TestCase):
         self.assertContains(resp, "10.88.0.0/24")
         # The tab warns that Kea shared-networks are a different concept (not imported as such).
         self.assertContains(resp, "different concept")
+
+
+class _MalformedConfigClient(KeaClient):
+    """Fake client whose ``config-get`` returns a malformed (non-list) shape."""
+
+    def __init__(self):
+        pass
+
+    def command(self, command, service=None, arguments=None, check=(0,)):
+        return {"not": "a list"}
+
+
+@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
+class FetchConfigIntentTest(TestCase):
+    """`_fetch_config_intent` surfaces a malformed config-get as a logged skip, not a crash."""
+
+    def setUp(self):
+        self.server = _make_db_server(dhcp4=True, dhcp6=False)
+
+    def test_malformed_config_get_is_logged_and_skipped(self):
+        with patch("netbox_kea.models.Server.get_client", return_value=_MalformedConfigClient()):
+            with self.assertLogs("netbox_kea.views.dhcp_plugin_sync", level="WARNING") as cm:
+                result = dps._fetch_config_intent(self.server, 4)
+        # Malformed shape → RuntimeError raised in _extract_dhcp_conf, caught here as a
+        # read failure: the version is skipped (None) and the problem is logged, not
+        # silently downgraded to "no config".
+        self.assertIsNone(result)
+        self.assertTrue(any("config-get failed" in line for line in cm.output))
+
+
+@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
+class SyncNowErrorHandlingTest(TestCase):
+    """The sync action follows the exception contract and never leaks a traceback."""
+
+    def setUp(self):
+        from django.contrib.auth import get_user_model
+
+        User = get_user_model()
+        self.user = User.objects.create_superuser("dps-err", "err@example.com", "pw")
+        self.client.force_login(self.user)
+        self.server = _make_db_server(sync_dhcp_plugin_enabled=True, dhcp4=True, dhcp6=False)
+        self.url = reverse("plugins:netbox_kea:server_dhcp_plugin_sync", args=[self.server.pk])
+
+    def test_kea_exception_routes_through_specific_handler(self):
+        # A KeaException (or its PartialPersistError subclass) is handled by the
+        # dedicated contract branch, logged distinctly, and shown as a generic error.
+        with (
+            patch.object(dps.dhcp_plugin, "is_available", return_value=True),
+            patch.object(dps, "run_dhcp_plugin_import", side_effect=KeaException({"result": 1, "text": "boom"})),
+        ):
+            with self.assertLogs("netbox_kea.views.dhcp_plugin_sync", level="ERROR") as cm:
+                resp = self.client.post(self.url, follow=True)
+        self.assertContains(resp, "An internal error occurred")
+        self.assertTrue(any("Kea read/validation" in line for line in cm.output))
+
+    def test_unexpected_exception_is_caught_not_leaked(self):
+        # A non-contract error (e.g. a DB error) still hits the fallback: logged,
+        # never surfaced as a 500 traceback.
+        with (
+            patch.object(dps.dhcp_plugin, "is_available", return_value=True),
+            patch.object(dps, "run_dhcp_plugin_import", side_effect=RuntimeError("db gone")),
+        ):
+            resp = self.client.post(self.url, follow=True)
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "An internal error occurred")

--- a/netbox_kea/tests/test_views_dhcp_plugin.py
+++ b/netbox_kea/tests/test_views_dhcp_plugin.py
@@ -149,3 +149,5 @@ class SyncNowEndToEndTest(TestCase):
             resp = self.client.get(tab_url)
         self.assertContains(resp, "Imported")
         self.assertContains(resp, "10.88.0.0/24")
+        # The tab warns that Kea shared-networks are a different concept (not imported as such).
+        self.assertContains(resp, "different concept")

--- a/netbox_kea/tests/test_views_leases.py
+++ b/netbox_kea/tests/test_views_leases.py
@@ -2186,6 +2186,19 @@ class TestFetchReservationByIP(_ViewTestBase):
         self.assertIn("10.0.0.1", result)
         self.assertIn("10.0.0.2", result)
 
+    def test_malformed_ip_fields_do_not_crash_rendering(self):
+        """A null/non-list ``ip-addresses`` (or null ``ip-address``) must be tolerated, not TypeError."""
+        page = [
+            {"subnet-id": 1, "ip-address": "10.0.0.5", "hw-address": "aa:bb:cc:dd:ee:01"},
+            {"subnet-id": 1, "ip-addresses": None, "hw-address": "aa:bb:cc:dd:ee:02"},  # null → no crash
+            {"subnet-id": 1, "ip-addresses": ["2001:db8::1", None, 7], "duid": "00:01"},  # mixed
+            {"subnet-id": 1, "ip-address": None, "hw-address": "aa:bb:cc:dd:ee:03"},  # null ip-address ignored
+        ]
+        result, available = self._run([(page, 0, 0)])
+        self.assertTrue(available)
+        # Only the well-formed string addresses are mapped; None/non-str are skipped.
+        self.assertEqual(set(result), {"10.0.0.5", "2001:db8::1"})
+
 
 # ---------------------------------------------------------------------------
 # _enrich_leases_with_badges — exception paths

--- a/netbox_kea/urls.py
+++ b/netbox_kea/urls.py
@@ -37,6 +37,11 @@ urlpatterns = (
     path("sync-jobs/", views.SyncJobsView.as_view(), name="sync_jobs"),
     path("servers/<int:pk>/sync-now/", views.ServerSyncNowView.as_view(), name="server_sync_now"),
     path("servers/<int:pk>/sync-toggle/", views.ServerSyncToggleView.as_view(), name="server_sync_toggle"),
+    path(
+        "servers/<int:pk>/dhcp-plugin/sync/",
+        views.ServerDhcpPluginSyncNowView.as_view(),
+        name="server_dhcp_plugin_sync",
+    ),
     path("servers/", views.ServerListView.as_view(), name="server_list"),
     path("servers/add/", views.ServerEditView.as_view(), name="server_add"),
     path(

--- a/netbox_kea/views/__init__.py
+++ b/netbox_kea/views/__init__.py
@@ -32,6 +32,12 @@ from .dhcp_control import (  # noqa: F401
     ServerDHCP6EnableView,
 )
 
+# Sync job management views
+from .dhcp_plugin_sync import (  # noqa: F401
+    ServerDhcpPluginSyncNowView,
+    ServerDhcpPluginView,
+)
+
 # Lease list/delete/add/sync views + low-level helpers
 from .leases import (  # noqa: F401
     BaseServerLeasesDeleteView,
@@ -127,8 +133,6 @@ from .subnets import (  # noqa: F401
     _warn_pool_reservation_overlap,
     _warn_reservation_pool_overlap,
 )
-
-# Sync job management views
 from .sync_jobs import (  # noqa: F401
     ServerSyncNowView,
     ServerSyncStatusView,

--- a/netbox_kea/views/combined.py
+++ b/netbox_kea/views/combined.py
@@ -12,7 +12,7 @@ from django.urls import reverse
 from django.views import View
 
 from .. import constants, forms, tables
-from ..kea import KeaException
+from ..kea import KeaException, iter_reservations
 from ..models import Server
 from ..utilities import (
     _enrich_reservation_sort_key,
@@ -457,25 +457,13 @@ def _fetch_reservations_from_server(server: "Server", version: int) -> list[dict
     service = f"dhcp{version}"
     client = server.get_client(version=version)
     reservations: list[dict[str, Any]] = []
-    from_index = 0
-    source_index = 0
-    while True:
-        page, next_from, next_source = client.reservation_get_page(
-            service, source_index=source_index, from_index=from_index, limit=100
-        )
-        for r in page:
-            r.setdefault("subnet_id", r.get("subnet-id", 0))
-            r.setdefault(
-                "ip_address", r.get("ip-address", r.get("ip-addresses", [""])[0] if r.get("ip-addresses") else "")
-            )
-            r["server_name"] = server.name
-            r["server_pk"] = server.pk
-            _enrich_reservation_sort_key(r)
-        reservations.extend(page)
-        if next_from == 0 and next_source == 0:
-            break
-        from_index = next_from
-        source_index = next_source
+    for r in iter_reservations(client, service):
+        r.setdefault("subnet_id", r.get("subnet-id", 0))
+        r.setdefault("ip_address", r.get("ip-address", r.get("ip-addresses", [""])[0] if r.get("ip-addresses") else ""))
+        r["server_name"] = server.name
+        r["server_pk"] = server.pk
+        _enrich_reservation_sort_key(r)
+        reservations.append(r)
     return reservations
 
 

--- a/netbox_kea/views/dhcp_plugin_sync.py
+++ b/netbox_kea/views/dhcp_plugin_sync.py
@@ -219,18 +219,21 @@ class ServerDhcpPluginSyncNowView(View):
                 f"DHCPv{version}: {summary.subnets_created} subnets created, "
                 f"{summary.subnets_updated} updated, {summary.pools_created} pools, "
                 f"{summary.reservations_created} reservations created, "
-                f"{summary.reservations_updated} updated"
+                f"{summary.reservations_updated} updated, "
+                f"{summary.options_created} options created, {summary.options_updated} updated"
             )
-            deferred = []
+            notes = []
+            if summary.option_defs_created:
+                notes.append(f"{summary.option_defs_created} custom option definition(s) created")
+            if summary.options_skipped:
+                notes.append(f"{summary.options_skipped} option(s) skipped (unresolved/invalid)")
             if summary.shared_networks_deferred:
-                deferred.append(
+                notes.append(
                     f"{summary.shared_networks_deferred} shared-network subnet(s) imported "
                     "individually (grouping not represented)"
                 )
-            if summary.options_deferred:
-                deferred.append(f"{summary.options_deferred} options skipped")
-            if deferred:
-                text += f" ({'; '.join(deferred)})"
+            if notes:
+                text += f" ({'; '.join(notes)})"
             if summary.errors:
                 messages.warning(request, f"{text} — {summary.errors} errors (see logs).")
             else:

--- a/netbox_kea/views/dhcp_plugin_sync.py
+++ b/netbox_kea/views/dhcp_plugin_sync.py
@@ -220,7 +220,9 @@ class ServerDhcpPluginSyncNowView(View):
                 f"{summary.subnets_updated} updated, {summary.pools_created} pools, "
                 f"{summary.reservations_created} reservations created, "
                 f"{summary.reservations_updated} updated, "
-                f"{summary.options_created} options created, {summary.options_updated} updated"
+                f"{summary.options_created} options created, {summary.options_updated} updated, "
+                f"{summary.client_classes_created} client classes created, "
+                f"{summary.client_classes_updated} updated"
             )
             notes = []
             if summary.option_defs_created:

--- a/netbox_kea/views/dhcp_plugin_sync.py
+++ b/netbox_kea/views/dhcp_plugin_sync.py
@@ -223,9 +223,12 @@ class ServerDhcpPluginSyncNowView(View):
             )
             deferred = []
             if summary.shared_networks_deferred:
-                deferred.append(f"{summary.shared_networks_deferred} shared-network subnets flattened")
+                deferred.append(
+                    f"{summary.shared_networks_deferred} shared-network subnet(s) imported "
+                    "individually (grouping not represented)"
+                )
             if summary.options_deferred:
-                deferred.append(f"{summary.options_deferred} options deferred")
+                deferred.append(f"{summary.options_deferred} options skipped")
             if deferred:
                 text += f" ({'; '.join(deferred)})"
             if summary.errors:

--- a/netbox_kea/views/dhcp_plugin_sync.py
+++ b/netbox_kea/views/dhcp_plugin_sync.py
@@ -21,8 +21,8 @@ from netbox.views import generic
 from utilities.views import register_model_view
 
 from ..integrations import dhcp_plugin
-from ..kea import KeaException
-from ..mappers.kea_to_dhcp import parse_dhcp_config
+from ..kea import KeaException, iter_reservations
+from ..mappers.kea_to_dhcp import parse_dhcp_config, parse_reservations_page
 from ..models import Server
 from ..utilities import OptionalViewTab
 
@@ -56,10 +56,14 @@ def _extract_dhcp_conf(resp, version: int) -> dict | None:
     return conf if isinstance(conf, dict) else None
 
 
-def _fetch_config_intent(server: Server, version: int):
+def _fetch_config_intent(server: Server, version: int, *, with_reservations: bool = False):
     """Read live ``config-get`` for one version and parse it to intent (read-only).
 
-    Returns the :class:`ServerConfigIntent`, or ``None`` if Kea could not be read.
+    ``config-get`` is issued exactly once here.  When *with_reservations* is set, the
+    DB-backed host reservations are also drained (``reservation-get-page``) **on the
+    same client** and attached to the intent — they never appear in ``config-get``
+    when a hosts database is used.  Returns the :class:`ServerConfigIntent`, or
+    ``None`` if Kea could not be read.
     """
     try:
         client = server.get_client(version=version)
@@ -70,7 +74,26 @@ def _fetch_config_intent(server: Server, version: int):
     conf = _extract_dhcp_conf(resp, version)
     if conf is None:
         return None
-    return parse_dhcp_config(conf, version)
+    intent = parse_dhcp_config(conf, version)
+    if with_reservations:
+        intent.page_reservations = _fetch_reservation_pages(client, version, server)
+    return intent
+
+
+def _fetch_reservation_pages(client, version: int, server: Server) -> dict:
+    """Drain DB-backed host reservations via ``reservation-get-page``, grouped by subnet-id.
+
+    Returns ``{}`` (and logs) when the ``host_cmds`` hook is absent or Kea cannot be
+    read — a missing hosts backend is not an error for the import.
+    """
+    try:
+        hosts = list(iter_reservations(client, f"dhcp{version}"))
+    except (KeaException, requests.RequestException, ValueError):
+        logger.warning(
+            "DHCP-plugin sync: reservation-get-page failed for %s (v%s)", server.name, version, exc_info=True
+        )
+        return {}
+    return parse_reservations_page(hosts, version)
 
 
 def run_dhcp_plugin_import(server: Server) -> list[tuple[int, object]]:
@@ -80,7 +103,7 @@ def run_dhcp_plugin_import(server: Server) -> list[tuple[int, object]]:
     """
     results: list[tuple[int, object]] = []
     for version in _enabled_versions(server):
-        intent = _fetch_config_intent(server, version)
+        intent = _fetch_config_intent(server, version, with_reservations=True)
         if intent is None:
             continue
         results.append((version, dhcp_plugin.import_server_config(server, intent)))

--- a/netbox_kea/views/dhcp_plugin_sync.py
+++ b/netbox_kea/views/dhcp_plugin_sync.py
@@ -1,0 +1,235 @@
+# SPDX-FileCopyrightText: 2025 Marcin Zieba <marcinpsk@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+"""Views for the optional "Sync to DHCP plugin" integration (import + drift, v1).
+
+These are inert unless the NetBox DHCP plugin (``netbox_dhcp``) is installed and
+the server has ``sync_dhcp_plugin_enabled`` set: the per-server tab hides itself
+and the sync action refuses.  All reads against Kea are read-only (``config-get``).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import requests
+from django.contrib import messages
+from django.http import HttpResponseForbidden, HttpResponseRedirect
+from django.shortcuts import get_object_or_404
+from django.urls import reverse
+from django.views import View
+from netbox.views import generic
+from utilities.views import register_model_view
+
+from ..integrations import dhcp_plugin
+from ..kea import KeaException
+from ..mappers.kea_to_dhcp import parse_dhcp_config
+from ..models import Server
+from ..utilities import OptionalViewTab
+
+logger = logging.getLogger(__name__)
+
+
+def _tab_enabled(server: Server) -> bool:
+    """Show the DHCP-plugin tab only when the plugin is installed and the server opts in."""
+    return dhcp_plugin.is_available() and server.sync_dhcp_plugin_enabled
+
+
+def _enabled_versions(server: Server) -> list[int]:
+    """Return the DHCP protocol versions enabled on *server* (4 and/or 6)."""
+    versions = []
+    if server.dhcp4:
+        versions.append(4)
+    if server.dhcp6:
+        versions.append(6)
+    return versions
+
+
+def _extract_dhcp_conf(resp, version: int) -> dict | None:
+    """Pull the ``Dhcp4``/``Dhcp6`` block out of a ``config-get`` response, or ``None``."""
+    dhcp_key = f"Dhcp{version}"
+    if not isinstance(resp, list) or not resp or not isinstance(resp[0], dict):
+        return None
+    if resp[0].get("result") != 0:
+        return None
+    args = resp[0].get("arguments") or {}
+    conf = args.get(dhcp_key) if isinstance(args, dict) else None
+    return conf if isinstance(conf, dict) else None
+
+
+def _fetch_config_intent(server: Server, version: int):
+    """Read live ``config-get`` for one version and parse it to intent (read-only).
+
+    Returns the :class:`ServerConfigIntent`, or ``None`` if Kea could not be read.
+    """
+    try:
+        client = server.get_client(version=version)
+        resp = client.command("config-get", service=[f"dhcp{version}"])
+    except (KeaException, requests.RequestException, ValueError):
+        logger.warning("DHCP-plugin sync: config-get failed for %s (v%s)", server.name, version, exc_info=True)
+        return None
+    conf = _extract_dhcp_conf(resp, version)
+    if conf is None:
+        return None
+    return parse_dhcp_config(conf, version)
+
+
+def run_dhcp_plugin_import(server: Server) -> list[tuple[int, object]]:
+    """Import every enabled version's live Kea config into the DHCP plugin.
+
+    Returns a list of ``(version, ImportSummary)`` for the versions that were read.
+    """
+    results: list[tuple[int, object]] = []
+    for version in _enabled_versions(server):
+        intent = _fetch_config_intent(server, version)
+        if intent is None:
+            continue
+        results.append((version, dhcp_plugin.import_server_config(server, intent)))
+    return results
+
+
+def compute_drift(server: Server) -> dict:
+    """Compare live Kea subnets against the imported DHCP-plugin records.
+
+    Returns ``{"versions": [...], "kea_unreachable": bool}`` where each version
+    entry lists subnet rows tagged ``imported`` (in both), ``new`` (in Kea, not
+    yet imported), or ``orphaned`` (imported, no longer in Kea).
+    """
+    from ..models import KeaDhcpLink
+
+    versions = []
+    kea_unreachable = False
+    for version in _enabled_versions(server):
+        intent = _fetch_config_intent(server, version)
+        links = {
+            link.kea_subnet_id: link
+            for link in KeaDhcpLink.objects.filter(server=server, family=version, kea_subnet_id__isnull=False)
+        }
+        rows = []
+        if intent is None:
+            kea_unreachable = True
+            # Without a live read we can still list what was imported before.
+            for sid, link in sorted(links.items()):
+                rows.append(
+                    {
+                        "kea_subnet_id": sid,
+                        "cidr": _link_cidr(link),
+                        "status": "unknown",
+                        "pools": "—",
+                        "reservations": "—",
+                    }
+                )
+            versions.append({"version": version, "rows": rows, "live": False})
+            continue
+
+        live_ids = set()
+        for subnet in intent.subnets:
+            live_ids.add(subnet.kea_subnet_id)
+            rows.append(
+                {
+                    "kea_subnet_id": subnet.kea_subnet_id,
+                    "cidr": subnet.cidr,
+                    "status": "imported" if subnet.kea_subnet_id in links else "new",
+                    "pools": len(subnet.pools),
+                    "reservations": len(subnet.reservations),
+                }
+            )
+        for sid, link in sorted(links.items()):
+            if sid not in live_ids:
+                rows.append(
+                    {
+                        "kea_subnet_id": sid,
+                        "cidr": _link_cidr(link),
+                        "status": "orphaned",
+                        "pools": "—",
+                        "reservations": "—",
+                    }
+                )
+        versions.append({"version": version, "rows": rows, "live": True})
+
+    return {"versions": versions, "kea_unreachable": kea_unreachable}
+
+
+def _link_cidr(link) -> str:
+    """Best-effort CIDR for a link's imported subnet (the DHCP-plugin prefix)."""
+    obj = link.sys4_object
+    prefix = getattr(obj, "prefix", None)
+    return str(getattr(prefix, "prefix", "")) if prefix is not None else ""
+
+
+_DHCP_PLUGIN_TAB = OptionalViewTab(label="DHCP Plugin", weight=1060, is_enabled=_tab_enabled)
+
+
+@register_model_view(Server, "dhcp_plugin")
+class ServerDhcpPluginView(generic.ObjectView):
+    """Per-server tab: import status + drift between live Kea and DHCP-plugin records."""
+
+    queryset = Server.objects.all()
+    tab = _DHCP_PLUGIN_TAB
+    template_name = "netbox_kea/server_dhcp_plugin.html"
+
+    def get_extra_context(self, request, instance):
+        """Return drift context for the template (live, read-only Kea read)."""
+        return {
+            "plugin_available": dhcp_plugin.is_available(),
+            "drift": compute_drift(instance) if dhcp_plugin.is_available() else None,
+            "can_sync": _user_can_sync(request.user, instance),
+        }
+
+
+def _user_can_sync(user, server: Server) -> bool:
+    """Sync requires server change + IPAM add/change (the DHCP-plugin rows share IPAM)."""
+    return (
+        user.has_perm("netbox_kea.change_server")
+        and user.has_perm("ipam.add_ipaddress")
+        and user.has_perm("ipam.change_ipaddress")
+        and Server.objects.restrict(user, "change").filter(pk=server.pk).exists()
+    )
+
+
+class ServerDhcpPluginSyncNowView(View):
+    """POST-only: import this server's live Kea data-tier config into the DHCP plugin."""
+
+    def post(self, request, pk):
+        """Run the import and report a per-version summary."""
+        server = get_object_or_404(Server.objects.restrict(request.user, "view"), pk=pk)
+        redirect = HttpResponseRedirect(reverse("plugins:netbox_kea:server_dhcp_plugin", args=[pk]))
+
+        if not dhcp_plugin.is_available():
+            messages.error(request, "The NetBox DHCP plugin (netbox_dhcp) is not installed.")
+            return redirect
+        if not server.sync_dhcp_plugin_enabled:
+            messages.error(request, "Enable 'Sync to DHCP plugin' on this server first.")
+            return redirect
+        if not _user_can_sync(request.user, server):
+            return HttpResponseForbidden("You do not have permission to sync to the DHCP plugin.")
+
+        try:
+            results = run_dhcp_plugin_import(server)
+        except Exception:
+            logger.exception("DHCP-plugin import failed for server %s", server.name)
+            messages.error(request, "An internal error occurred during the DHCP-plugin import.")
+            return redirect
+
+        if not results:
+            messages.warning(request, "No Kea configuration could be read (is the server reachable?).")
+            return redirect
+
+        for version, summary in results:
+            text = (
+                f"DHCPv{version}: {summary.subnets_created} subnets created, "
+                f"{summary.subnets_updated} updated, {summary.pools_created} pools, "
+                f"{summary.reservations_created} reservations created, "
+                f"{summary.reservations_updated} updated"
+            )
+            deferred = []
+            if summary.shared_networks_deferred:
+                deferred.append(f"{summary.shared_networks_deferred} shared-network subnets flattened")
+            if summary.options_deferred:
+                deferred.append(f"{summary.options_deferred} options deferred")
+            if deferred:
+                text += f" ({'; '.join(deferred)})"
+            if summary.errors:
+                messages.warning(request, f"{text} — {summary.errors} errors (see logs).")
+            else:
+                messages.success(request, text + ".")
+        return redirect

--- a/netbox_kea/views/dhcp_plugin_sync.py
+++ b/netbox_kea/views/dhcp_plugin_sync.py
@@ -45,14 +45,22 @@ def _enabled_versions(server: Server) -> list[int]:
 
 
 def _extract_dhcp_conf(resp, version: int) -> dict | None:
-    """Pull the ``Dhcp4``/``Dhcp6`` block out of a ``config-get`` response, or ``None``."""
+    """Pull the ``Dhcp4``/``Dhcp6`` block out of a ``config-get`` response, or ``None``.
+
+    Raises ``RuntimeError`` on a malformed response *shape* so a protocol/contract
+    failure is surfaced rather than silently downgraded to "no config". Returns
+    ``None`` only for the legitimate cases: a non-zero Kea ``result`` or this
+    version's block simply being absent.
+    """
     dhcp_key = f"Dhcp{version}"
     if not isinstance(resp, list) or not resp or not isinstance(resp[0], dict):
-        return None
+        raise RuntimeError("Malformed Kea config-get response: expected a non-empty list of dicts")
     if resp[0].get("result") != 0:
         return None
     args = resp[0].get("arguments") or {}
-    conf = args.get(dhcp_key) if isinstance(args, dict) else None
+    if not isinstance(args, dict):
+        raise RuntimeError("Malformed Kea config-get response: 'arguments' must be a dict")
+    conf = args.get(dhcp_key)
     return conf if isinstance(conf, dict) else None
 
 
@@ -68,10 +76,10 @@ def _fetch_config_intent(server: Server, version: int, *, with_reservations: boo
     try:
         client = server.get_client(version=version)
         resp = client.command("config-get", service=[f"dhcp{version}"])
-    except (KeaException, requests.RequestException, ValueError):
+        conf = _extract_dhcp_conf(resp, version)
+    except (KeaException, requests.RequestException, ValueError, RuntimeError):
         logger.warning("DHCP-plugin sync: config-get failed for %s (v%s)", server.name, version, exc_info=True)
         return None
-    conf = _extract_dhcp_conf(resp, version)
     if conf is None:
         return None
     intent = parse_dhcp_config(conf, version)
@@ -231,7 +239,13 @@ class ServerDhcpPluginSyncNowView(View):
 
         try:
             results = run_dhcp_plugin_import(server)
-        except Exception:
+        except (KeaException, requests.RequestException, ValueError):
+            # Expected external-boundary failures (Kea read / validation);
+            # PartialPersistError is a KeaException subclass and lands here too.
+            logger.exception("DHCP-plugin import failed for server %s (Kea read/validation)", server.name)
+            messages.error(request, "An internal error occurred during the DHCP-plugin import.")
+            return redirect
+        except Exception:  # noqa: BLE001 — DB/unexpected errors are logged here, never leaked as a 500 traceback
             logger.exception("DHCP-plugin import failed for server %s", server.name)
             messages.error(request, "An internal error occurred during the DHCP-plugin import.")
             return redirect

--- a/netbox_kea/views/dhcp_plugin_sync.py
+++ b/netbox_kea/views/dhcp_plugin_sync.py
@@ -76,15 +76,18 @@ def _fetch_config_intent(server: Server, version: int, *, with_reservations: boo
         return None
     intent = parse_dhcp_config(conf, version)
     if with_reservations:
-        intent.page_reservations = _fetch_reservation_pages(client, version, server)
+        pages, available = _fetch_reservation_pages(client, version, server)
+        intent.page_reservations = pages
+        intent.reservations_unavailable = not available
     return intent
 
 
-def _fetch_reservation_pages(client, version: int, server: Server) -> dict:
+def _fetch_reservation_pages(client, version: int, server: Server) -> tuple[dict, bool]:
     """Drain DB-backed host reservations via ``reservation-get-page``, grouped by subnet-id.
 
-    Returns ``{}`` (and logs) when the ``host_cmds`` hook is absent or Kea cannot be
-    read — a missing hosts backend is not an error for the import.
+    Returns ``({}, False)`` (and logs) when the ``host_cmds`` hook is absent or Kea
+    cannot be read — a missing hosts backend is not a hard error for the import, but
+    the ``False`` lets the caller report that DB-backed reservations may be missing.
     """
     try:
         hosts = list(iter_reservations(client, f"dhcp{version}"))
@@ -92,8 +95,8 @@ def _fetch_reservation_pages(client, version: int, server: Server) -> dict:
         logger.warning(
             "DHCP-plugin sync: reservation-get-page failed for %s (v%s)", server.name, version, exc_info=True
         )
-        return {}
-    return parse_reservations_page(hosts, version)
+        return {}, False
+    return parse_reservations_page(hosts, version), True
 
 
 def run_dhcp_plugin_import(server: Server) -> list[tuple[int, object]]:
@@ -259,7 +262,13 @@ class ServerDhcpPluginSyncNowView(View):
                 )
             if notes:
                 text += f" ({'; '.join(notes)})"
-            if summary.errors:
+            if summary.reservations_unread:
+                messages.warning(
+                    request,
+                    f"{text} — DB-backed host reservations could not be read "
+                    "(is the host_cmds hook loaded?); reservation counts may be incomplete.",
+                )
+            elif summary.errors:
                 messages.warning(request, f"{text} — {summary.errors} errors (see logs).")
             else:
                 messages.success(request, text + ".")

--- a/netbox_kea/views/leases.py
+++ b/netbox_kea/views/leases.py
@@ -1130,11 +1130,16 @@ def _fetch_reservation_by_ip(client: KeaClient, version: int) -> tuple[dict[str,
     """
     reservation_by_ip: dict[str, dict] = {}
     for r in iter_reservations(client, f"dhcp{version}", limit=1000):
-        if "ip-address" in r:
-            reservation_by_ip[r["ip-address"]] = r
-        elif "ip-addresses" in r:
-            for addr in r["ip-addresses"]:
-                reservation_by_ip[addr] = r
+        # Normalize: Kea may send a null/non-list ip-addresses; iterating it raw
+        # would TypeError and break lease-page rendering.
+        ip = r.get("ip-address")
+        if isinstance(ip, str) and ip:
+            reservation_by_ip[ip] = r
+        raw_addrs = r.get("ip-addresses")
+        if isinstance(raw_addrs, list):
+            for addr in raw_addrs:
+                if isinstance(addr, str) and addr:
+                    reservation_by_ip[addr] = r
     return reservation_by_ip, True
 
 

--- a/netbox_kea/views/leases.py
+++ b/netbox_kea/views/leases.py
@@ -25,7 +25,7 @@ from utilities.paginator import EnhancedPaginator, get_paginate_count
 from utilities.views import GetReturnURLMixin, register_model_view
 
 from .. import constants, forms, tables
-from ..kea import KeaClient, KeaException
+from ..kea import KeaClient, KeaException, iter_reservations
 from ..models import Server
 from ..signals import lease_added, leases_deleted
 from ..sync import sync_lease_to_netbox
@@ -1129,22 +1129,12 @@ def _fetch_reservation_by_ip(client: KeaClient, version: int) -> tuple[dict[str,
     Returns ``(reservation_by_ip, host_cmds_available)``.
     """
     reservation_by_ip: dict[str, dict] = {}
-    from_index = 0
-    source_index = 0
-    while True:
-        page, next_from, next_source = client.reservation_get_page(
-            f"dhcp{version}", limit=1000, source_index=source_index, from_index=from_index
-        )
-        for r in page:
-            if "ip-address" in r:
-                reservation_by_ip[r["ip-address"]] = r
-            elif "ip-addresses" in r:
-                for addr in r["ip-addresses"]:
-                    reservation_by_ip[addr] = r
-        if next_from == 0 and next_source == 0:
-            break
-        from_index = next_from
-        source_index = next_source
+    for r in iter_reservations(client, f"dhcp{version}", limit=1000):
+        if "ip-address" in r:
+            reservation_by_ip[r["ip-address"]] = r
+        elif "ip-addresses" in r:
+            for addr in r["ip-addresses"]:
+                reservation_by_ip[addr] = r
     return reservation_by_ip, True
 
 

--- a/netbox_kea/views/reservations.py
+++ b/netbox_kea/views/reservations.py
@@ -15,7 +15,7 @@ from netbox.views import generic
 from utilities.views import register_model_view
 
 from .. import forms, tables
-from ..kea import KeaClient, KeaException, PartialPersistError
+from ..kea import KeaClient, KeaException, PartialPersistError, iter_reservations
 from ..models import Server
 from ..signals import reservation_created, reservation_deleted, reservation_updated
 from ..sync import sync_reservation_to_netbox
@@ -367,16 +367,7 @@ class ServerReservations4View(generic.ObjectView):
         reservations: list[dict] = []
         try:
             client = server.get_client(version=4)
-            source_index, from_index, limit = 0, 0, 100
-            while True:
-                page, next_from, next_source = client.reservation_get_page(
-                    "dhcp4", source_index=source_index, from_index=from_index, limit=limit
-                )
-                reservations.extend(page)
-                if next_from == 0 and next_source == 0:
-                    break
-                from_index = next_from
-                source_index = next_source
+            reservations = list(iter_reservations(client, "dhcp4"))
         except KeaException as exc:
             if exc.response.get("result") == 2:
                 hook_available = False
@@ -443,16 +434,7 @@ class ServerReservations6View(generic.ObjectView):
         reservations: list[dict] = []
         try:
             client = server.get_client(version=6)
-            source_index, from_index, limit = 0, 0, 100
-            while True:
-                page, next_from, next_source = client.reservation_get_page(
-                    "dhcp6", source_index=source_index, from_index=from_index, limit=limit
-                )
-                reservations.extend(page)
-                if next_from == 0 and next_source == 0:
-                    break
-                from_index = next_from
-                source_index = next_source
+            reservations = list(iter_reservations(client, "dhcp6"))
         except KeaException as exc:
             if exc.response.get("result") == 2:
                 hook_available = False

--- a/netbox_kea/views/subnets.py
+++ b/netbox_kea/views/subnets.py
@@ -14,7 +14,7 @@ from utilities.htmx import htmx_partial
 from utilities.views import register_model_view
 
 from .. import forms, tables
-from ..kea import KeaClient, KeaException, PartialPersistError
+from ..kea import KeaClient, KeaException, PartialPersistError, iter_reservations
 from ..models import Server
 from ..utilities import (
     OptionalViewTab,
@@ -254,26 +254,16 @@ def _warn_pool_reservation_overlap(
             pool_range = IPNetwork(pool_str)
 
         overlapping: list[str] = []
-        source_index, from_index = 0, 0
-        while True:
-            hosts, from_index, source_index = client.reservation_get_page(
-                service=f"dhcp{version}",
-                source_index=source_index,
-                from_index=from_index,
-                limit=200,
-            )
-            for host in hosts:
-                if host.get("subnet-id") != subnet_id:
-                    continue
-                candidate_ips = list(filter(None, [host.get("ip-address")] + list(host.get("ip-addresses") or [])))
-                for ip_str in candidate_ips:
-                    try:
-                        if IPAddress(ip_str) in pool_range:
-                            overlapping.append(ip_str)
-                    except Exception:  # noqa: BLE001, PERF203
-                        pass
-            if from_index == 0 and source_index == 0:
-                break
+        for host in iter_reservations(client, f"dhcp{version}", limit=200):
+            if host.get("subnet-id") != subnet_id:
+                continue
+            candidate_ips = list(filter(None, [host.get("ip-address")] + list(host.get("ip-addresses") or [])))
+            for ip_str in candidate_ips:
+                try:
+                    if IPAddress(ip_str) in pool_range:
+                        overlapping.append(ip_str)
+                except Exception:  # noqa: BLE001, PERF203
+                    pass
 
         if overlapping:
             sample = ", ".join(overlapping[:5])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,8 @@ addopts = "--ignore=tests/docker"
 
 [tool.coverage.run]
 source = ["netbox_kea"]
-omit = ["*/migrations/*"]
+# Don't measure coverage of the test suite itself — only of the code under test.
+omit = ["*/migrations/*", "*/tests/*"]
 
 [tool.coverage.report]
 show_missing = true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional sync of Kea DHCP config into the NetBox DHCP plugin (servers, subnets, pools, reservations, and options).
  * Introduced per-server DHCP plugin sync toggle, new sync tab with import and drift comparison, and a server sync endpoint.
* **Bug Fixes**
  * Prevent stale IP cleanup from removing IPs still referenced by DHCP-plugin reservations.
  * Improved robustness when Kea returns malformed reservation data.
* **Performance Improvements**
  * Faster, safer reservation retrieval via streaming iteration instead of manual pagination.
* **Tests**
  * Expanded unit and integration tests for mapping, sync flow, drift/error handling, and the stale-IP protection behavior.
* **Chores**
  * Adjusted coverage reporting to exclude plugin-only code paths not exercised in CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->