### PR TITLE
fix(combined): validate Kea response shape before indexing resp[0]

### DIFF
--- a/netbox_kea/tests/test_views_combined.py
+++ b/netbox_kea/tests/test_views_combined.py
@@ -49,6 +49,55 @@ class TestFetchSharedNetworksFromServer(_ViewTestBase):
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
+class TestCombinedResponseShapeGuards(_ViewTestBase):
+    """Malformed Kea responses (empty list / non-dict entry) must raise RuntimeError.
+
+    ``KeaClient.command`` only guarantees a *list*; ``check_response`` iterating an
+    empty list raises nothing, so indexing ``resp[0]["result"]`` / ``config[0][...]``
+    blows up with ``IndexError``/``TypeError``. The sibling subnet/option/server
+    views guard this with ``isinstance(resp, list) and resp and isinstance(resp[0],
+    dict)`` and raise ``RuntimeError``; these combined helpers must do the same
+    (CLAUDE.md: "Validate Kea response shape before indexing … raise RuntimeError").
+    """
+
+    def _patched(self, command_return):
+        p = patch("netbox_kea.models.KeaClient")
+        mock = p.start()
+        self.addCleanup(p.stop)
+        mock.return_value.command.return_value = command_return
+        return mock
+
+    def test_leases_empty_response_raises_runtime_error(self):
+        from netbox_kea import constants
+        from netbox_kea.views import _fetch_leases_from_server
+
+        self._patched([])
+        with self.assertRaises(RuntimeError):
+            _fetch_leases_from_server(self.server, "10.0.0.1", constants.BY_IP, 4)
+
+    def test_all_leases_non_dict_entry_raises_runtime_error(self):
+        from netbox_kea.views import _fetch_all_leases_from_server
+
+        self._patched(["not-a-dict"])
+        with self.assertRaises(RuntimeError):
+            _fetch_all_leases_from_server(self.server, 4)
+
+    def test_subnets_empty_response_raises_runtime_error(self):
+        from netbox_kea.views import _fetch_subnets_from_server
+
+        self._patched([])
+        with self.assertRaises(RuntimeError):
+            _fetch_subnets_from_server(self.server, 4)
+
+    def test_shared_networks_empty_response_raises_runtime_error(self):
+        from netbox_kea.views import _fetch_shared_networks_from_server
+
+        self._patched([])
+        with self.assertRaises(RuntimeError):
+            _fetch_shared_networks_from_server(self.server, 4)
+
+
+@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestCombinedReservationsMultiPage(_ViewTestBase):
     """Lines 4065-4066: combined reservations multi-page pagination."""
 

--- a/netbox_kea/views/combined.py
+++ b/netbox_kea/views/combined.py
@@ -26,6 +26,20 @@ from .reservations import _enrich_reservations_with_badges, _filter_reservations
 logger = logging.getLogger(__name__)
 
 
