### PR TITLE
chore: cover .github/CODEOWNERS in REUSE.toml

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -91,3 +91,9 @@ path = [
 ]
 SPDX-FileCopyrightText = "Copyright (C) 2025 Marcin Zieba <marcinpsk@gmail.com>"
 SPDX-License-Identifier = "Apache-2.0"
+
+# CODEOWNERS (auto-request review); added via API so it had no license info — annotate it here.
+[[annotations]]
+path = ".github/CODEOWNERS"
+SPDX-FileCopyrightText = "2025 Marcin Zieba <marcinpsk@gmail.com>"
+SPDX-License-Identifier = "Apache-2.0"


### PR DESCRIPTION
The `.github/CODEOWNERS` file (added to auto-request review on incoming PRs) was created directly via the API, so it bypassed pre-commit and carries no license info — `reuse lint` flags it. This adds a `REUSE.toml` annotation for it (Apache-2.0, © Marcin Zieba). No functional change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added copyright and licensing metadata for the repository ownership configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->