### PR TITLE
ci: ruff bandit (S) rules + custom opengrep ruleset (on top of CodeRabbit)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,30 @@ jobs:
       - name: REUSE compliance
         run: uv run reuse lint
 
+  opengrep:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Install opengrep
+        env:
+          OPENGREP_VERSION: v1.23.0
+          OPENGREP_SHA256: 1f06548af379ab6080698a609612890ffad2d92dc2172f1e97d38d48096d5ef8
+        run: |
+          curl -fsSL -o /usr/local/bin/opengrep \
+            "https://github.com/opengrep/opengrep/releases/download/${OPENGREP_VERSION}/opengrep_manylinux_x86"
+          echo "${OPENGREP_SHA256}  /usr/local/bin/opengrep" | sha256sum -c -
+          chmod +x /usr/local/bin/opengrep
+          opengrep --version
+
+      - name: Run opengrep rule-tests
+        run: ./scripts/opengrep-test.sh
+
+      - name: Run opengrep custom ruleset
+        run: ./scripts/opengrep-scan.sh
+
   test:
     strategy:
       fail-fast: false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,6 +45,12 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
+          # The opengrep rule-test fixtures deliberately contain vulnerable
+          # patterns (so the rule-tests are meaningful) and are not shipped code.
+          # Exclude them from CodeQL, mirroring the ruff exclusion.
+          config: |
+            paths-ignore:
+              - '.opengrep/**'
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@c793b717bc78562f491db7b0e93a3a178b099162  # v4

--- a/.opengrep/README.md
+++ b/.opengrep/README.md
@@ -64,7 +64,7 @@ The `opengrep` hook in `.pre-commit-config.yaml` runs at the **pre-push** stage
 (not on every commit). Install the hook types once:
 
 ```bash
-pre-commit install --install-hooks
+uv run pre-commit install --install-hooks
 ```
 
 CI runs the same rules in the `opengrep` job (`.github/workflows/ci.yml`), so a