+def _require_first_entry(resp: Any, what: str) -> dict[str, Any]:
+    """Validate a Kea command-response shape and return its first entry.
+
+    ``KeaClient.command`` only guarantees a list, and ``check_response`` iterating
+    an empty list raises nothing — so indexing ``resp[0]`` on a malformed (empty or
+    non-dict) payload blows up with ``IndexError``/``TypeError``. Surface it as a
+    ``RuntimeError`` (the contract callers already catch) instead, matching the
+    guard the subnet/option/server views use.
+    """
+    if not isinstance(resp, list) or not resp or not isinstance(resp[0], dict):
+        raise RuntimeError(f"Malformed Kea response for {what}")
+    return resp[0]
+
+
 def _fetch_leases_from_server(server: Server, q: Any, by: str, version: int) -> list[dict[str, Any]]:
     """Fetch leases matching *q*/*by* from a single server and tag with server info.
 
@@ -68,10 +82,11 @@ def _fetch_leases_from_server(server: Server, q: Any, by: str, version: int) -> 
         check=(0, 3),
     )
 
-    if resp[0]["result"] == 3:
+    entry = _require_first_entry(resp, f"lease{version}-get{command_suffix}")
+    if entry["result"] == 3:
         return []
 
-    args = resp[0]["arguments"]
+    args = entry["arguments"]
     if args is None:
         raise RuntimeError(f"Unexpected None arguments from lease{version}-get{command_suffix}")
 
@@ -117,9 +132,10 @@ def _fetch_all_leases_from_server(
             arguments={"from": cursor, "limit": per_page},
             check=(0, 3),
         )
-        if resp[0]["result"] == 3:
+        entry = _require_first_entry(resp, f"lease{version}-get-page")
+        if entry["result"] == 3:
             break
-        args = resp[0]["arguments"]
+        args = entry["arguments"]
         if args is None:
             raise RuntimeError(f"Unexpected None arguments from lease{version}-get-page")
         raw_leases = args["leases"]
@@ -216,11 +232,12 @@ def _fetch_subnets_from_server(server: "Server", version: int) -> list[dict[str,
 
     client = server.get_client(version=version)
     config = client.command("config-get", service=[f"dhcp{version}"])
-    if config[0]["arguments"] is None:
+    entry = _require_first_entry(config, f"config-get for dhcp{version}")
+    if entry["arguments"] is None:
         raise RuntimeError(f"Unexpected None arguments from config-get for dhcp{version}")
     dhcp_key = f"Dhcp{version}"
     subnet_key = f"subnet{version}"
-    args = config[0]["arguments"].get(dhcp_key, {})
+    args = entry["arguments"].get(dhcp_key, {})
     result = [
         {
             "id": s["id"],
@@ -347,9 +364,10 @@ def _fetch_shared_networks_from_server(server: "Server", version: int) -> list[d
     """Fetch all shared networks from a single server's config-get and tag with server info."""
     client = server.get_client(version=version)
     config = client.command("config-get", service=[f"dhcp{version}"])
-    if config[0]["arguments"] is None:
+    entry = _require_first_entry(config, f"config-get for dhcp{version}")
+    if entry["arguments"] is None:
         raise RuntimeError(f"Unexpected None arguments from config-get for dhcp{version}")
-    dhcp_conf = config[0]["arguments"].get(f"Dhcp{version}", {})
+    dhcp_conf = entry["arguments"].get(f"Dhcp{version}", {})
     result = []
     for sn in dhcp_conf.get("shared-networks", []):
         subnets = sn.get(f"subnet{version}", [])


### PR DESCRIPTION
## What

The combined multi-server lease/subnet/shared-network views indexed `resp[0]["result"]` / `config[0]["arguments"]` directly. `KeaClient.command()` only guarantees a *list*, and `check_response()` iterating an empty list raises nothing — so an empty or non-dict Kea payload raised `IndexError`/`TypeError`, masked per-server by the executor's broad `except Exception` instead of surfacing cleanly.

## Fix

Add `_require_first_entry()` — mirrors the `isinstance(resp, list) and resp and isinstance(resp[0], dict)` guard already used in the subnet/option/server views — and route all four sites through it, raising `RuntimeError` on a malformed shape (the contract the callers already catch).

Aligns with the repo rule: *"Validate Kea response shape before indexing … Malformed payloads should raise RuntimeError."*

## Tests

`TestCombinedResponseShapeGuards` — 4 red-first tests (empty list / non-dict entry) across all four helpers; confirmed **failing with `IndexError`** against the unfixed code and **passing** after the guard. Full `test_views_combined.py` suite green (6/6).

Found proactively via cr-audit (recurring CodeRabbit family `phantom:medusa:ocelot` — "validate response shape before indexing").

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for malformed Kea API responses. Invalid response shapes now raise clear, consistent error messages instead of cryptic indexing or type errors during lease and network queries.

* **Tests**
  * Added test suite validating response shape requirements across lease and network configuration retrieval operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->