### PR TITLE
fix: allow auto-id to work when there's empty subnets

### DIFF
--- a/netbox_kea/kea.py
+++ b/netbox_kea/kea.py
@@ -385,9 +385,7 @@ class KeaClient:
                 else:
                     arguments = list_resp[0].get("arguments")
                     if not isinstance(arguments, dict) or not isinstance(arguments.get("subnets"), list):
-                        raise RuntimeError(
-                            f"subnet{version}-list returned malformed arguments: {list_resp[0]!r}"
-                        )
+                        raise RuntimeError(f"subnet{version}-list returned malformed arguments: {list_resp[0]!r}")
                     existing = arguments["subnets"]
                 max_id = max((s.get("id", 0) for s in existing), default=0)
                 subnet_def["id"] = max_id + 1

--- a/netbox_kea/kea.py
+++ b/netbox_kea/kea.py
@@ -378,11 +378,17 @@ class KeaClient:
                     service=[service],
                     check=(0, 3),  # result=3 means no subnets yet — treat as empty list
                 )
-                existing = (
-                    (list_resp[0].get("arguments") or {}).get("subnets", [])
-                    if isinstance(list_resp, list) and list_resp and isinstance(list_resp[0], dict)
-                    else []
-                )
+                if not list_resp or not isinstance(list_resp[0], dict):
+                    raise RuntimeError(f"subnet{version}-list returned malformed response: {list_resp!r}")
+                if list_resp[0].get("result") == 3:
+                    existing = []
+                else:
+                    arguments = list_resp[0].get("arguments")
+                    if not isinstance(arguments, dict) or not isinstance(arguments.get("subnets"), list):
+                        raise RuntimeError(
+                            f"subnet{version}-list returned malformed arguments: {list_resp[0]!r}"
+                        )
+                    existing = arguments["subnets"]
                 max_id = max((s.get("id", 0) for s in existing), default=0)
                 subnet_def["id"] = max_id + 1
             except KeaException:

--- a/netbox_kea/kea.py
+++ b/netbox_kea/kea.py
@@ -376,6 +376,7 @@ class KeaClient:
                 list_resp = self.command(
                     f"subnet{version}-list",
                     service=[service],
+                    check=(0, 3),  # result=3 means no subnets yet — treat as empty list
                 )
                 existing = (
                     (list_resp[0].get("arguments") or {}).get("subnets", [])

--- a/netbox_kea/tests/test_kea_client.py
+++ b/netbox_kea/tests/test_kea_client.py
@@ -1079,6 +1079,35 @@ class TestSubnetAdd(TestCase):
         # _SUBNET4_LIST_RESP has ids 1 and 2, so auto-assigned should be 3
         self.assertEqual(add_call["arguments"]["subnet4"][0]["id"], 3)
 
+    def test_subnet_add_auto_assigns_id_1_when_no_subnets_exist(self):
+        """result=3 (no subnets configured yet) is accepted via check=(0, 3) and treated as an empty list, so the first subnet gets id 1 — the case this fix restores on Kea 3.x."""
+        empty_list_resp = [{"result": 3, "text": "no subnets configured"}]
+        with patch.object(
+            self.client._session,
+            "post",
+            side_effect=_side_effects(empty_list_resp, _SUBNET4_ADD_RESP, _CONFIG_GET_RUNNING_RESP, _OK, _OK),
+        ) as mock_post:
+            self.client.subnet_add(version=4, subnet_cidr="10.99.0.0/24")
+        add_call = next(
+            c.kwargs.get("json") or c[1]["json"]
+            for c in mock_post.call_args_list
+            if (c.kwargs.get("json") or c[1]["json"])["command"] == "subnet4-add"
+        )
+        self.assertEqual(add_call["arguments"]["subnet4"][0]["id"], 1)
+
+    def test_subnet_add_raises_on_malformed_list_response(self):
+        """A subnet-list response with no result envelope (empty list) must raise RuntimeError, not be silently treated as empty — otherwise id 1 could collide with real subnets."""
+        with patch.object(self.client._session, "post", side_effect=_side_effects([])):
+            with self.assertRaises(RuntimeError):
+                self.client.subnet_add(version=4, subnet_cidr="10.99.0.0/24")
+
+    def test_subnet_add_raises_on_malformed_list_arguments(self):
+        """A result=0 subnet-list response missing arguments.subnets must raise RuntimeError rather than assume "no subnets" and assign a colliding id 1."""
+        malformed = [{"result": 0}]  # ok result code, but no 'arguments' — can't trust it as empty
+        with patch.object(self.client._session, "post", side_effect=_side_effects(malformed)):
+            with self.assertRaises(RuntimeError):
+                self.client.subnet_add(version=4, subnet_cidr="10.99.0.0/24")
+
     def test_subnet_add_includes_pools(self):
         """subnet4-add payload includes pools when provided."""
         with patch.object(


### PR DESCRIPTION
If your Kea server has zero subnets defined, you can't use the auto-id function to create a new subnet from Netbox. 

It will always fail, you get "3" back as a response for how many subnets you have (none) - but there is a default value set in the function to auto-id, let's use that. so allow 0 and 3 as a response.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed subnet creation/ID assignment when there are no subnets yet, correctly handling Kea’s “no subnets” response so the first subnet ID is assigned as expected.
  * Improved error handling for subnet list retrieval, raising a clear error when Kea returns malformed or incomplete data instead of proceeding with missing values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->