--- a/.opengrep/README.md
+++ b/.opengrep/README.md
@@ -1,0 +1,84 @@
+<!--
+SPDX-FileCopyrightText: 2026 Marcin Zieba <marcinpsk@gmail.com>
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# opengrep ruleset
+
+Custom [opengrep](https://github.com/opengrep/opengrep) rules that encode this
+project's `CLAUDE.md` security/correctness invariants as machine-checked gates,
+so the same classes of bug stop coming back review after review.
+
+## Why opengrep (and not just ruff / CodeQL)
+
+- **ruff** (incl. the `S` / flake8-bandit rules) covers generic Python lint and
+  security smells, but can't express project-specific call-shape rules.
+- **CodeQL** (`.github/workflows/codeql.yml`) covers broad dataflow SAST.
+- **opengrep** fills the gap: cheap, readable YAML patterns for *our* invariants
+  — and it is the same engine **CodeRabbit** runs.
+
+## Relationship to CodeRabbit (these run *on top* of CR's defaults)
+
+CodeRabbit auto-detects an opengrep config **only** when it is named
+`opengrep.yml` / `semgrep.yml` (and a few variants) — and when it finds one it
+runs *that* **instead of** its default packs. We deliberately do **not** use
+those names: the ruleset lives at **`.opengrep/kea-rules.yaml`**, so CodeRabbit
+keeps running its own default opengrep packs, and these custom rules are enforced
+*additionally* by the **pre-push hook** and the **CI `opengrep` job**. Net result:
+CR's broad coverage **plus** our project-specific rules.
+
+## Layout
+
+| Path | Purpose |
+| --- | --- |
+| `.opengrep/kea-rules.yaml` | The ruleset. **Single source of truth.** Used by the pre-push hook and CI; intentionally not named so CodeRabbit auto-detects it. |
+| `.opengrep/tests/*.py` | Annotated rule-test fixtures (`# ruleid:` must match, `# ok:` must not). |
+| `scripts/opengrep-scan.sh` | Scan the source tree; used by the pre-push hook and CI. Exits non-zero on any finding. |
+| `scripts/opengrep-test.sh` | Run the rule-tests against the ruleset. |
+
+## Rules
+
+| Rule id | Severity | Catches |
+| --- | --- | --- |
+| `kea-get-client-missing-version` | warning | `server.get_client()` without `version=` (wrong daemon on dual-URL servers). |
+| `kea-exception-detail-in-response` | error | `str(exc)` / f-string of a caught exception leaked into `messages.*` / HTTP / DRF responses. |
+| `kea-command-result-indexed-without-guard` | error | `client.command(...)[0]` indexed directly, before validating the response shape. |
+
+## Running locally
+
+```bash
+# Scan (same as the pre-push hook):
+./scripts/opengrep-scan.sh
+
+# Run the rule-tests:
+./scripts/opengrep-test.sh
+```
+
+Both scripts find opengrep via `$OPENGREP_BIN`, then `PATH`, then
+`~/.local/opt/opengrep/bin`. Install opengrep from
+<https://github.com/opengrep/opengrep> (or set `OPENGREP_BIN`).
+
+## How it gates pushes
+
+The `opengrep` hook in `.pre-commit-config.yaml` runs at the **pre-push** stage
+(not on every commit). Install the hook types once:
+
+```bash
+pre-commit install --install-hooks
+```
+
+CI runs the same rules in the `opengrep` job (`.github/workflows/ci.yml`), so a
+`--no-verify` push is still caught.
+
+## Suppressing a true exception
+
+Add an inline `# nosemgrep: <rule-id>` on the offending line, with a short reason
+comment above it — see `views/server.py` (the version-agnostic Control Agent
+status call).
+
+## Adding a rule
+
+1. Add the rule to `.opengrep/kea-rules.yaml`.
+2. Add a fixture `.opengrep/tests/<rule-id>.py` with `# ruleid:` / `# ok:` lines.
+3. `./scripts/opengrep-test.sh` — confirm it passes.
+4. `./scripts/opengrep-scan.sh` — confirm the existing tree is clean (or fix it).

--- a/.opengrep/kea-rules.yaml
+++ b/.opengrep/kea-rules.yaml
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: 2026 Marcin Zieba <marcinpsk@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+#
+# Custom opengrep ruleset encoding the project's CLAUDE.md security/correctness
+# invariants. These run ON TOP OF CodeRabbit's default opengrep packs: the file
+# is intentionally NOT named opengrep.yml / at the repo root, so CodeRabbit does
+# NOT treat it as its config (which would replace its default ruleset). Instead
+# these rules are enforced by the local pre-push hook and the CI opengrep job
+# (scripts/opengrep-scan.sh), while CodeRabbit keeps running its own packs.
+#
+# Rule-test fixtures live in .opengrep/tests/; run them with scripts/opengrep-test.sh.
+rules:
+  - id: kea-get-client-missing-version
+    languages: [python]
+    severity: WARNING
+    message: >-
+      Pass an explicit DHCP version to server.get_client(version=...) when the
+      version is known. On dual-URL servers, omitting version= can hit the wrong
+      daemon endpoint. If the call is deliberately version-agnostic (e.g. the
+      Control Agent status check), suppress it on that line with
+      `# nosemgrep: kea-get-client-missing-version`.
+    metadata:
+      category: correctness
+      confidence: HIGH
+      references:
+        - "CLAUDE.md: Always pass version= to server.get_client()"
+    paths:
+      exclude:
+        - "**/tests/**"
+        - "**/migrations/**"
+    patterns:
+      - pattern: $X.get_client()
+
+  - id: kea-exception-detail-in-response
+    languages: [python]
+    severity: ERROR
+    message: >-
+      Do not leak exception details to user-facing responses. str(exc) or an
+      f-string interpolating a caught exception can expose internal URLs, TLS
+      details, or Kea API config. Log server-side with logger.exception() and
+      return a generic message (or a sanitised kea_error_hint()).
+    metadata:
+      category: security
+      confidence: HIGH
+      cwe:
+        - "CWE-209: Generation of Error Message Containing Sensitive Information"
+      owasp:
+        - "A09:2021 - Security Logging and Monitoring Failures"
+      references:
+        - "CLAUDE.md: Never leak exception details to HTTP responses"
+    paths:
+      exclude:
+        - "**/tests/**"
+        - "**/migrations/**"
+    patterns:
+      - pattern-inside: |
+          try:
+              ...
+          except $EXC as $E:
+              ...
+      - pattern-either:
+          - pattern: messages.error($REQ, str($E), ...)
+          - pattern: messages.warning($REQ, str($E), ...)
+          - pattern: messages.info($REQ, str($E), ...)
+          - pattern: messages.error($REQ, f"...{$E}...", ...)
+          - pattern: messages.warning($REQ, f"...{$E}...", ...)
+          - pattern: messages.info($REQ, f"...{$E}...", ...)
+          - pattern: HttpResponse(str($E), ...)
+          - pattern: HttpResponse(f"...{$E}...", ...)
+          - pattern: HttpResponseBadRequest(str($E), ...)
+          - pattern: HttpResponseBadRequest(f"...{$E}...", ...)
+          - pattern: HttpResponseServerError(str($E), ...)
+          - pattern: HttpResponseServerError(f"...{$E}...", ...)
+          - pattern: JsonResponse(str($E), ...)
+          - pattern: Response(str($E), ...)
+          - pattern: Response(f"...{$E}...", ...)
+
+  - id: kea-command-result-indexed-without-guard
+    languages: [python]
+    severity: ERROR
+    message: >-
+      Do not index a Kea command result directly (client.command(...)[0]).
+      command() only guarantees a list; an empty or malformed payload makes
+      [0] raise IndexError/TypeError. Assign the result and validate its shape
+      (non-empty list with a dict first entry) before indexing — see
+      _require_first_entry() in views/combined.py.
+    metadata:
+      category: correctness
+      confidence: HIGH
+      references:
+        - "CLAUDE.md: Validate Kea response shape before indexing resp[0]"
+    paths:
+      exclude:
+        - "**/tests/**"
+        - "**/migrations/**"
+    patterns:
+      - pattern: $C.command(...)[0]

--- a/.opengrep/tests/kea-command-result-indexed-without-guard.py
+++ b/.opengrep/tests/kea-command-result-indexed-without-guard.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2026 Marcin Zieba <marcinpsk@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+# Test fixtures for kea-command-result-indexed-without-guard. Intentionally
+# contains rule-violating code; excluded from ruff (see pyproject exclude).
+
+
+def bad_chained(client):
+    # ruleid: kea-command-result-indexed-without-guard
+    args = client.command("lease4-get-all", service=["dhcp4"])[0]["arguments"]
+    return args
+
+
+def bad_simple(client):
+    # ruleid: kea-command-result-indexed-without-guard
+    first = client.command("status-get")[0]
+    return first
+
+
+def ok_guarded(client):
+    resp = client.command("status-get")
+    if not resp or not isinstance(resp[0], dict):
+        raise RuntimeError("malformed Kea response")
+    # ok: kea-command-result-indexed-without-guard
+    return resp[0]["arguments"]

--- a/.opengrep/tests/kea-exception-detail-in-response.py
+++ b/.opengrep/tests/kea-exception-detail-in-response.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2026 Marcin Zieba <marcinpsk@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+# Test fixtures for kea-exception-detail-in-response. Intentionally contains
+# rule-violating code; excluded from ruff (see pyproject [tool.ruff] exclude).
+from django.contrib import messages
+from django.http import HttpResponse
+
+
+def bad_str(request):
+    try:
+        do()
+    except Exception as exc:
+        # ruleid: kea-exception-detail-in-response
+        messages.error(request, str(exc))
+
+
+def bad_fstring(request):
+    try:
+        do()
+    except Exception as exc:
+        # ruleid: kea-exception-detail-in-response
+        messages.warning(request, f"Failed: {exc}")
+
+
+def bad_http(request):
+    try:
+        do()
+    except ValueError as err:
+        # ruleid: kea-exception-detail-in-response
+        return HttpResponse(str(err))
+
+
+def ok_generic(request):
+    try:
+        do()
+    except Exception:
+        # ok: kea-exception-detail-in-response
+        messages.error(request, "An internal error occurred")
+
+
+def ok_hint(request):
+    try:
+        do()
+    except Exception as exc:
+        logger.exception("kea call failed")
+        # ok: kea-exception-detail-in-response
+        messages.error(request, kea_error_hint(exc))

--- a/.opengrep/tests/kea-get-client-missing-version.py
+++ b/.opengrep/tests/kea-get-client-missing-version.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2026 Marcin Zieba <marcinpsk@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+# Test fixtures for kea-get-client-missing-version. Intentionally contains
+# rule-violating code; excluded from ruff (see pyproject [tool.ruff] exclude).
+
+
+def fetch(server):
+    # ruleid: kea-get-client-missing-version
+    client = server.get_client()
+    return client
+
+
+def fetch_versioned(server):
+    # ok: kea-get-client-missing-version
+    client = server.get_client(version=4)
+    return client
+
+
+def fetch_versioned_var(server, version):
+    # ok: kea-get-client-missing-version
+    client = server.get_client(version=version)
+    return client
+
+
+def nested(server, helper):
+    # ruleid: kea-get-client-missing-version
+    return helper(server.get_client())

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,23 @@ repos:
         additional_dependencies: [reuse]
         pass_filenames: false
 
+  # Custom opengrep ruleset (.opengrep/kea-rules.yaml) — enforce CLAUDE.md
+  # security/correctness invariants before pushing. These run on top of
+  # CodeRabbit's default opengrep packs (CI mirrors this in the `opengrep` job).
+  # Runs on pre-push (not every commit) and scans the whole package. Requires
+  # opengrep (https://github.com/opengrep/opengrep) on PATH or at
+  # ~/.local/opt/opengrep/bin; set OPENGREP_BIN to override the binary location.
+  - repo: local
+    hooks:
+      - id: opengrep
+        name: opengrep (custom Kea rules)
+        entry: scripts/opengrep-scan.sh
+        language: script
+        pass_filenames: false
+        stages: [pre-push]
+        types: [python]
+
 # Configuration
-default_install_hook_types: [pre-commit, commit-msg]
+default_install_hook_types: [pre-commit, commit-msg, pre-push]
 default_stages: [pre-commit]
 fail_fast: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,9 @@ uv run ruff check netbox_kea/              # lint
 uv run ruff format --check netbox_kea/     # check formatting
 uv run ruff format netbox_kea/             # auto-format
 uv run reuse lint                          # SPDX/REUSE compliance
-uv run pre-commit install                  # install pre-commit hooks
+uv run pre-commit install --install-hooks  # install pre-commit hooks (incl. pre-push opengrep)
+./scripts/opengrep-scan.sh                 # custom opengrep ruleset gate (pre-push + CI)
+./scripts/opengrep-test.sh                 # opengrep rule-tests
 ```
 
 ### Unit tests (no Docker required)
@@ -86,6 +88,11 @@ URL request
 - Pool operations support both Kea 2.x and 3.x APIs.
 
 ## Security & Code Quality Rules
+
+Several of these rules are machine-enforced by the custom opengrep ruleset in
+`.opengrep/kea-rules.yaml` (see `.opengrep/README.md`) — run on pre-push and in
+CI, *in addition* to CodeRabbit's default opengrep packs. When a rule below has a
+matching opengrep rule, a violation fails the gate before review.
 
 - **Never leak exception details to HTTP responses.** Use `logger.exception()` for server-side logging and return a generic message like `"An internal error occurred"` to users. Raw `str(exc)` can expose internal URLs, TLS details, or Kea API config.
 - **Always pass `version=` to `server.get_client()`** when the DHCP version is known (e.g., `server.get_client(version=self.dhcp_version)`). Omitting it may hit the wrong endpoint when dual URLs are configured.

--- a/netbox_kea/kea.py
+++ b/netbox_kea/kea.py
@@ -1024,7 +1024,7 @@ class KeaClient:
         if max_leases is not None and max_leases < 1:
             raise ValueError(f"max_leases must be >= 1 (or None for no cap), got {max_leases!r}")
         service = f"dhcp{version}"
-        cursor = "0.0.0.0" if version == 4 else "::"
+        cursor = "0.0.0.0" if version == 4 else "::"  # noqa: S104  lease-page pagination cursor, not a socket bind
         all_leases: list[dict] = []
         truncated = False
 

--- a/netbox_kea/sync.py
+++ b/netbox_kea/sync.py
@@ -65,7 +65,7 @@ def find_prefix_length(ip_str: str) -> int:
             net = IPNetwork(str(prefix.prefix))
             if ip in net and net.prefixlen > best_len:
                 best_len = net.prefixlen
-        except Exception:  # noqa: BLE001, PERF203
+        except Exception:  # noqa: BLE001, PERF203, S112  skip unparseable prefixes
             continue
 
     return best_len if best_len >= 0 else default
@@ -202,7 +202,7 @@ def _update_mac_description(mac_obj: object, hostname: str) -> bool:
 
     Returns ``True`` when the description was changed.
     """
-    TOKEN = "dhcp_hostname: "
+    TOKEN = "dhcp_hostname: "  # noqa: S105  description-label prefix, not a credential
     new_value = f"{TOKEN}{hostname}"
     desc = mac_obj.description or ""
     has_interface = getattr(mac_obj, "assigned_object", None) is not None

--- a/netbox_kea/tests/test_views_leases.py
+++ b/netbox_kea/tests/test_views_leases.py
@@ -2375,6 +2375,47 @@ class TestGetLeasesPageEdgeCases(_ViewTestBase):
         self.assertEqual(response.status_code, 200)
 
 
+@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
+class TestGetLeasesPageAllLeasesMode(_ViewTestBase):
+    """All-leases browse mode (``by=""``) starts pagination at the address-space root.
+
+    Covers ``BaseServerLeasesView.get_leases_page()`` when *subnet* is ``None``: the
+    lease-page ``from`` cursor must be ``"0.0.0.0"`` for DHCPv4 and ``"::"`` for
+    DHCPv6. The existing get_leases_page tests all pass ``by=subnet``, so the
+    ``subnet is None`` branch was otherwise unexercised.
+    """
+
+    def _url4(self):
+        return reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
+
+    def _url6(self):
+        return reverse("plugins:netbox_kea:server_leases6", args=[self.server.pk])
+
+    @patch("netbox_kea.models.KeaClient")
+    def test_all_leases_v4_starts_from_zero_address(self, MockKeaClient):
+        """``by=""`` on the v4 view must call lease4-get-page with ``from="0.0.0.0"``."""
+        mock_client = MockKeaClient.return_value
+        mock_client.command.return_value = [{"result": 0, "arguments": {"count": 0, "leases": []}}]
+
+        response = self.client.get(self._url4(), {"by": ""}, HTTP_HX_REQUEST="true")
+
+        self.assertEqual(response.status_code, 200)
+        page_call = next(c for c in mock_client.command.call_args_list if c.args[0] == "lease4-get-page")
+        self.assertEqual(page_call.kwargs["arguments"]["from"], "0.0.0.0")
+
+    @patch("netbox_kea.models.KeaClient")
+    def test_all_leases_v6_starts_from_unspecified_address(self, MockKeaClient):
+        """``by=""`` on the v6 view must call lease6-get-page with ``from="::"``."""
+        mock_client = MockKeaClient.return_value
+        mock_client.command.return_value = [{"result": 0, "arguments": {"count": 0, "leases": []}}]
+
+        response = self.client.get(self._url6(), {"by": ""}, HTTP_HX_REQUEST="true")
+
+        self.assertEqual(response.status_code, 200)
+        page_call = next(c for c in mock_client.command.call_args_list if c.args[0] == "lease6-get-page")
+        self.assertEqual(page_call.kwargs["arguments"]["from"], "::")
+
+
 # ---------------------------------------------------------------------------
 # get_leases — AbortRequest and null args (lines 522, 535)
 # ---------------------------------------------------------------------------

--- a/netbox_kea/views/combined.py
+++ b/netbox_kea/views/combined.py
@@ -118,7 +118,7 @@ def _fetch_all_leases_from_server(
 
     """
     client = server.get_client(version=version)
-    start_ip = "0.0.0.0" if version == 4 else "::"
+    start_ip = "0.0.0.0" if version == 4 else "::"  # noqa: S104  lease-page pagination cursor, not a socket bind
     per_page = 250
 
     all_leases: list[dict[str, Any]] = []

--- a/netbox_kea/views/leases.py
+++ b/netbox_kea/views/leases.py
@@ -256,7 +256,7 @@ class BaseServerLeasesView(generic.ObjectView, Generic[T]):
         if page:
             frm = page
         elif subnet is None:
-            frm = "0.0.0.0" if self.dhcp_version == 4 else "::"
+            frm = "0.0.0.0" if self.dhcp_version == 4 else "::"  # noqa: S104  lease-page start cursor, not a socket bind
         elif int(subnet.network) == 0:
             frm = str(subnet.network)
         else:
@@ -461,7 +461,7 @@ class BaseServerLeasesView(generic.ObjectView, Generic[T]):
         """
         instance = self.get_object(**kwargs)
 
-        start_ip = "0.0.0.0" if self.dhcp_version == 4 else "::"
+        start_ip = "0.0.0.0" if self.dhcp_version == 4 else "::"  # noqa: S104  lease-page start cursor, not a socket bind
         per_page = 1000
 
         all_leases: list[dict[str, Any]] = []

--- a/netbox_kea/views/server.py
+++ b/netbox_kea/views/server.py
@@ -219,7 +219,9 @@ class ServerStatusView(generic.ObjectView):
         result: dict[str, dict[str, Any]] = {}
         if server.has_control_agent:
             try:
-                result["Control Agent"] = self._get_ca_status(server.get_client())
+                # Control Agent is version-agnostic (top-level CA endpoint, not dhcp4/dhcp6).
+                ca_client = server.get_client()  # nosemgrep: kea-get-client-missing-version
+                result["Control Agent"] = self._get_ca_status(ca_client)
             except (KeaException, requests.RequestException, ValueError, RuntimeError):
                 logger.exception("Failed to fetch Control Agent status for server %s", server.pk)
         result.update(self._get_dhcp_status(server))

--- a/netbox_kea/views/subnets.py
+++ b/netbox_kea/views/subnets.py
@@ -262,7 +262,7 @@ def _warn_pool_reservation_overlap(
                 try:
                     if IPAddress(ip_str) in pool_range:
                         overlapping.append(ip_str)
-                except Exception:  # noqa: BLE001, PERF203
+                except Exception:  # noqa: BLE001, PERF203, S110  skip unparseable reservation IPs
                     pass
 
         if overlapping:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,8 +70,13 @@ exclude = ["netbox_kea/tests"]
 
 [tool.ruff]
 line-length = 120
+# force-exclude so excluded paths are skipped even when passed explicitly
+# (e.g. by the ruff pre-commit hook). Keeps the opengrep rule-test fixtures —
+# which deliberately contain rule-violating code — out of ruff's scope.
+force-exclude = true
 exclude = [
   "netbox_kea/migrations",
+  ".opengrep",
 ]
 
 [tool.ruff.lint]
@@ -84,6 +89,7 @@ select = [
   "I",
   "PERF",  # perflint
   "RET",   # flake8-return
+  "S",     # flake8-bandit (security smells)
   "UP",
   "W",
 ]
@@ -115,10 +121,12 @@ max-complexity = 15
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
 "*/migrations/*.py" = ["D"]
-"*/tests/*.py" = ["D"]
-"tests/*.py" = ["D"]
-"e2e/*.py" = ["D"]
-".devcontainer/**/*.py" = ["D", "C4"]
+# Test code: bandit/security smells (asserts, hardcoded test creds, bind-all,
+# try/except/pass in helpers) are expected fixtures, not production risks.
+"*/tests/*.py" = ["D", "S"]
+"tests/*.py" = ["D", "S"]
+"e2e/*.py" = ["D", "S"]
+".devcontainer/**/*.py" = ["D", "C4", "S"]
 "netbox_kea/forms.py" = ["C901"]  # upstream complex validation logic
 
 [tool.pytest.ini_options]

--- a/scripts/opengrep-scan.sh
+++ b/scripts/opengrep-scan.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Marcin Zieba <marcinpsk@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+#
+# Run the repo's custom opengrep ruleset (.opengrep/rules) over the source tree.
+# Used by the pre-push hook and CI to catch CLAUDE.md rule violations locally,
+# before CodeRabbit's opengrep pass flags them on the PR.
+#
+# Locates opengrep via (1) $OPENGREP_BIN, (2) PATH, (3) the default user install
+# dir (~/.local/opt/opengrep/bin), so it works even when opengrep is not on PATH.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+opengrep_bin="${OPENGREP_BIN:-}"
+if [[ -z "$opengrep_bin" ]]; then
+  if command -v opengrep >/dev/null 2>&1; then
+    opengrep_bin="$(command -v opengrep)"
+  elif [[ -x "$HOME/.local/opt/opengrep/bin/opengrep" ]]; then
+    opengrep_bin="$HOME/.local/opt/opengrep/bin/opengrep"
+  else
+    echo "error: opengrep not found. Install it from https://github.com/opengrep/opengrep" >&2
+    echo "       (or set OPENGREP_BIN=/path/to/opengrep)." >&2
+    exit 1
+  fi
+fi
+
+# Scan explicit targets if given, otherwise the package source tree.
+targets=("$@")
+if [[ ${#targets[@]} -eq 0 ]]; then
+  targets=("$repo_root/netbox_kea")
+fi
+
+exec "$opengrep_bin" scan \
+  --config "$repo_root/.opengrep/kea-rules.yaml" \
+  --error \
+  "${targets[@]}"

--- a/scripts/opengrep-test.sh
+++ b/scripts/opengrep-test.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Marcin Zieba <marcinpsk@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+#
+# Run opengrep rule-tests for the ruleset (.opengrep/kea-rules.yaml) against the
+# annotated fixtures in .opengrep/tests/. Each fixture carries `# ruleid:` /
+# `# ok:` markers asserting which lines must (and must not) match.
+#
+# `opengrep test` pairs a <stem>.yaml rule file with a same-stem <stem>.py
+# fixture inside one directory. To keep a single source of truth
+# (.opengrep/kea-rules.yaml) we stage a temp directory pairing a copy of the
+# ruleset with each fixture, then run the test there.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+opengrep_bin="${OPENGREP_BIN:-}"
+if [[ -z "$opengrep_bin" ]]; then
+  if command -v opengrep >/dev/null 2>&1; then
+    opengrep_bin="$(command -v opengrep)"
+  elif [[ -x "$HOME/.local/opt/opengrep/bin/opengrep" ]]; then
+    opengrep_bin="$HOME/.local/opt/opengrep/bin/opengrep"
+  else
+    echo "error: opengrep not found. Install it from https://github.com/opengrep/opengrep" >&2
+    echo "       (or set OPENGREP_BIN=/path/to/opengrep)." >&2
+    exit 1
+  fi
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+for fixture in "$repo_root"/.opengrep/tests/*.py; do
+  stem="$(basename "$fixture" .py)"
+  cp "$repo_root/.opengrep/kea-rules.yaml" "$tmp/$stem.yaml"
+  cp "$fixture" "$tmp/$stem.py"
+done
+
+exec "$opengrep_bin" test "$tmp"


### PR DESCRIPTION
## What & why

Two layers of static security/correctness checking that run **locally (pre-push)** and **in CI**, encoding `CLAUDE.md` invariants as machine-checked gates so the same classes of bug stop recurring in review.

### 1. ruff `S` (flake8-bandit)
- Enable the `S` ruleset for generic Python security smells.
- Ignored in test paths (asserts / hardcoded test creds are expected fixtures).
- All 7 production findings were reviewed as **false positives** and waived with targeted `# noqa` + a one-line reason: 5× S104 lease-page cursors (`"0.0.0.0"`/`"::"`, not socket binds), 1× S105 `dhcp_hostname:` label, 2× S110/S112 existing skip-guards.

### 2. Custom opengrep ruleset — `.opengrep/kea-rules.yaml`
Three rules from `CLAUDE.md`:
- `kea-get-client-missing-version` — `get_client()` without `version=`.
- `kea-exception-detail-in-response` — `str(exc)`/f-string of a caught exception leaked into responses.
- `kea-command-result-indexed-without-guard` — `client.command(...)[0]` indexed without a shape check.

**Runs on top of CodeRabbit's defaults:** the file is intentionally *not* named `opengrep.yml`/`semgrep.yml`, so CodeRabbit keeps running its own default opengrep packs while these rules are enforced *additionally* via the pre-push hook and a new CI `opengrep` job (pinned `v1.23.0` binary, SHA256-verified).

## Enforcement
- **pre-push** hook (`.pre-commit-config.yaml`) — `pre-commit install --install-hooks`.
- **CI** `opengrep` job — runs the rule-tests then the scan.
- One documented `# nosemgrep` waiver (version-agnostic Control Agent status call in `server.py`).

## Testing
- opengrep rule-tests: **3/3 pass** (`scripts/opengrep-test.sh`).
- Full `netbox_kea` suite in the devcontainer: **2239 passed, 36 skipped, 0 failures**.
- `ruff check` / `ruff format` / `reuse lint` all clean.

## Note
The CI `opengrep` job adds a new check. Shout if you'd prefer it non-blocking initially.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores / Automation**
  * Added an additional CI job to run OpenGrep scans and rule tests.
  * Added a pre-push OpenGrep hook to catch issues before changes are pushed.
  * Introduced local OpenGrep scan/test scripts for consistent developer workflows.

* **Documentation**
  * Documented the custom OpenGrep ruleset, its fixtures, and how gating/suppression works.

* **Code Quality**
  * Updated CodeQL to ignore the OpenGrep fixture directory.
  * Expanded lint configuration to better control scope and security rule coverage.

* **Tests**
  * Added coverage for the “all leases” pagination behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->