### PR TITLE
test: de-mock the view tests (PR A) — real KeaClient + HTTP-boundary stub

### DIFF
--- a/netbox_kea/tests/kea_stub.py
+++ b/netbox_kea/tests/kea_stub.py
@@ -102,12 +102,14 @@ class KeaHttpStub:
     def __init__(self, responses: dict[str, Any]) -> None:
         self._responses = dict(responses)
         self.requests: list[dict[str, Any]] = []
+        self._urls: list[str] = []
         self._lock = threading.Lock()
 
     def __call__(self, url: str, **kwargs: Any) -> MagicMock:
         body = kwargs.get("json") or {}
         with self._lock:
             self.requests.append(body)
+            self._urls.append(url)
             cmd = body.get("command")
             if cmd not in self._responses:
                 raise AssertionError(f"KeaHttpStub: no response registered for command {cmd!r} (url={url})")
@@ -131,6 +133,15 @@ class KeaHttpStub:
         """Every request body sent for *command* (for asserting args / absence of ``service``)."""
         with self._lock:
             return [r for r in self.requests if r.get("command") == command]
+
+    def urls(self) -> list[str]:
+        """Ordered list of endpoint URLs POSTed to (parallel to :meth:`commands`).
+
+        Lets dual-URL tests assert that a per-version client hit the protocol-specific
+        endpoint (``dhcp4_url``/``dhcp6_url``) rather than the shared CA URL.
+        """
+        with self._lock:
+            return list(self._urls)
 
 
 @contextmanager

--- a/netbox_kea/tests/kea_stub.py
+++ b/netbox_kea/tests/kea_stub.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: 2025 Marcin Zieba <marcinpsk@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+"""Command-aware HTTP stub for de-mocked view tests.
+
+Instead of patching ``netbox_kea.models.KeaClient`` with a ``MagicMock`` (which
+never builds or inspects the real request payload), these helpers let the view
+use a **real** ``KeaClient`` while stubbing only the HTTP boundary —
+``requests.Session.post`` — so the actual JSON sent to Kea is exercised and can
+be asserted on. This is what lets a payload regression (e.g. a stray/missing
+``service`` key) actually fail a test.
+
+Patched at the **class** level (``requests.Session.post``) so it also covers
+``KeaClient.clone()``, which builds a fresh ``requests.Session`` for the worker
+threads used by the reservation/lease-enrichment views.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import requests
+
+
+def _http_response(payload: Any, status: int = 200) -> MagicMock:
+    """Build a spec'd ``requests.Response`` returning *payload* from ``.json()``."""
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status
+    resp.json.return_value = payload
+    if status >= 400:
+        resp.raise_for_status.side_effect = requests.HTTPError(f"HTTP {status}")
+    else:
+        resp.raise_for_status.return_value = None
+    return resp
+
+
+class KeaHttpStub:
+    """Dispatch Kea commands by name and record the request bodies sent.
+
+    ``responses`` maps a command name to what that command should return. A value
+    may be:
+
+    * a dict/list payload — used for every call of that command;
+    * a ``list`` — consumed as a FIFO queue (the last item repeats);
+    * a callable ``(body) -> payload`` — for argument-dependent responses.
+
+    ``KeaClient`` expects a JSON list (one entry per targeted service); a payload
+    that is not already a list is wrapped in a single-element list.
+    """
+
+    def __init__(self, responses: dict[str, Any]) -> None:
+        self._responses = {k: (list(v) if isinstance(v, list) else v) for k, v in responses.items()}
+        self.requests: list[dict[str, Any]] = []
+
+    def __call__(self, url: str, **kwargs: Any) -> MagicMock:
+        body = kwargs.get("json") or {}
+        self.requests.append(body)
+        cmd = body.get("command")
+        if cmd not in self._responses:
+            raise AssertionError(f"KeaHttpStub: no response registered for command {cmd!r} (url={url})")
+        spec = self._responses[cmd]
+        if callable(spec):
+            payload = spec(body)
+        elif isinstance(spec, list):
+            payload = spec.pop(0) if len(spec) > 1 else spec[0]
+        else:
+            payload = spec
+        return _http_response(payload if isinstance(payload, list) else [payload])
+
+    # --- assertion helpers ---
+    def commands(self) -> list[str]:
+        """Ordered list of command names sent."""
+        return [r.get("command") for r in self.requests]
+
+    def bodies(self, command: str) -> list[dict[str, Any]]:
+        """Every request body sent for *command* (for asserting args / absence of ``service``)."""
+        return [r for r in self.requests if r.get("command") == command]
+
+
+@contextmanager
+def stub_kea(responses: dict[str, Any]):
+    """Exercise a view against a real ``KeaClient`` with the HTTP boundary stubbed.
+
+    Yields a :class:`KeaHttpStub` so tests can assert on the real request bodies::
+
+        with stub_kea({"lease4-del": {"result": 0, "text": "Success"}}) as kea:
+            resp = self.client.post(url, ...)
+        assert "lease4-del" in kea.commands()
+    """
+    stub = KeaHttpStub(responses)
+
+    def _post(self, url, **kwargs):  # noqa: ANN001 - mirrors requests.Session.post(self, url, ...)
+        return stub(url, **kwargs)
+
+    with patch("netbox_kea.kea.requests.Session.post", new=_post):
+        yield stub

--- a/netbox_kea/tests/kea_stub.py
+++ b/netbox_kea/tests/kea_stub.py
@@ -16,6 +16,8 @@ threads used by the reservation/lease-enrichment views.
 
 from __future__ import annotations
 
+import threading
+from collections import deque
 from contextlib import contextmanager
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -40,14 +42,46 @@ def _is_exc(obj: Any) -> bool:
     return isinstance(obj, BaseException) or (isinstance(obj, type) and issubclass(obj, BaseException))
 
 
+class ResponseQueue:
+    """An explicit FIFO of sequential responses for one command.
+
+    Each call consumes the next response; once a single response remains it
+    repeats (so callers can register ``queued(page, end)`` and let ``end`` answer
+    every subsequent call). Kept distinct from a plain ``list`` so an ordinary
+    multi-service Kea response — itself a list — is never mistaken for a queue.
+    """
+
+    def __init__(self, responses: Any) -> None:
+        self._items: deque = deque(responses)
+        if not self._items:
+            raise ValueError("queued() requires at least one response")
+
+    def next(self) -> Any:
+        """Pop the next response (the last one repeats). Caller holds the stub lock."""
+        return self._items.popleft() if len(self._items) > 1 else self._items[0]
+
+
+def queued(*responses: Any) -> ResponseQueue:
+    """Register a sequence of responses answered in order for one command.
+
+    ``stub_kea({"lease4-get-page": queued(page1, page2, end)})`` returns ``page1``
+    on the first call, ``page2`` on the second, then ``end`` for every call after.
+    """
+    return ResponseQueue(responses)
+
+
 class KeaHttpStub:
     """Dispatch Kea commands by name and record the request bodies sent.
 
     ``responses`` maps a command name to what that command should return. A value
     may be:
 
-    * a dict/list payload — used for every call of that command;
-    * a ``list`` — consumed as a FIFO queue (the last item repeats);
+    * a ``dict`` payload — the single ``.json()`` entry, used for every call;
+    * a ``list`` payload — returned **verbatim** as the ``.json()`` body (Kea
+      returns one entry per targeted service, so a real multi-service response is
+      a list);
+    * a :class:`ResponseQueue` from :func:`queued` — sequential responses, one per
+      call (the last repeats), for pagination / partial-failure paths;
     * a callable ``(body) -> payload`` — for argument-dependent responses;
     * an exception instance or class — **raised** when the command is called, or
       returned by a callable, to simulate a transport error (e.g.
@@ -59,22 +93,28 @@ class KeaHttpStub:
 
     ``KeaClient`` expects a JSON list (one entry per targeted service); a payload
     that is not already a list is wrapped in a single-element list.
+
+    Request recording and queue dispatch are guarded by a lock because the
+    reservation/lease-enrichment views ``clone()`` the client and POST from worker
+    threads.
     """
 
     def __init__(self, responses: dict[str, Any]) -> None:
-        self._responses = {k: (list(v) if isinstance(v, list) else v) for k, v in responses.items()}
+        self._responses = dict(responses)
         self.requests: list[dict[str, Any]] = []
+        self._lock = threading.Lock()
 
     def __call__(self, url: str, **kwargs: Any) -> MagicMock:
         body = kwargs.get("json") or {}
-        self.requests.append(body)
-        cmd = body.get("command")
-        if cmd not in self._responses:
-            raise AssertionError(f"KeaHttpStub: no response registered for command {cmd!r} (url={url})")
-        spec = self._responses[cmd]
-        if isinstance(spec, list):
-            spec = spec.pop(0) if len(spec) > 1 else spec[0]
-        # A callable (but not an exception class) is resolved against the body.
+        with self._lock:
+            self.requests.append(body)
+            cmd = body.get("command")
+            if cmd not in self._responses:
+                raise AssertionError(f"KeaHttpStub: no response registered for command {cmd!r} (url={url})")
+            spec = self._responses[cmd]
+            if isinstance(spec, ResponseQueue):
+                spec = spec.next()
+        # Callables/exceptions are resolved outside the lock (they may be slow or raise).
         if callable(spec) and not _is_exc(spec):
             spec = spec(body)
         if _is_exc(spec):
@@ -84,11 +124,13 @@ class KeaHttpStub:
     # --- assertion helpers ---
     def commands(self) -> list[str]:
         """Ordered list of command names sent."""
-        return [r.get("command") for r in self.requests]
+        with self._lock:
+            return [r.get("command") for r in self.requests]
 
     def bodies(self, command: str) -> list[dict[str, Any]]:
         """Every request body sent for *command* (for asserting args / absence of ``service``)."""
-        return [r for r in self.requests if r.get("command") == command]
+        with self._lock:
+            return [r for r in self.requests if r.get("command") == command]
 
 
 @contextmanager

--- a/netbox_kea/tests/kea_stub.py
+++ b/netbox_kea/tests/kea_stub.py
@@ -174,6 +174,14 @@ def _subnet_get(version: int, pools: list[str] | None = None, subnet_id: int = 1
     }
 
 
+def _subnet_list(version: int, subnets: list[dict[str, Any]]) -> dict[str, Any]:  # noqa: ARG001 - version kept for call-site symmetry with _subnet_get
+    """A ``subnet{v}-list`` payload (read by ``reservation_get_by_ip`` to find candidate subnets).
+
+    *subnets* is the list of subnet dicts (each ``{"id": …, "subnet": <cidr>}``) Kea reports.
+    """
+    return {"result": 0, "arguments": {"subnets": list(subnets)}}
+
+
 @contextmanager
 def stub_kea(responses: dict[str, Any]):
     """Exercise a view against a real ``KeaClient`` with the HTTP boundary stubbed.

--- a/netbox_kea/tests/kea_stub.py
+++ b/netbox_kea/tests/kea_stub.py
@@ -35,6 +35,11 @@ def _http_response(payload: Any, status: int = 200) -> MagicMock:
     return resp
 
 
+def _is_exc(obj: Any) -> bool:
+    """True if *obj* is an exception instance or an exception class."""
+    return isinstance(obj, BaseException) or (isinstance(obj, type) and issubclass(obj, BaseException))
+
+
 class KeaHttpStub:
     """Dispatch Kea commands by name and record the request bodies sent.
 
@@ -43,7 +48,14 @@ class KeaHttpStub:
 
     * a dict/list payload — used for every call of that command;
     * a ``list`` — consumed as a FIFO queue (the last item repeats);
-    * a callable ``(body) -> payload`` — for argument-dependent responses.
+    * a callable ``(body) -> payload`` — for argument-dependent responses;
+    * an exception instance or class — **raised** when the command is called, or
+      returned by a callable, to simulate a transport error (e.g.
+      ``requests.ConnectionError``) at the HTTP boundary. This lets error-path
+      tests drive the real ``KeaClient`` error handling instead of mocking
+      ``command.side_effect``. A KeaException-style failure is instead modelled by
+      returning a payload with a non-accepted ``result`` code, which the real
+      ``KeaClient.command()`` turns into a ``KeaException``.
 
     ``KeaClient`` expects a JSON list (one entry per targeted service); a payload
     that is not already a list is wrapped in a single-element list.
@@ -60,13 +72,14 @@ class KeaHttpStub:
         if cmd not in self._responses:
             raise AssertionError(f"KeaHttpStub: no response registered for command {cmd!r} (url={url})")
         spec = self._responses[cmd]
-        if callable(spec):
-            payload = spec(body)
-        elif isinstance(spec, list):
-            payload = spec.pop(0) if len(spec) > 1 else spec[0]
-        else:
-            payload = spec
-        return _http_response(payload if isinstance(payload, list) else [payload])
+        if isinstance(spec, list):
+            spec = spec.pop(0) if len(spec) > 1 else spec[0]
+        # A callable (but not an exception class) is resolved against the body.
+        if callable(spec) and not _is_exc(spec):
+            spec = spec(body)
+        if _is_exc(spec):
+            raise spec() if isinstance(spec, type) else spec
+        return _http_response(spec if isinstance(spec, list) else [spec])
 
     # --- assertion helpers ---
     def commands(self) -> list[str]:

--- a/netbox_kea/tests/kea_stub.py
+++ b/netbox_kea/tests/kea_stub.py
@@ -144,6 +144,36 @@ class KeaHttpStub:
             return list(self._urls)
 
 
+# --- shared Kea response builders (kept next to stub_kea so their shape can't
+#     drift across the test modules that register them) ---
+
+
+def _res_page(hosts: Any, *, next_from: int = 0, next_source: int = 0) -> dict[str, Any]:
+    """A ``reservation-get-page`` payload: *hosts* plus Kea's pagination cursor.
+
+    ``next_from``/``next_source`` both 0 marks the source exhausted, so
+    ``iter_reservations`` stops after this page.
+    """
+    return {"result": 0, "arguments": {"hosts": list(hosts), "next": {"from": next_from, "source-index": next_source}}}
+
+
+def _res_get(reservation: dict[str, Any]) -> dict[str, Any]:
+    """A ``reservation-get`` payload: the host fields Kea returns directly inside ``arguments``."""
+    return {"result": 0, "arguments": dict(reservation)}
+
+
+def _subnet_get(version: int, pools: list[str] | None = None, subnet_id: int = 1) -> dict[str, Any]:
+    """A ``subnet{v}-get`` payload for the reservation-add pool-overlap probe.
+
+    *pools* is a list of pool range strings; the probe warns only when the
+    reservation IP falls inside one of them.
+    """
+    return {
+        "result": 0,
+        "arguments": {f"subnet{version}": [{"id": subnet_id, "pools": [{"pool": p} for p in (pools or [])]}]},
+    }
+
+
 @contextmanager
 def stub_kea(responses: dict[str, Any]):
     """Exercise a view against a real ``KeaClient`` with the HTTP boundary stubbed.

--- a/netbox_kea/tests/test_api_leases.py
+++ b/netbox_kea/tests/test_api_leases.py
@@ -6,18 +6,37 @@ These tests cover:
 - GET /api/plugins/netbox-kea/servers/{pk}/leases4/
 - GET /api/plugins/netbox-kea/servers/{pk}/leases6/
 
-All Kea HTTP calls are mocked; no running Kea instance required.
+These tests drive the **real** ``KeaClient``; only the HTTP boundary is stubbed
+via ``kea_stub.stub_kea``. The lease endpoints issue ``lease{v}-get`` (by IP),
+``lease{v}-get-by-hw-address``, ``lease6-get-by-duid``,
+``lease{v}-get-by-hostname``, or ``lease{v}-get-all`` (by subnet); the real
+request payloads (command + service) are exercised and asserted.
 """
-
-from unittest.mock import MagicMock, patch
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from rest_framework.test import APIClient
 
-from netbox_kea.kea import KeaClient
 from netbox_kea.models import Server
+
+from .kea_stub import stub_kea
+
+# A single DHCPv6 lease (result 0) returned by lease6-get.
+_LEASE6_RESPONSE = [
+    {
+        "result": 0,
+        "arguments": {
+            "ip-address": "2001:db8::1",
+            "duid": "00:01:02:03",
+            "iaid": 12345,
+            "subnet-id": 10,
+            "valid-lft": 3600,
+            "cltt": 1700000000,
+            "state": 0,
+        },
+    }
+]
 
 User = get_user_model()
 
@@ -159,85 +178,61 @@ class TestLease4API(_APITestBase):
         response = self.api_client.get(url, {"ip_address": "10.0.0.1"})
         self.assertEqual(response.status_code, 404)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_by_ip_address_returns_200(self, MockKeaClient):
+    def test_get_by_ip_address_returns_200(self):
         """?ip_address=10.0.0.100 returns 200 with lease data."""
-        mock_client = MagicMock(spec=KeaClient)
-        MockKeaClient.return_value = mock_client
-        mock_client.command.return_value = _LEASE4_RESPONSE
-        response = self.api_client.get(self._url(), {"ip_address": "10.0.0.100"})
+        with stub_kea({"lease4-get": _LEASE4_RESPONSE}):
+            response = self.api_client.get(self._url(), {"ip_address": "10.0.0.100"})
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_by_ip_address_results_in_response(self, MockKeaClient):
+    def test_get_by_ip_address_results_in_response(self):
         """Response includes a 'results' list and 'count' key."""
-        mock_client = MagicMock(spec=KeaClient)
-        MockKeaClient.return_value = mock_client
-        mock_client.command.return_value = _LEASE4_RESPONSE
-        response = self.api_client.get(self._url(), {"ip_address": "10.0.0.100"})
+        with stub_kea({"lease4-get": _LEASE4_RESPONSE}):
+            response = self.api_client.get(self._url(), {"ip_address": "10.0.0.100"})
         data = response.json()
         self.assertIn("results", data)
         self.assertIn("count", data)
         self.assertEqual(data["count"], 1)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_by_hw_address_returns_200(self, MockKeaClient):
+    def test_get_by_hw_address_returns_200(self):
         """?hw_address=aa:bb:cc:dd:ee:ff returns 200 with lease list."""
-        mock_client = MagicMock(spec=KeaClient)
-        MockKeaClient.return_value = mock_client
-        mock_client.command.return_value = _LEASE4_LIST_RESPONSE
-        response = self.api_client.get(self._url(), {"hw_address": "aa:bb:cc:dd:ee:ff"})
+        with stub_kea({"lease4-get-by-hw-address": _LEASE4_LIST_RESPONSE}):
+            response = self.api_client.get(self._url(), {"hw_address": "aa:bb:cc:dd:ee:ff"})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["count"], 1)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_by_hostname_returns_200(self, MockKeaClient):
+    def test_get_by_hostname_returns_200(self):
         """?hostname=host.example.com returns 200."""
-        mock_client = MagicMock(spec=KeaClient)
-        MockKeaClient.return_value = mock_client
-        mock_client.command.return_value = _LEASE4_LIST_RESPONSE
-        response = self.api_client.get(self._url(), {"hostname": "host.example.com"})
+        with stub_kea({"lease4-get-by-hostname": _LEASE4_LIST_RESPONSE}):
+            response = self.api_client.get(self._url(), {"hostname": "host.example.com"})
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_by_subnet_id_returns_200(self, MockKeaClient):
+    def test_get_by_subnet_id_returns_200(self):
         """?subnet_id=1 returns 200."""
-        mock_client = MagicMock(spec=KeaClient)
-        MockKeaClient.return_value = mock_client
-        mock_client.command.return_value = _LEASE4_LIST_RESPONSE
-        response = self.api_client.get(self._url(), {"subnet_id": "1"})
+        with stub_kea({"lease4-get-all": _LEASE4_LIST_RESPONSE}):
+            response = self.api_client.get(self._url(), {"subnet_id": "1"})
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_not_found_returns_empty_results(self, MockKeaClient):
+    def test_not_found_returns_empty_results(self):
         """When Kea returns result=3 (not found), results is empty list."""
-        mock_client = MagicMock(spec=KeaClient)
-        MockKeaClient.return_value = mock_client
-        mock_client.command.return_value = _LEASE4_NOT_FOUND
-        response = self.api_client.get(self._url(), {"ip_address": "10.0.0.99"})
+        with stub_kea({"lease4-get": _LEASE4_NOT_FOUND}):
+            response = self.api_client.get(self._url(), {"ip_address": "10.0.0.99"})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["count"], 0)
         self.assertEqual(response.json()["results"], [])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_kea_connection_error_returns_502(self, MockKeaClient):
+    def test_kea_connection_error_returns_502(self):
         """When Kea is unreachable, returns HTTP 502."""
         import requests as rq
 
-        mock_client = MagicMock(spec=KeaClient)
-        MockKeaClient.return_value = mock_client
-        mock_client.command.side_effect = rq.ConnectionError("refused")
-        response = self.api_client.get(self._url(), {"ip_address": "10.0.0.1"})
+        with stub_kea({"lease4-get": rq.ConnectionError("refused")}):
+            response = self.api_client.get(self._url(), {"ip_address": "10.0.0.1"})
         self.assertEqual(response.status_code, 502)
 
-    @patch.object(Server, "get_client")
-    def test_get_client_called_with_version_4(self, mock_get_client):
-        """The view calls server.get_client(version=4) to select the DHCPv4 endpoint."""
-        mock_client = MagicMock(spec=KeaClient)
-        mock_get_client.return_value = mock_client
-        mock_client.command.return_value = _LEASE4_RESPONSE
-        self.api_client.get(self._url(), {"ip_address": "10.0.0.100"})
-        mock_get_client.assert_called_once_with(version=4)
+    def test_uses_dhcp4_service(self):
+        """The v4 endpoint issues lease4-get to service=['dhcp4'] (version=4 routing)."""
+        with stub_kea({"lease4-get": _LEASE4_RESPONSE}) as kea:
+            self.api_client.get(self._url(), {"ip_address": "10.0.0.100"})
+        self.assertEqual(kea.bodies("lease4-get")[0]["service"], ["dhcp4"])
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -269,78 +264,28 @@ class TestLease6API(_APITestBase):
         response = self.api_client.get(url, {"ip_address": "2001:db8::1"})
         self.assertEqual(response.status_code, 404)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_by_ip_address_returns_200(self, MockKeaClient):
+    def test_get_by_ip_address_returns_200(self):
         """?ip_address=2001:db8::1 returns 200 with v6 lease data."""
-        mock_client = MagicMock(spec=KeaClient)
-        MockKeaClient.return_value = mock_client
-        mock_client.command.return_value = [
-            {
-                "result": 0,
-                "arguments": {
-                    "ip-address": "2001:db8::1",
-                    "duid": "00:01:02:03",
-                    "iaid": 12345,
-                    "subnet-id": 10,
-                    "valid-lft": 3600,
-                    "cltt": 1700000000,
-                    "state": 0,
-                },
-            }
-        ]
-        response = self.api_client.get(self._url(), {"ip_address": "2001:db8::1"})
+        with stub_kea({"lease6-get": _LEASE6_RESPONSE}):
+            response = self.api_client.get(self._url(), {"ip_address": "2001:db8::1"})
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_by_duid_returns_200(self, MockKeaClient):
+    def test_get_by_duid_returns_200(self):
         """?duid=00:01:02:03 returns 200 with v6 lease list."""
-        mock_client = MagicMock(spec=KeaClient)
-        MockKeaClient.return_value = mock_client
-        mock_client.command.return_value = _LEASE6_LIST_RESPONSE
-        response = self.api_client.get(self._url(), {"duid": "00:01:02:03"})
+        with stub_kea({"lease6-get-by-duid": _LEASE6_LIST_RESPONSE}):
+            response = self.api_client.get(self._url(), {"duid": "00:01:02:03"})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["count"], 1)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_uses_dhcp6_service(self, MockKeaClient):
-        """The v6 endpoint calls Kea with service=['dhcp6']."""
-        mock_client = MagicMock(spec=KeaClient)
-        MockKeaClient.return_value = mock_client
-        mock_client.command.return_value = [
-            {
-                "result": 0,
-                "arguments": {
-                    "ip-address": "2001:db8::1",
-                    "duid": "00:01:02:03",
-                    "iaid": 12345,
-                    "valid-lft": 3600,
-                    "cltt": 1700000000,
-                    "state": 0,
-                },
-            }
-        ]
-        self.api_client.get(self._url(), {"ip_address": "2001:db8::1"})
-        call_args = mock_client.command.call_args
-        service = call_args.kwargs.get("service") or (call_args.args[1] if len(call_args.args) > 1 else None)
-        self.assertEqual(service, ["dhcp6"])
+    def test_uses_dhcp6_service(self):
+        """The v6 endpoint issues lease6-get to service=['dhcp6']."""
+        with stub_kea({"lease6-get": _LEASE6_RESPONSE}) as kea:
+            self.api_client.get(self._url(), {"ip_address": "2001:db8::1"})
+        self.assertEqual(kea.bodies("lease6-get")[0]["service"], ["dhcp6"])
 
-    @patch.object(Server, "get_client")
-    def test_get_client_called_with_version_6(self, mock_get_client):
-        """The view calls server.get_client(version=6) to select the DHCPv6 endpoint."""
-        mock_client = MagicMock(spec=KeaClient)
-        mock_get_client.return_value = mock_client
-        mock_client.command.return_value = [
-            {
-                "result": 0,
-                "arguments": {
-                    "ip-address": "2001:db8::1",
-                    "duid": "00:01:02:03",
-                    "iaid": 12345,
-                    "valid-lft": 3600,
-                    "cltt": 1700000000,
-                    "state": 0,
-                },
-            }
-        ]
-        self.api_client.get(self._url(), {"ip_address": "2001:db8::1"})
-        mock_get_client.assert_called_once_with(version=6)
+    def test_uses_version_6_command(self):
+        """The v6 endpoint selects the DHCPv6 client → issues the lease6-* command variant."""
+        with stub_kea({"lease6-get": _LEASE6_RESPONSE}) as kea:
+            self.api_client.get(self._url(), {"ip_address": "2001:db8::1"})
+        self.assertIn("lease6-get", kea.commands())
+        self.assertNotIn("lease4-get", kea.commands())

--- a/netbox_kea/tests/test_api_reservations.py
+++ b/netbox_kea/tests/test_api_reservations.py
@@ -19,7 +19,7 @@ from rest_framework.test import APIClient
 
 from netbox_kea.models import Server
 
-from .kea_stub import queued, stub_kea
+from .kea_stub import _res_page, queued, stub_kea
 
 User = get_user_model()
 
@@ -41,39 +41,10 @@ _RESERVATION4_RESPONSE = [
 # Not found — reservation-get result=3
 _RESERVATION_NOT_FOUND = [{"result": 3, "text": "Host not found."}]
 
-# reservation-get-page returns a "hosts" list under arguments
-_RESERVATION4_PAGE_RESPONSE = [
-    {
-        "result": 0,
-        "arguments": {
-            "hosts": [
-                {
-                    "ip-address": "10.0.0.50",
-                    "hw-address": "aa:bb:cc:dd:ee:ff",
-                    "subnet-id": 1,
-                    "hostname": "reserved.example.com",
-                }
-            ],
-            "next": {"from": 0, "source-index": 0},
-        },
-    }
-]
-
-_RESERVATION6_PAGE_RESPONSE = [
-    {
-        "result": 0,
-        "arguments": {
-            "hosts": [
-                {
-                    "ip-addresses": ["2001:db8::50"],
-                    "duid": "00:01:02:03",
-                    "subnet-id": 10,
-                }
-            ],
-            "next": {"from": 0, "source-index": 0},
-        },
-    }
-]
+# reservation-get-page returns a "hosts" list under arguments (shared page shape).
+_RESERVATION4_PAGE_RESPONSE = _res_page(
+    [{"ip-address": "10.0.0.50", "hw-address": "aa:bb:cc:dd:ee:ff", "subnet-id": 1, "hostname": "reserved.example.com"}]
+)
 
 _RESERVATION6_SINGLE = [
     {
@@ -197,20 +168,11 @@ class TestReservation4API(_APITestBase):
 
     def test_get_by_subnet_id_paginates_all_pages(self):
         """?subnet_id=1 fetches ALL pages from reservation-get-page, not just the first."""
-        page1 = {
-            "result": 0,
-            "arguments": {
-                "hosts": [{"ip-address": "10.0.0.51", "hw-address": "aa:bb:cc:dd:ee:01", "subnet-id": 1}],
-                "next": {"from": 1, "source-index": 0},  # not exhausted
-            },
-        }
-        page2 = {
-            "result": 0,
-            "arguments": {
-                "hosts": [{"ip-address": "10.0.0.52", "hw-address": "aa:bb:cc:dd:ee:02", "subnet-id": 1}],
-                "next": {"from": 0, "source-index": 0},  # exhausted
-            },
-        }
+        page1 = _res_page(
+            [{"ip-address": "10.0.0.51", "hw-address": "aa:bb:cc:dd:ee:01", "subnet-id": 1}],
+            next_from=1,  # not exhausted
+        )
+        page2 = _res_page([{"ip-address": "10.0.0.52", "hw-address": "aa:bb:cc:dd:ee:02", "subnet-id": 1}])  # exhausted
         with stub_kea({"reservation-get-page": queued(page1, page2)}) as kea:
             response = self.api_client.get(self._url(), {"subnet_id": "1"})
         self.assertEqual(response.status_code, 200)

--- a/netbox_kea/tests/test_api_reservations.py
+++ b/netbox_kea/tests/test_api_reservations.py
@@ -6,18 +6,20 @@ These tests cover:
 - GET /api/plugins/netbox-kea/servers/{pk}/reservations4/
 - GET /api/plugins/netbox-kea/servers/{pk}/reservations6/
 
-All Kea HTTP calls are mocked; no running Kea instance required.
+These tests drive the **real** ``KeaClient``; only the HTTP boundary is stubbed
+via ``kea_stub.stub_kea``. The reservation endpoints issue ``reservation-get``
+(lookup by ip/hw/duid + subnet) or ``reservation-get-page`` (paginated, subnet-id
+only); the request payloads are exercised and asserted.
 """
-
-from unittest.mock import MagicMock, patch
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from rest_framework.test import APIClient
 
-from netbox_kea.kea import KeaClient
 from netbox_kea.models import Server
+
+from .kea_stub import queued, stub_kea
 
 User = get_user_model()
 
@@ -164,99 +166,79 @@ class TestReservation4API(_APITestBase):
         response = self.api_client.get(self._url(pk=99999), {"subnet_id": "1"})
         self.assertEqual(response.status_code, 404)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_by_ip_and_subnet_returns_200(self, MockKeaClient):
+    def test_get_by_ip_and_subnet_returns_200(self):
         """?ip_address=10.0.0.50&subnet_id=1 returns 200 with reservation data."""
-        mock_client = MagicMock(spec=KeaClient)
-        MockKeaClient.return_value = mock_client
-        mock_client.reservation_get.return_value = _RESERVATION4_RESPONSE[0]["arguments"]
-        response = self.api_client.get(self._url(), {"ip_address": "10.0.0.50", "subnet_id": "1"})
+        with stub_kea({"reservation-get": _RESERVATION4_RESPONSE}):
+            response = self.api_client.get(self._url(), {"ip_address": "10.0.0.50", "subnet_id": "1"})
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_by_ip_and_subnet_returns_count_and_results(self, MockKeaClient):
+    def test_get_by_ip_and_subnet_returns_count_and_results(self):
         """Response includes 'count' and 'results' keys."""
-        mock_client = MagicMock(spec=KeaClient)
-        MockKeaClient.return_value = mock_client
-        mock_client.reservation_get.return_value = _RESERVATION4_RESPONSE[0]["arguments"]
-        response = self.api_client.get(self._url(), {"ip_address": "10.0.0.50", "subnet_id": "1"})
+        with stub_kea({"reservation-get": _RESERVATION4_RESPONSE}):
+            response = self.api_client.get(self._url(), {"ip_address": "10.0.0.50", "subnet_id": "1"})
         data = response.json()
         self.assertIn("count", data)
         self.assertIn("results", data)
         self.assertEqual(data["count"], 1)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_by_hw_address_and_subnet_returns_200(self, MockKeaClient):
+    def test_get_by_hw_address_and_subnet_returns_200(self):
         """?hw_address=aa:bb&subnet_id=1 returns 200."""
-        mock_client = MagicMock(spec=KeaClient)
-        MockKeaClient.return_value = mock_client
-        mock_client.reservation_get.return_value = _RESERVATION4_RESPONSE[0]["arguments"]
-        response = self.api_client.get(self._url(), {"hw_address": "aa:bb:cc:dd:ee:ff", "subnet_id": "1"})
+        with stub_kea({"reservation-get": _RESERVATION4_RESPONSE}):
+            response = self.api_client.get(self._url(), {"hw_address": "aa:bb:cc:dd:ee:ff", "subnet_id": "1"})
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_by_subnet_id_uses_get_page(self, MockKeaClient):
-        """?subnet_id=1 (no IP/hw) calls reservation_get_page and returns results."""
-        mock_client = MagicMock(spec=KeaClient)
-        MockKeaClient.return_value = mock_client
-        # reservation_get_page returns (hosts, next_from, next_source_index)
-        mock_client.reservation_get_page.return_value = (
-            _RESERVATION4_PAGE_RESPONSE[0]["arguments"]["hosts"],
-            0,
-            0,
-        )
-        response = self.api_client.get(self._url(), {"subnet_id": "1"})
+    def test_get_by_subnet_id_uses_get_page(self):
+        """?subnet_id=1 (no IP/hw) drives reservation-get-page and returns results."""
+        with stub_kea({"reservation-get-page": _RESERVATION4_PAGE_RESPONSE}) as kea:
+            response = self.api_client.get(self._url(), {"subnet_id": "1"})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["count"], 1)
+        self.assertIn("reservation-get-page", kea.commands())
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_by_subnet_id_paginates_all_pages(self, MockKeaClient):
-        """?subnet_id=1 fetches ALL pages from reservation_get_page, not just the first."""
-        mock_client = MagicMock(spec=KeaClient)
-        MockKeaClient.return_value = mock_client
-        page1_host = {"ip-address": "10.0.0.51", "hw-address": "aa:bb:cc:dd:ee:01", "subnet-id": 1}
-        page2_host = {"ip-address": "10.0.0.52", "hw-address": "aa:bb:cc:dd:ee:02", "subnet-id": 1}
-        mock_client.reservation_get_page.side_effect = [
-            ([page1_host], 1, 0),  # first page: next_from=1, not exhausted
-            ([page2_host], 0, 0),  # second page: exhausted
-        ]
-        response = self.api_client.get(self._url(), {"subnet_id": "1"})
+    def test_get_by_subnet_id_paginates_all_pages(self):
+        """?subnet_id=1 fetches ALL pages from reservation-get-page, not just the first."""
+        page1 = {
+            "result": 0,
+            "arguments": {
+                "hosts": [{"ip-address": "10.0.0.51", "hw-address": "aa:bb:cc:dd:ee:01", "subnet-id": 1}],
+                "next": {"from": 1, "source-index": 0},  # not exhausted
+            },
+        }
+        page2 = {
+            "result": 0,
+            "arguments": {
+                "hosts": [{"ip-address": "10.0.0.52", "hw-address": "aa:bb:cc:dd:ee:02", "subnet-id": 1}],
+                "next": {"from": 0, "source-index": 0},  # exhausted
+            },
+        }
+        with stub_kea({"reservation-get-page": queued(page1, page2)}) as kea:
+            response = self.api_client.get(self._url(), {"subnet_id": "1"})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["count"], 2)
-        self.assertEqual(mock_client.reservation_get_page.call_count, 2)
+        self.assertEqual(len(kea.bodies("reservation-get-page")), 2)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_not_found_returns_empty_results(self, MockKeaClient):
-        """When reservation_get returns None, results is empty list with count=0."""
-        mock_client = MagicMock(spec=KeaClient)
-        MockKeaClient.return_value = mock_client
-        mock_client.reservation_get.return_value = None
-        response = self.api_client.get(self._url(), {"ip_address": "10.0.0.99", "subnet_id": "1"})
+    def test_not_found_returns_empty_results(self):
+        """When reservation-get returns not-found (result 3), results is empty with count=0."""
+        with stub_kea({"reservation-get": _RESERVATION_NOT_FOUND}):
+            response = self.api_client.get(self._url(), {"ip_address": "10.0.0.99", "subnet_id": "1"})
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(data["count"], 0)
         self.assertEqual(data["results"], [])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_kea_connection_error_returns_502(self, MockKeaClient):
+    def test_kea_connection_error_returns_502(self):
         """When Kea is unreachable, returns HTTP 502."""
         import requests as rq
 
-        mock_client = MagicMock(spec=KeaClient)
-        MockKeaClient.return_value = mock_client
-        mock_client.reservation_get.side_effect = rq.ConnectionError("refused")
-        response = self.api_client.get(self._url(), {"ip_address": "10.0.0.1", "subnet_id": "1"})
+        with stub_kea({"reservation-get": rq.ConnectionError("refused")}):
+            response = self.api_client.get(self._url(), {"ip_address": "10.0.0.1", "subnet_id": "1"})
         self.assertEqual(response.status_code, 502)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_uses_dhcp4_service(self, MockKeaClient):
-        """The v4 endpoint calls reservation_get with service='dhcp4'."""
-        mock_client = MagicMock(spec=KeaClient)
-        MockKeaClient.return_value = mock_client
-        mock_client.reservation_get.return_value = _RESERVATION4_RESPONSE[0]["arguments"]
-        self.api_client.get(self._url(), {"ip_address": "10.0.0.50", "subnet_id": "1"})
-        call_args = mock_client.reservation_get.call_args
-        self.assertEqual(call_args.args[0], "dhcp4")
+    def test_uses_dhcp4_service(self):
+        """The v4 endpoint issues reservation-get to service='dhcp4'."""
+        with stub_kea({"reservation-get": _RESERVATION4_RESPONSE}) as kea:
+            self.api_client.get(self._url(), {"ip_address": "10.0.0.50", "subnet_id": "1"})
+        self.assertEqual(kea.bodies("reservation-get")[0]["service"], ["dhcp4"])
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -282,30 +264,20 @@ class TestReservation6API(_APITestBase):
         self.assertEqual(response.status_code, 400)
         self.assertIn("subnet_id", response.json()["detail"])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_by_ip_and_subnet_returns_200(self, MockKeaClient):
+    def test_get_by_ip_and_subnet_returns_200(self):
         """?ip_address=2001:db8::50&subnet_id=10 returns 200."""
-        mock_client = MagicMock(spec=KeaClient)
-        MockKeaClient.return_value = mock_client
-        mock_client.reservation_get.return_value = _RESERVATION6_SINGLE[0]["arguments"]
-        response = self.api_client.get(self._url(), {"ip_address": "2001:db8::50", "subnet_id": "10"})
+        with stub_kea({"reservation-get": _RESERVATION6_SINGLE}):
+            response = self.api_client.get(self._url(), {"ip_address": "2001:db8::50", "subnet_id": "10"})
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_by_duid_and_subnet_returns_200(self, MockKeaClient):
+    def test_get_by_duid_and_subnet_returns_200(self):
         """?duid=00:01:02:03&subnet_id=10 returns 200."""
-        mock_client = MagicMock(spec=KeaClient)
-        MockKeaClient.return_value = mock_client
-        mock_client.reservation_get.return_value = _RESERVATION6_SINGLE[0]["arguments"]
-        response = self.api_client.get(self._url(), {"duid": "00:01:02:03", "subnet_id": "10"})
+        with stub_kea({"reservation-get": _RESERVATION6_SINGLE}):
+            response = self.api_client.get(self._url(), {"duid": "00:01:02:03", "subnet_id": "10"})
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_uses_dhcp6_service(self, MockKeaClient):
-        """The v6 endpoint calls reservation_get with service='dhcp6'."""
-        mock_client = MagicMock(spec=KeaClient)
-        MockKeaClient.return_value = mock_client
-        mock_client.reservation_get.return_value = _RESERVATION6_SINGLE[0]["arguments"]
-        self.api_client.get(self._url(), {"ip_address": "2001:db8::50", "subnet_id": "10"})
-        call_args = mock_client.reservation_get.call_args
-        self.assertEqual(call_args.args[0], "dhcp6")
+    def test_uses_dhcp6_service(self):
+        """The v6 endpoint issues reservation-get to service='dhcp6'."""
+        with stub_kea({"reservation-get": _RESERVATION6_SINGLE}) as kea:
+            self.api_client.get(self._url(), {"ip_address": "2001:db8::50", "subnet_id": "10"})
+        self.assertEqual(kea.bodies("reservation-get")[0]["service"], ["dhcp6"])

--- a/netbox_kea/tests/test_api_views_direct.py
+++ b/netbox_kea/tests/test_api_views_direct.py
@@ -6,6 +6,13 @@ Covers all paths in _lease_search, _fetch_leases, _reservation_search, and
 _fetch_reservations.  The TestCase-based api test files cover the same happy
 paths via a real DB + HTTP stack; these SimpleTestCase tests provide fast,
 DB-free coverage for every branch.
+
+The view methods are called directly (DRF's get_object/permission hooks are the
+only mocks — they are framework plumbing, not Kea). ``get_object`` returns a
+**real, unsaved** ``Server`` (instantiating a model touches no DB), so
+``server.get_client()`` builds a **real** ``KeaClient`` and the HTTP boundary is
+stubbed via ``kea_stub.stub_kea`` — the actual ``command`` payloads (command name
++ ``service``) are exercised, and error paths run through the real client.
 """
 
 from __future__ import annotations
@@ -17,26 +24,40 @@ from django.test import SimpleTestCase, override_settings
 from rest_framework import status
 
 from netbox_kea.api.views import ServerViewSet
-from netbox_kea.kea import KeaClient, KeaException
 from netbox_kea.models import Server
+
+from .kea_stub import queued, stub_kea
 
 _PLUGINS_CONFIG = {"netbox_kea": {"kea_timeout": 30}}
 
-# Minimal KeaResponse dict accepted by KeaException.__init__
+# A Kea error response (result 1) → the real KeaClient turns this into a KeaException.
 _KEA_ERR_RESP = {"result": 1, "text": "command failed"}
 
 
-def _make_view():
-    """Return a ServerViewSet with get_object() mocked to return a mock Server."""
+def _make_view(**server_kwargs):
+    """Return ``(view, server)`` where *server* is a real (unsaved) Server.
+
+    Only DRF plumbing is stubbed: ``get_object`` returns the real Server and the
+    permission hooks are no-ops so the action can be invoked directly. The Server
+    is a genuine model instance (no ``.save()`` → no DB), so ``get_client()`` builds
+    a real ``KeaClient``.
+    """
     view = ServerViewSet()
     view.kwargs = {}
     view.format_kwarg = None
-    mock_server = MagicMock(spec=Server)
-    mock_server.name = "test-server"
-    view.get_object = MagicMock(return_value=mock_server)  # mock-ok: stub DRF get_object
+    defaults = {
+        "name": "test-server",
+        "ca_url": "https://kea.example.com",
+        "dhcp4": True,
+        "dhcp6": True,
+        "has_control_agent": True,
+    }
+    defaults.update(server_kwargs)
+    server = Server(**defaults)
+    view.get_object = MagicMock(return_value=server)  # mock-ok: DRF get_object → real unsaved Server
     view.check_permissions = MagicMock()  # mock-ok: stub DRF permission hook for direct view call
     view.check_object_permissions = MagicMock()  # mock-ok: stub DRF object-permission hook
-    return view, mock_server
+    return view, server
 
 
 def _make_request(query_params: dict):
@@ -44,15 +65,6 @@ def _make_request(query_params: dict):
     req = MagicMock()  # mock-ok: minimal DRF request (query_params only)
     req.query_params = query_params
     return req
-
-
-def _view_with_command(command_return):
-    """Return (view, mock_client) with client.command pre-configured."""
-    view, server = _make_view()
-    mock_client = MagicMock(spec=KeaClient)
-    mock_client.command.return_value = command_return
-    server.get_client.return_value = mock_client
-    return view, mock_client
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -65,22 +77,18 @@ class TestLeaseActionDispatch(SimpleTestCase):
     """leases4() and leases6() dispatch to _lease_search with the right version."""
 
     def test_leases4_dispatches_with_version_4(self):
-        view, server = _make_view()
-        mock_client = MagicMock(spec=KeaClient)
-        mock_client.command.return_value = [{"result": 0, "arguments": None}]
-        server.get_client.return_value = mock_client
-        response = view.leases4(_make_request({"ip_address": "10.0.0.1"}), pk=1)
-        server.get_client.assert_called_once_with(version=4)
+        view, _ = _make_view()
+        with stub_kea({"lease4-get": [{"result": 0, "arguments": None}]}) as kea:
+            response = view.leases4(_make_request({"ip_address": "10.0.0.1"}), pk=1)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(kea.bodies("lease4-get")[0]["service"], ["dhcp4"])
 
     def test_leases6_dispatches_with_version_6(self):
-        view, server = _make_view()
-        mock_client = MagicMock(spec=KeaClient)
-        mock_client.command.return_value = [{"result": 0, "arguments": None}]
-        server.get_client.return_value = mock_client
-        response = view.leases6(_make_request({"ip_address": "2001:db8::1"}), pk=1)
-        server.get_client.assert_called_once_with(version=6)
+        view, _ = _make_view()
+        with stub_kea({"lease6-get": [{"result": 0, "arguments": None}]}) as kea:
+            response = view.leases6(_make_request({"ip_address": "2001:db8::1"}), pk=1)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(kea.bodies("lease6-get")[0]["service"], ["dhcp6"])
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -90,54 +98,59 @@ class TestLeaseActionDispatch(SimpleTestCase):
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestLeaseSearchValidation(SimpleTestCase):
-    """Parameter validation paths in _lease_search."""
+    """Parameter validation paths in _lease_search (no Kea traffic)."""
 
     def test_no_params_returns_400(self):
         view, _ = _make_view()
-        response = view._lease_search(_make_request({}), version=4)
+        with stub_kea({}) as kea:
+            response = view._lease_search(_make_request({}), version=4)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("required", response.data["detail"])
+        self.assertEqual(kea.commands(), [])
 
     def test_no_params_v6_includes_duid_in_message(self):
         view, _ = _make_view()
-        response = view._lease_search(_make_request({}), version=6)
+        with stub_kea({}):
+            response = view._lease_search(_make_request({}), version=6)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("duid", response.data["detail"])
 
     def test_invalid_subnet_id_returns_400(self):
         view, _ = _make_view()
-        response = view._lease_search(_make_request({"subnet_id": "not-a-number"}), version=4)
+        with stub_kea({}):
+            response = view._lease_search(_make_request({"subnet_id": "not-a-number"}), version=4)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("subnet_id", response.data["detail"])
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestLeaseSearchErrors(SimpleTestCase):
-    """Error handling paths in _lease_search."""
+    """Error handling paths in _lease_search (real client, boundary-injected errors)."""
 
     def test_connection_error_returns_502(self):
-        view, server = _make_view()
-        server.get_client.side_effect = rq.ConnectionError("refused")
-        response = view._lease_search(_make_request({"ip_address": "10.0.0.1"}), version=4)
+        view, _ = _make_view()
+        with stub_kea({"lease4-get": rq.ConnectionError("refused")}):
+            response = view._lease_search(_make_request({"ip_address": "10.0.0.1"}), version=4)
         self.assertEqual(response.status_code, status.HTTP_502_BAD_GATEWAY)
 
     def test_kea_exception_returns_502(self):
-        view, server = _make_view()
-        server.get_client.side_effect = KeaException(_KEA_ERR_RESP)
-        response = view._lease_search(_make_request({"ip_address": "10.0.0.1"}), version=4)
+        view, _ = _make_view()
+        with stub_kea({"lease4-get": _KEA_ERR_RESP}):
+            response = view._lease_search(_make_request({"ip_address": "10.0.0.1"}), version=4)
         self.assertEqual(response.status_code, status.HTTP_502_BAD_GATEWAY)
 
     def test_value_error_returns_500(self):
-        view, server = _make_view()
-        server.get_client.side_effect = ValueError("missing DHCPv4 URL")
-        response = view._lease_search(_make_request({"ip_address": "10.0.0.1"}), version=4)
+        # cert-without-key makes the real get_client() raise ValueError (configuration error).
+        view, _ = _make_view(client_cert_path="/nonexistent-cert.pem")
+        with stub_kea({}):
+            response = view._lease_search(_make_request({"ip_address": "10.0.0.1"}), version=4)
         self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
         self.assertIn("configuration error", response.data["detail"].lower())
 
     def test_generic_exception_returns_500(self):
-        view, server = _make_view()
-        server.get_client.side_effect = RuntimeError("unexpected internal error")
-        response = view._lease_search(_make_request({"ip_address": "10.0.0.1"}), version=4)
+        view, _ = _make_view()
+        with stub_kea({"lease4-get": RuntimeError("unexpected internal error")}):
+            response = view._lease_search(_make_request({"ip_address": "10.0.0.1"}), version=4)
         self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
         self.assertIn("internal error", response.data["detail"].lower())
 
@@ -149,106 +162,116 @@ class TestLeaseSearchErrors(SimpleTestCase):
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestFetchLeasesIpAddress(SimpleTestCase):
-    """ip_address branch in _fetch_leases (lines 112-122)."""
+    """ip_address branch in _fetch_leases (lease{v}-get)."""
 
     def test_result3_returns_empty(self):
-        view, _ = _view_with_command([{"result": 3, "text": "not found"}])
-        response = view._lease_search(_make_request({"ip_address": "10.0.0.99"}), version=4)
+        view, _ = _make_view()
+        with stub_kea({"lease4-get": [{"result": 3, "text": "not found"}]}):
+            response = view._lease_search(_make_request({"ip_address": "10.0.0.99"}), version=4)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 0)
 
     def test_null_arguments_returns_empty(self):
-        view, _ = _view_with_command([{"result": 0, "arguments": None}])
-        response = view._lease_search(_make_request({"ip_address": "10.0.0.1"}), version=4)
+        view, _ = _make_view()
+        with stub_kea({"lease4-get": [{"result": 0, "arguments": None}]}):
+            response = view._lease_search(_make_request({"ip_address": "10.0.0.1"}), version=4)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 0)
 
     def test_lease_returned_in_results(self):
         lease = {"ip-address": "10.0.0.1", "subnet-id": 1}
-        view, _ = _view_with_command([{"result": 0, "arguments": lease}])
-        response = view._lease_search(_make_request({"ip_address": "10.0.0.1"}), version=4)
+        view, _ = _make_view()
+        with stub_kea({"lease4-get": [{"result": 0, "arguments": lease}]}):
+            response = view._lease_search(_make_request({"ip_address": "10.0.0.1"}), version=4)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 1)
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestFetchLeasesHwAddress(SimpleTestCase):
-    """hw_address branch in _fetch_leases (lines 124-133)."""
+    """hw_address branch in _fetch_leases (lease{v}-get-by-hw-address)."""
 
     def test_result3_returns_empty(self):
-        view, _ = _view_with_command([{"result": 3}])
-        response = view._lease_search(_make_request({"hw_address": "aa:bb:cc:dd:ee:ff"}), version=4)
+        view, _ = _make_view()
+        with stub_kea({"lease4-get-by-hw-address": [{"result": 3}]}):
+            response = view._lease_search(_make_request({"hw_address": "aa:bb:cc:dd:ee:ff"}), version=4)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 0)
 
     def test_leases_returned_in_results(self):
         lease = {"ip-address": "10.0.0.1", "hw-address": "aa:bb:cc:dd:ee:ff", "subnet-id": 1}
-        view, _ = _view_with_command([{"result": 0, "arguments": {"leases": [lease]}}])
-        response = view._lease_search(_make_request({"hw_address": "aa:bb:cc:dd:ee:ff"}), version=4)
+        view, _ = _make_view()
+        with stub_kea({"lease4-get-by-hw-address": [{"result": 0, "arguments": {"leases": [lease]}}]}):
+            response = view._lease_search(_make_request({"hw_address": "aa:bb:cc:dd:ee:ff"}), version=4)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 1)
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestFetchLeasesDuid(SimpleTestCase):
-    """duid branch in _fetch_leases (lines 135-144)."""
+    """duid branch in _fetch_leases (lease6-get-by-duid)."""
 
     def test_result3_returns_empty(self):
-        view, _ = _view_with_command([{"result": 3}])
-        response = view._lease_search(_make_request({"duid": "00:01:02:03"}), version=6)
+        view, _ = _make_view()
+        with stub_kea({"lease6-get-by-duid": [{"result": 3}]}):
+            response = view._lease_search(_make_request({"duid": "00:01:02:03"}), version=6)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 0)
 
     def test_leases_returned_in_results(self):
         lease = {"ip-address": "2001:db8::1", "duid": "00:01:02:03", "subnet-id": 10}
-        view, _ = _view_with_command([{"result": 0, "arguments": {"leases": [lease]}}])
-        response = view._lease_search(_make_request({"duid": "00:01:02:03"}), version=6)
+        view, _ = _make_view()
+        with stub_kea({"lease6-get-by-duid": [{"result": 0, "arguments": {"leases": [lease]}}]}):
+            response = view._lease_search(_make_request({"duid": "00:01:02:03"}), version=6)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 1)
 
     def test_duid_on_v4_falls_through_to_empty(self):
-        """duid provided on v4 skips the duid branch; no other param matches → empty (line 168)."""
-        view, server = _make_view()
-        mock_client = MagicMock(spec=KeaClient)
-        server.get_client.return_value = mock_client
-        response = view._lease_search(_make_request({"duid": "00:01:02:03"}), version=4)
+        """duid provided on v4 skips the duid branch; no other param matches → empty (no Kea call)."""
+        view, _ = _make_view()
+        with stub_kea({}) as kea:
+            response = view._lease_search(_make_request({"duid": "00:01:02:03"}), version=4)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 0)
-        mock_client.command.assert_not_called()
+        self.assertEqual(kea.commands(), [])
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestFetchLeasesHostname(SimpleTestCase):
-    """hostname branch in _fetch_leases (lines 146-155)."""
+    """hostname branch in _fetch_leases (lease{v}-get-by-hostname)."""
 
     def test_result3_returns_empty(self):
-        view, _ = _view_with_command([{"result": 3}])
-        response = view._lease_search(_make_request({"hostname": "host1"}), version=4)
+        view, _ = _make_view()
+        with stub_kea({"lease4-get-by-hostname": [{"result": 3}]}):
+            response = view._lease_search(_make_request({"hostname": "host1"}), version=4)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 0)
 
     def test_leases_returned_in_results(self):
         lease = {"ip-address": "10.0.0.1", "hostname": "host1", "subnet-id": 1}
-        view, _ = _view_with_command([{"result": 0, "arguments": {"leases": [lease]}}])
-        response = view._lease_search(_make_request({"hostname": "host1"}), version=4)
+        view, _ = _make_view()
+        with stub_kea({"lease4-get-by-hostname": [{"result": 0, "arguments": {"leases": [lease]}}]}):
+            response = view._lease_search(_make_request({"hostname": "host1"}), version=4)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 1)
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestFetchLeasesSubnetId(SimpleTestCase):
-    """subnet_id branch in _fetch_leases (lines 157-166)."""
+    """subnet_id branch in _fetch_leases (lease{v}-get-all)."""
 
     def test_result3_returns_empty(self):
-        view, _ = _view_with_command([{"result": 3}])
-        response = view._lease_search(_make_request({"subnet_id": "1"}), version=4)
+        view, _ = _make_view()
+        with stub_kea({"lease4-get-all": [{"result": 3}]}):
+            response = view._lease_search(_make_request({"subnet_id": "1"}), version=4)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 0)
 
     def test_leases_returned_in_results(self):
         lease = {"ip-address": "10.0.0.1", "subnet-id": 1}
-        view, _ = _view_with_command([{"result": 0, "arguments": {"leases": [lease]}}])
-        response = view._lease_search(_make_request({"subnet_id": "1"}), version=4)
+        view, _ = _make_view()
+        with stub_kea({"lease4-get-all": [{"result": 0, "arguments": {"leases": [lease]}}]}):
+            response = view._lease_search(_make_request({"subnet_id": "1"}), version=4)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 1)
 
@@ -263,22 +286,20 @@ class TestReservationActionDispatch(SimpleTestCase):
     """reservations4() and reservations6() dispatch with correct version."""
 
     def test_reservations4_dispatches_with_version_4(self):
-        view, server = _make_view()
-        mock_client = MagicMock(spec=KeaClient)
-        mock_client.reservation_get.return_value = {"ip-address": "10.0.0.50", "subnet-id": 1}
-        server.get_client.return_value = mock_client
-        response = view.reservations4(_make_request({"ip_address": "10.0.0.50", "subnet_id": "1"}), pk=1)
-        server.get_client.assert_called_once_with(version=4)
+        view, _ = _make_view()
+        reservation = {"result": 0, "arguments": {"ip-address": "10.0.0.50", "subnet-id": 1}}
+        with stub_kea({"reservation-get": reservation}) as kea:
+            response = view.reservations4(_make_request({"ip_address": "10.0.0.50", "subnet_id": "1"}), pk=1)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(kea.bodies("reservation-get")[0]["service"], ["dhcp4"])
 
     def test_reservations6_dispatches_with_version_6(self):
-        view, server = _make_view()
-        mock_client = MagicMock(spec=KeaClient)
-        mock_client.reservation_get.return_value = {"ip-addresses": ["2001:db8::50"], "subnet-id": 10}
-        server.get_client.return_value = mock_client
-        response = view.reservations6(_make_request({"ip_address": "2001:db8::50", "subnet_id": "10"}), pk=1)
-        server.get_client.assert_called_once_with(version=6)
+        view, _ = _make_view()
+        reservation = {"result": 0, "arguments": {"ip-addresses": ["2001:db8::50"], "subnet-id": 10}}
+        with stub_kea({"reservation-get": reservation}) as kea:
+            response = view.reservations6(_make_request({"ip_address": "2001:db8::50", "subnet_id": "10"}), pk=1)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(kea.bodies("reservation-get")[0]["service"], ["dhcp6"])
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -288,54 +309,58 @@ class TestReservationActionDispatch(SimpleTestCase):
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestReservationSearchValidation(SimpleTestCase):
-    """Parameter validation paths in _reservation_search."""
+    """Parameter validation paths in _reservation_search (no Kea traffic)."""
 
     def test_no_params_returns_400(self):
         view, _ = _make_view()
-        response = view._reservation_search(_make_request({}), version=4)
+        with stub_kea({}) as kea:
+            response = view._reservation_search(_make_request({}), version=4)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("required", response.data["detail"])
+        self.assertEqual(kea.commands(), [])
 
     def test_no_params_v6_includes_duid_in_message(self):
         view, _ = _make_view()
-        response = view._reservation_search(_make_request({}), version=6)
+        with stub_kea({}):
+            response = view._reservation_search(_make_request({}), version=6)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("duid", response.data["detail"])
 
     def test_invalid_subnet_id_returns_400(self):
         view, _ = _make_view()
-        response = view._reservation_search(_make_request({"subnet_id": "not-a-number"}), version=4)
+        with stub_kea({}):
+            response = view._reservation_search(_make_request({"subnet_id": "not-a-number"}), version=4)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("subnet_id", response.data["detail"])
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestReservationSearchErrors(SimpleTestCase):
-    """Error handling paths in _reservation_search."""
+    """Error handling paths in _reservation_search (real client, boundary-injected errors)."""
 
     def test_connection_error_returns_502(self):
-        view, server = _make_view()
-        server.get_client.side_effect = rq.ConnectionError("refused")
-        response = view._reservation_search(_make_request({"subnet_id": "1"}), version=4)
+        view, _ = _make_view()
+        with stub_kea({"reservation-get-page": rq.ConnectionError("refused")}):
+            response = view._reservation_search(_make_request({"subnet_id": "1"}), version=4)
         self.assertEqual(response.status_code, status.HTTP_502_BAD_GATEWAY)
 
     def test_kea_exception_returns_502(self):
-        view, server = _make_view()
-        server.get_client.side_effect = KeaException(_KEA_ERR_RESP)
-        response = view._reservation_search(_make_request({"subnet_id": "1"}), version=4)
+        view, _ = _make_view()
+        with stub_kea({"reservation-get-page": _KEA_ERR_RESP}):
+            response = view._reservation_search(_make_request({"subnet_id": "1"}), version=4)
         self.assertEqual(response.status_code, status.HTTP_502_BAD_GATEWAY)
 
     def test_value_error_returns_500(self):
-        view, server = _make_view()
-        server.get_client.side_effect = ValueError("missing DHCPv4 URL")
-        response = view._reservation_search(_make_request({"subnet_id": "1"}), version=4)
+        view, _ = _make_view(client_cert_path="/nonexistent-cert.pem")
+        with stub_kea({}):
+            response = view._reservation_search(_make_request({"subnet_id": "1"}), version=4)
         self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
         self.assertIn("configuration error", response.data["detail"].lower())
 
     def test_generic_exception_returns_500(self):
-        view, server = _make_view()
-        server.get_client.side_effect = RuntimeError("unexpected")
-        response = view._reservation_search(_make_request({"subnet_id": "1"}), version=4)
+        view, _ = _make_view()
+        with stub_kea({"reservation-get-page": RuntimeError("unexpected")}):
+            response = view._reservation_search(_make_request({"subnet_id": "1"}), version=4)
         self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
         self.assertIn("internal error", response.data["detail"].lower())
 
@@ -347,107 +372,99 @@ class TestReservationSearchErrors(SimpleTestCase):
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestFetchReservationsIpAndSubnet(SimpleTestCase):
-    """ip_address + subnet_id branch in _fetch_reservations (lines 253-255)."""
+    """ip_address + subnet_id branch in _fetch_reservations (reservation-get)."""
 
     def test_found_returns_one_reservation(self):
-        view, server = _make_view()
-        mock_client = MagicMock(spec=KeaClient)
-        mock_client.reservation_get.return_value = {"ip-address": "10.0.0.50", "subnet-id": 1}
-        server.get_client.return_value = mock_client
-        response = view._reservation_search(_make_request({"ip_address": "10.0.0.50", "subnet_id": "1"}), version=4)
+        view, _ = _make_view()
+        reservation = {"result": 0, "arguments": {"ip-address": "10.0.0.50", "subnet-id": 1}}
+        with stub_kea({"reservation-get": reservation}):
+            response = view._reservation_search(_make_request({"ip_address": "10.0.0.50", "subnet_id": "1"}), version=4)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 1)
 
     def test_not_found_returns_empty(self):
-        view, server = _make_view()
-        mock_client = MagicMock(spec=KeaClient)
-        mock_client.reservation_get.return_value = None
-        server.get_client.return_value = mock_client
-        response = view._reservation_search(_make_request({"ip_address": "10.0.0.99", "subnet_id": "1"}), version=4)
+        view, _ = _make_view()
+        with stub_kea({"reservation-get": {"result": 3}}):
+            response = view._reservation_search(_make_request({"ip_address": "10.0.0.99", "subnet_id": "1"}), version=4)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 0)
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestFetchReservationsHwAndSubnet(SimpleTestCase):
-    """hw_address + subnet_id branch in _fetch_reservations (lines 257-259)."""
+    """hw_address + subnet_id branch in _fetch_reservations (reservation-get)."""
 
     def test_found_returns_one_reservation(self):
-        view, server = _make_view()
-        mock_client = MagicMock(spec=KeaClient)
-        mock_client.reservation_get.return_value = {"ip-address": "10.0.0.50", "hw-address": "aa:bb:cc:dd:ee:ff"}
-        server.get_client.return_value = mock_client
-        response = view._reservation_search(
-            _make_request({"hw_address": "aa:bb:cc:dd:ee:ff", "subnet_id": "1"}), version=4
-        )
+        view, _ = _make_view()
+        reservation = {"result": 0, "arguments": {"ip-address": "10.0.0.50", "hw-address": "aa:bb:cc:dd:ee:ff"}}
+        with stub_kea({"reservation-get": reservation}):
+            response = view._reservation_search(
+                _make_request({"hw_address": "aa:bb:cc:dd:ee:ff", "subnet_id": "1"}), version=4
+            )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 1)
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestFetchReservationsDuidAndSubnet(SimpleTestCase):
-    """duid + subnet_id + version=6 branch in _fetch_reservations (lines 261-263)."""
+    """duid + subnet_id + version=6 branch in _fetch_reservations (reservation-get)."""
 
     def test_found_returns_one_reservation(self):
-        view, server = _make_view()
-        mock_client = MagicMock(spec=KeaClient)
-        mock_client.reservation_get.return_value = {"ip-addresses": ["2001:db8::50"], "duid": "00:01:02:03"}
-        server.get_client.return_value = mock_client
-        response = view._reservation_search(_make_request({"duid": "00:01:02:03", "subnet_id": "10"}), version=6)
+        view, _ = _make_view()
+        reservation = {"result": 0, "arguments": {"ip-addresses": ["2001:db8::50"], "duid": "00:01:02:03"}}
+        with stub_kea({"reservation-get": reservation}):
+            response = view._reservation_search(_make_request({"duid": "00:01:02:03", "subnet_id": "10"}), version=6)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 1)
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestFetchReservationsSubnetOnly(SimpleTestCase):
-    """subnet_id-only pagination branch in _fetch_reservations (lines 265-277)."""
+    """subnet_id-only pagination branch in _fetch_reservations (reservation-get-page)."""
+
+    def _page(self, hosts, *, next_from=0, next_source=0):
+        return {"result": 0, "arguments": {"hosts": hosts, "next": {"from": next_from, "source-index": next_source}}}
 
     def test_single_page_returns_all_hosts(self):
-        view, server = _make_view()
-        mock_client = MagicMock(spec=KeaClient)
+        view, _ = _make_view()
         host = {"ip-address": "10.0.0.50", "subnet-id": 1}
-        mock_client.reservation_get_page.return_value = ([host], 0, 0)
-        server.get_client.return_value = mock_client
-        response = view._reservation_search(_make_request({"subnet_id": "1"}), version=4)
+        with stub_kea({"reservation-get-page": self._page([host])}):
+            response = view._reservation_search(_make_request({"subnet_id": "1"}), version=4)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 1)
 
     def test_multi_page_collects_all_hosts(self):
-        view, server = _make_view()
-        mock_client = MagicMock(spec=KeaClient)
+        view, _ = _make_view()
         host1 = {"ip-address": "10.0.0.1", "subnet-id": 1}
         host2 = {"ip-address": "10.0.0.2", "subnet-id": 1}
-        mock_client.reservation_get_page.side_effect = [
-            ([host1], 1, 1),  # first page: next_from=1 → continue
-            ([host2], 0, 0),  # second page: exhausted
-        ]
-        server.get_client.return_value = mock_client
-        response = view._reservation_search(_make_request({"subnet_id": "1"}), version=4)
+        pages = queued(
+            self._page([host1], next_from=1, next_source=1),  # not exhausted
+            self._page([host2]),  # exhausted
+        )
+        with stub_kea({"reservation-get-page": pages}):
+            response = view._reservation_search(_make_request({"subnet_id": "1"}), version=4)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 2)
 
     def test_filters_by_subnet_id(self):
-        view, server = _make_view()
-        mock_client = MagicMock(spec=KeaClient)
+        view, _ = _make_view()
         host_in = {"ip-address": "10.0.0.1", "subnet-id": 1}
         host_out = {"ip-address": "10.0.0.2", "subnet-id": 2}
-        mock_client.reservation_get_page.return_value = ([host_in, host_out], 0, 0)
-        server.get_client.return_value = mock_client
-        response = view._reservation_search(_make_request({"subnet_id": "1"}), version=4)
+        with stub_kea({"reservation-get-page": self._page([host_in, host_out])}):
+            response = view._reservation_search(_make_request({"subnet_id": "1"}), version=4)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 1)
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestFetchReservationsNoMatch(SimpleTestCase):
-    """Fallthrough return [] when no branch matches (line 279)."""
+    """Fallthrough return [] when no branch matches."""
 
     def test_duid_without_subnet_on_v4_returns_empty(self):
-        """duid only on v4 (no subnet_id) — none of the 4 branches fires → empty list."""
-        view, server = _make_view()
-        mock_client = MagicMock(spec=KeaClient)
-        server.get_client.return_value = mock_client
-        response = view._reservation_search(_make_request({"duid": "00:01:02:03"}), version=4)
+        """duid only on v4 (no subnet_id) — none of the 4 branches fires → empty list, no Kea call."""
+        view, _ = _make_view()
+        with stub_kea({}) as kea:
+            response = view._reservation_search(_make_request({"duid": "00:01:02:03"}), version=4)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 0)
-        mock_client.reservation_get.assert_not_called()
+        self.assertEqual(kea.commands(), [])

--- a/netbox_kea/tests/test_api_views_direct.py
+++ b/netbox_kea/tests/test_api_views_direct.py
@@ -26,7 +26,7 @@ from rest_framework import status
 from netbox_kea.api.views import ServerViewSet
 from netbox_kea.models import Server
 
-from .kea_stub import queued, stub_kea
+from .kea_stub import _res_page, queued, stub_kea
 
 _PLUGINS_CONFIG = {"netbox_kea": {"kea_timeout": 30}}
 
@@ -422,13 +422,10 @@ class TestFetchReservationsDuidAndSubnet(SimpleTestCase):
 class TestFetchReservationsSubnetOnly(SimpleTestCase):
     """subnet_id-only pagination branch in _fetch_reservations (reservation-get-page)."""
 
-    def _page(self, hosts, *, next_from=0, next_source=0):
-        return {"result": 0, "arguments": {"hosts": hosts, "next": {"from": next_from, "source-index": next_source}}}
-
     def test_single_page_returns_all_hosts(self):
         view, _ = _make_view()
         host = {"ip-address": "10.0.0.50", "subnet-id": 1}
-        with stub_kea({"reservation-get-page": self._page([host])}):
+        with stub_kea({"reservation-get-page": _res_page([host])}):
             response = view._reservation_search(_make_request({"subnet_id": "1"}), version=4)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 1)
@@ -438,8 +435,8 @@ class TestFetchReservationsSubnetOnly(SimpleTestCase):
         host1 = {"ip-address": "10.0.0.1", "subnet-id": 1}
         host2 = {"ip-address": "10.0.0.2", "subnet-id": 1}
         pages = queued(
-            self._page([host1], next_from=1, next_source=1),  # not exhausted
-            self._page([host2]),  # exhausted
+            _res_page([host1], next_from=1, next_source=1),  # not exhausted
+            _res_page([host2]),  # exhausted
         )
         with stub_kea({"reservation-get-page": pages}):
             response = view._reservation_search(_make_request({"subnet_id": "1"}), version=4)
@@ -450,7 +447,7 @@ class TestFetchReservationsSubnetOnly(SimpleTestCase):
         view, _ = _make_view()
         host_in = {"ip-address": "10.0.0.1", "subnet-id": 1}
         host_out = {"ip-address": "10.0.0.2", "subnet-id": 2}
-        with stub_kea({"reservation-get-page": self._page([host_in, host_out])}):
+        with stub_kea({"reservation-get-page": _res_page([host_in, host_out])}):
             response = view._reservation_search(_make_request({"subnet_id": "1"}), version=4)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 1)

--- a/netbox_kea/tests/test_global_views.py
+++ b/netbox_kea/tests/test_global_views.py
@@ -52,7 +52,7 @@ from ipam.models import IPAddress
 from netbox_kea import constants
 from netbox_kea.models import Server
 
-from .kea_stub import stub_kea
+from .kea_stub import _res_get, _res_page, stub_kea
 from .utils import _PLUGINS_CONFIG, User, _make_db_server
 
 # ---------------------------------------------------------------------------
@@ -120,20 +120,6 @@ _MOCK_CONFIG_V6 = [
 # ---------------------------------------------------------------------------
 # Stub response builders (real KeaClient + HTTP-boundary stub)
 # ---------------------------------------------------------------------------
-
-
-def _res_page(hosts):
-    """A ``reservation-get-page`` result: *hosts* then an exhausted cursor.
-
-    ``next.from``/``next.source-index`` both 0 mark the source exhausted, so
-    ``iter_reservations`` stops after this single page.
-    """
-    return {"result": 0, "arguments": {"hosts": list(hosts), "next": {"from": 0, "source-index": 0}}}
-
-
-def _res_get(reservation):
-    """A ``reservation-get`` result (host fields returned directly in ``arguments``)."""
-    return {"result": 0, "arguments": dict(reservation)}
 
 
 def _leases(entries):

--- a/netbox_kea/tests/test_global_views.py
+++ b/netbox_kea/tests/test_global_views.py
@@ -21,24 +21,42 @@ All views:
 - Extend _CombinedViewMixin which injects all_servers, selected_server_pks, server_qs, active_tab
 - Use concurrent.futures.ThreadPoolExecutor for parallel fetching
 - Gracefully handle unreachable servers (warning, not 500)
+
+These tests drive the **real** ``KeaClient``; only the HTTP boundary is stubbed
+via ``kea_stub.stub_kea``, so the request payloads the views actually send to Kea
+are exercised. The command chains each combined view issues (per queried server,
+run concurrently) are:
+
+* dashboard: none — the overview never calls Kea.
+* status badge: ``version-get`` per enabled protocol (Online iff it doesn't raise).
+* reservations: ``reservation-get-page`` (drained via ``iter_reservations``) then,
+  when any reservations are found, ``lease{v}-get-all`` per unique subnet for the
+  active-lease badge (NetBox IPAM badges hit the DB, not Kea).
+* leases (q + by): ``lease{v}-get`` (by IP) or ``lease{v}-get-by-<field>`` then,
+  per lease, ``reservation-get`` (by IP, then by MAC) for the reservation badge.
+* leases (state only, no q): ``lease{v}-get-page`` (enumerate) + the same badge
+  enrichment on the survivors.
+* subnets: ``config-get`` + ``stat-lease{v}-get`` (stats are best-effort).
+* shared networks: ``config-get``.
+
+A transport failure is modelled by registering a ``requests.ConnectionError``
+instance for a command (the stub raises it at the boundary), so the per-server
+error handling runs through the real client instead of a mocked ``side_effect``.
 """
 
-from unittest.mock import MagicMock, patch
-
 import requests
-from django.contrib.auth import get_user_model
 from django.test import TestCase, override_settings
 from django.urls import reverse
+from ipam.models import IPAddress
 
 from netbox_kea import constants
-from netbox_kea.kea import KeaClient
 from netbox_kea.models import Server
 
-User = get_user_model()
-_PLUGINS_CONFIG = {"netbox_kea": {"kea_timeout": 30}}
+from .kea_stub import stub_kea
+from .utils import _PLUGINS_CONFIG, User, _make_db_server
 
 # ---------------------------------------------------------------------------
-# Mock Kea response fixtures
+# Kea response fixtures
 # ---------------------------------------------------------------------------
 
 _MOCK_RESERVATION_V4 = {
@@ -99,17 +117,44 @@ _MOCK_CONFIG_V6 = [
 ]
 
 
-def _make_server(**kwargs) -> Server:
-    """Create a Server without triggering live connectivity checks."""
-    defaults = {
-        "name": "global-test",
-        "ca_url": "https://kea.example.com",
-        "dhcp4": True,
-        "dhcp6": True,
-        "has_control_agent": False,
-    }
-    defaults.update(kwargs)
-    return Server.objects.create(**defaults)
+# ---------------------------------------------------------------------------
+# Stub response builders (real KeaClient + HTTP-boundary stub)
+# ---------------------------------------------------------------------------
+
+
+def _res_page(hosts):
+    """A ``reservation-get-page`` result: *hosts* then an exhausted cursor.
+
+    ``next.from``/``next.source-index`` both 0 mark the source exhausted, so
+    ``iter_reservations`` stops after this single page.
+    """
+    return {"result": 0, "arguments": {"hosts": list(hosts), "next": {"from": 0, "source-index": 0}}}
+
+
+def _res_get(reservation):
+    """A ``reservation-get`` result (host fields returned directly in ``arguments``)."""
+    return {"result": 0, "arguments": dict(reservation)}
+
+
+def _leases(entries):
+    """A multi-lease response for ``lease{v}-get-*`` / ``lease{v}-get-page``."""
+    entries = list(entries)
+    return {"result": 0, "arguments": {"count": len(entries), "leases": entries}}
+
+
+def _lease_one(entry):
+    """A single-lease response for ``lease{v}-get`` (by-IP lookup)."""
+    return {"result": 0, "arguments": dict(entry)}
+
+
+#: ``reservation-get-page`` with no hosts (source exhausted → empty reservation list).
+_RES_EMPTY_PAGE = {"result": 3}
+#: ``reservation-get`` with result 3 = no such reservation.
+_RES_NOT_FOUND = {"result": 3}
+#: ``lease{v}-get-all`` / ``lease{v}-get`` with result 3 = no such lease.
+_LEASE_NONE = {"result": 3}
+#: ``stat-lease{v}-get`` with no result-set (utilisation stats absent, non-fatal).
+_STAT_EMPTY = {"result": 0, "arguments": {}}
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
@@ -123,9 +168,9 @@ class _CombinedViewBase(TestCase):
             password="testpass",
         )
         self.client.force_login(self.user)
-        self.v4_server = _make_server(name="v4-server", dhcp4=True, dhcp6=False)
-        self.v6_server = _make_server(name="v6-server", dhcp4=False, dhcp6=True)
-        self.dual_server = _make_server(name="dual-server", dhcp4=True, dhcp6=True)
+        self.v4_server = _make_db_server(name="v4-server", dhcp4=True, dhcp6=False, has_control_agent=False)
+        self.v6_server = _make_db_server(name="v6-server", dhcp4=False, dhcp6=True, has_control_agent=False)
+        self.dual_server = _make_db_server(name="dual-server", dhcp4=True, dhcp6=True, has_control_agent=False)
 
 
 # ---------------------------------------------------------------------------
@@ -157,11 +202,11 @@ class TestCombinedDashboardView(_CombinedViewBase):
         self.assertContains(response, "dual-server")
 
     def test_no_kea_api_calls_on_dashboard(self):
-        """Dashboard must not call Kea API (would slow down page for many servers)."""
-        with patch("netbox_kea.models.KeaClient") as MockKeaClient:
+        """Dashboard must not call Kea API (would slow down the page for many servers)."""
+        with stub_kea({}) as kea:
             url = reverse("plugins:netbox_kea:combined")
             self.client.get(url)
-        MockKeaClient.assert_not_called()
+        self.assertEqual(kea.commands(), [])
 
     def test_context_contains_all_servers(self):
         url = reverse("plugins:netbox_kea:combined")
@@ -200,19 +245,17 @@ class TestCombinedServerStatusBadge(_CombinedViewBase):
     def _url(self, server):
         return reverse("plugins:netbox_kea:combined_server_status_badge", args=[server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_online_server_returns_200_with_online_text(self, MockKeaClient):
+    def test_online_server_returns_200_with_online_text(self):
         """Reachable server should return 200 and contain 'Online'."""
-        MockKeaClient.return_value.command.return_value = [{"result": 0, "arguments": {"extended": "Kea DHCPv4/2.x"}}]
-        response = self.client.get(self._url(self.v4_server))
+        with stub_kea({"version-get": {"result": 0, "arguments": {"extended": "Kea DHCPv4/2.x"}}}):
+            response = self.client.get(self._url(self.v4_server))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Online")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_offline_server_returns_200_with_offline_text(self, MockKeaClient):
+    def test_offline_server_returns_200_with_offline_text(self):
         """Unreachable server should return 200 and contain 'Offline' (no 500)."""
-        MockKeaClient.return_value.command.side_effect = requests.RequestException("connection refused")
-        response = self.client.get(self._url(self.v4_server))
+        with stub_kea({"version-get": requests.ConnectionError("connection refused")}):
+            response = self.client.get(self._url(self.v4_server))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Offline")
 
@@ -223,36 +266,32 @@ class TestCombinedServerStatusBadge(_CombinedViewBase):
         self.assertEqual(response.status_code, 302)
         self.assertIn("login", response.url)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_v4_only_server_shows_v4_badge(self, MockKeaClient):
+    def test_v4_only_server_shows_v4_badge(self):
         """DHCPv4-only server should show DHCPv4 status badge only."""
-        MockKeaClient.return_value.command.return_value = [{"result": 0, "arguments": {"extended": "Kea DHCPv4/2.x"}}]
-        response = self.client.get(self._url(self.v4_server))
+        with stub_kea({"version-get": {"result": 0, "arguments": {"extended": "Kea DHCPv4/2.x"}}}):
+            response = self.client.get(self._url(self.v4_server))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "DHCPv4")
         self.assertNotContains(response, "DHCPv6")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_v6_only_server_shows_v6_badge(self, MockKeaClient):
+    def test_v6_only_server_shows_v6_badge(self):
         """DHCPv6-only server should show DHCPv6 status badge only."""
-        MockKeaClient.return_value.command.return_value = [{"result": 0, "arguments": {"extended": "Kea DHCPv6/2.x"}}]
-        response = self.client.get(self._url(self.v6_server))
+        with stub_kea({"version-get": {"result": 0, "arguments": {"extended": "Kea DHCPv6/2.x"}}}):
+            response = self.client.get(self._url(self.v6_server))
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, "DHCPv4")
         self.assertContains(response, "DHCPv6")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_dual_stack_shows_both_badges(self, MockKeaClient):
+    def test_dual_stack_shows_both_badges(self):
         """Dual-stack server should show both DHCPv4 and DHCPv6 status badges."""
-        MockKeaClient.return_value.command.return_value = [{"result": 0, "arguments": {"extended": "Kea/2.x"}}]
-        response = self.client.get(self._url(self.dual_server))
+        with stub_kea({"version-get": {"result": 0, "arguments": {"extended": "Kea/2.x"}}}):
+            response = self.client.get(self._url(self.dual_server))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "DHCPv4")
         self.assertContains(response, "DHCPv6")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_nonexistent_server_returns_404(self, MockKeaClient):
-        """Request for a server that does not exist must return 404."""
+    def test_nonexistent_server_returns_404(self):
+        """Request for a server that does not exist must return 404 (before any Kea call)."""
         url = reverse("plugins:netbox_kea:combined_server_status_badge", args=[99999])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
@@ -267,11 +306,10 @@ class TestCombinedServerStatusBadge(_CombinedViewBase):
 class TestCombinedReservations4View(_CombinedViewBase):
     """GET /plugins/kea/combined/reservations4/ — all DHCPv4 reservations."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_returns_200(self, MockKeaClient):
-        MockKeaClient.return_value.reservation_get_page.return_value = ([], 0, 0)
-        url = reverse("plugins:netbox_kea:combined_reservations4")
-        response = self.client.get(url)
+    def test_get_returns_200(self):
+        with stub_kea({"reservation-get-page": _RES_EMPTY_PAGE}):
+            url = reverse("plugins:netbox_kea:combined_reservations4")
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
     def test_unauthenticated_redirects_to_login(self):
@@ -281,126 +319,110 @@ class TestCombinedReservations4View(_CombinedViewBase):
         self.assertEqual(response.status_code, 302)
         self.assertIn("login", response.url)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_queries_all_v4_servers(self, MockKeaClient):
+    def test_queries_all_v4_servers(self):
         """Without a server filter, every dhcp4-enabled server is queried."""
-        MockKeaClient.return_value.reservation_get_page.return_value = (
-            [dict(_MOCK_RESERVATION_V4)],
-            0,
-            0,
-        )
-        url = reverse("plugins:netbox_kea:combined_reservations4")
-        self.client.get(url)
-        # v4_server + dual_server have dhcp4=True → at least 2 calls
-        self.assertGreaterEqual(MockKeaClient.return_value.reservation_get_page.call_count, 2)
+        with stub_kea(
+            {"reservation-get-page": _res_page([dict(_MOCK_RESERVATION_V4)]), "lease4-get-all": _LEASE_NONE}
+        ) as kea:
+            url = reverse("plugins:netbox_kea:combined_reservations4")
+            self.client.get(url)
+        # v4_server + dual_server have dhcp4=True → at least 2 get-page calls
+        self.assertGreaterEqual(kea.commands().count("reservation-get-page"), 2)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_server_filter_limits_queried_servers(self, MockKeaClient):
+    def test_server_filter_limits_queried_servers(self):
         """?server=<pk> filters down to exactly that one server."""
-        MockKeaClient.return_value.reservation_get_page.return_value = ([], 0, 0)
-        url = reverse("plugins:netbox_kea:combined_reservations4") + f"?server={self.v4_server.pk}"
-        self.client.get(url)
-        self.assertEqual(MockKeaClient.return_value.reservation_get_page.call_count, 1)
+        with stub_kea({"reservation-get-page": _RES_EMPTY_PAGE}) as kea:
+            url = reverse("plugins:netbox_kea:combined_reservations4") + f"?server={self.v4_server.pk}"
+            self.client.get(url)
+        self.assertEqual(kea.commands().count("reservation-get-page"), 1)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_results_include_server_name(self, MockKeaClient):
+    def test_results_include_server_name(self):
         """Each row in the merged table must carry the originating server name."""
-        rec = dict(_MOCK_RESERVATION_V4)
-        MockKeaClient.return_value.reservation_get_page.return_value = ([rec], 0, 0)
-        url = reverse("plugins:netbox_kea:combined_reservations4") + f"?server={self.v4_server.pk}"
-        response = self.client.get(url)
+        with stub_kea({"reservation-get-page": _res_page([dict(_MOCK_RESERVATION_V4)]), "lease4-get-all": _LEASE_NONE}):
+            url = reverse("plugins:netbox_kea:combined_reservations4") + f"?server={self.v4_server.pk}"
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "v4-server")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_unreachable_server_returns_200_with_warning(self, MockKeaClient):
+    def test_unreachable_server_returns_200_with_warning(self):
         """A server that raises an exception must not cause a 500."""
-        MockKeaClient.return_value.reservation_get_page.side_effect = Exception("refused")
-        url = reverse("plugins:netbox_kea:combined_reservations4")
-        response = self.client.get(url)
+        with stub_kea({"reservation-get-page": requests.ConnectionError("refused")}):
+            url = reverse("plugins:netbox_kea:combined_reservations4")
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_no_v4_servers_returns_200_empty_table(self, MockKeaClient):
-        """If no dhcp4-enabled servers exist, the view renders with an empty table."""
+    def test_no_v4_servers_returns_200_empty_table(self):
+        """If no dhcp4-enabled servers exist, the view renders with an empty table (no Kea traffic)."""
         Server.objects.filter(dhcp4=True).update(dhcp4=False)
-        url = reverse("plugins:netbox_kea:combined_reservations4")
-        response = self.client.get(url)
+        with stub_kea({}) as kea:
+            url = reverse("plugins:netbox_kea:combined_reservations4")
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        MockKeaClient.assert_not_called()
+        self.assertEqual(kea.commands(), [])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_context_active_tab(self, MockKeaClient):
-        MockKeaClient.return_value.reservation_get_page.return_value = ([], 0, 0)
-        url = reverse("plugins:netbox_kea:combined_reservations4")
-        response = self.client.get(url)
+    def test_context_active_tab(self):
+        with stub_kea({"reservation-get-page": _RES_EMPTY_PAGE}):
+            url = reverse("plugins:netbox_kea:combined_reservations4")
+            response = self.client.get(url)
         self.assertEqual(response.context["active_tab"], "reservations4")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_export_returns_csv(self, MockKeaClient):
+    def test_export_returns_csv(self):
         """?export=table returns a CSV download of the v4 reservations table."""
-        rec = dict(_MOCK_RESERVATION_V4)
-        MockKeaClient.return_value.reservation_get_page.return_value = ([rec], 0, 0)
-        url = reverse("plugins:netbox_kea:combined_reservations4") + f"?server={self.v4_server.pk}&export=table"
-        response = self.client.get(url)
+        with stub_kea({"reservation-get-page": _res_page([dict(_MOCK_RESERVATION_V4)]), "lease4-get-all": _LEASE_NONE}):
+            url = reverse("plugins:netbox_kea:combined_reservations4") + f"?server={self.v4_server.pk}&export=table"
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertIn("text/csv", response.get("Content-Type", ""))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_search_form_in_context(self, MockKeaClient):
+    def test_search_form_in_context(self):
         """Response context must contain search_form for the search card to render."""
-        MockKeaClient.return_value.reservation_get_page.return_value = ([], 0, 0)
-        url = reverse("plugins:netbox_kea:combined_reservations4")
-        response = self.client.get(url)
+        with stub_kea({"reservation-get-page": _RES_EMPTY_PAGE}):
+            url = reverse("plugins:netbox_kea:combined_reservations4")
+            response = self.client.get(url)
         self.assertIn("search_form", response.context)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_search_by_hostname_filters_results(self, MockKeaClient):
+    def test_search_by_hostname_filters_results(self):
         """?q=host-v4 returns only records whose hostname matches."""
         rec_match = dict(_MOCK_RESERVATION_V4)  # hostname="host-v4"
         rec_nomatch = dict(_MOCK_RESERVATION_V4)
         rec_nomatch["hostname"] = "other-host"
         rec_nomatch["ip-address"] = "10.0.0.200"
-        MockKeaClient.return_value.reservation_get_page.return_value = ([rec_match, rec_nomatch], 0, 0)
-        url = reverse("plugins:netbox_kea:combined_reservations4") + f"?server={self.v4_server.pk}&q=host-v4"
-        response = self.client.get(url)
+        with stub_kea({"reservation-get-page": _res_page([rec_match, rec_nomatch]), "lease4-get-all": _LEASE_NONE}):
+            url = reverse("plugins:netbox_kea:combined_reservations4") + f"?server={self.v4_server.pk}&q=host-v4"
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "10.0.0.100")
         self.assertNotContains(response, "10.0.0.200")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_search_by_ip_filters_results(self, MockKeaClient):
+    def test_search_by_ip_filters_results(self):
         """?q=10.0.0.100 returns only the matching record."""
         rec = dict(_MOCK_RESERVATION_V4)
         rec2 = dict(_MOCK_RESERVATION_V4)
         rec2["ip-address"] = "10.0.0.200"
         rec2["hostname"] = "other"
-        MockKeaClient.return_value.reservation_get_page.return_value = ([rec, rec2], 0, 0)
-        url = reverse("plugins:netbox_kea:combined_reservations4") + f"?server={self.v4_server.pk}&q=10.0.0.100"
-        response = self.client.get(url)
+        with stub_kea({"reservation-get-page": _res_page([rec, rec2]), "lease4-get-all": _LEASE_NONE}):
+            url = reverse("plugins:netbox_kea:combined_reservations4") + f"?server={self.v4_server.pk}&q=10.0.0.100"
+            response = self.client.get(url)
         self.assertContains(response, "10.0.0.100")
         self.assertNotContains(response, "10.0.0.200")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_search_by_subnet_id_filters_results(self, MockKeaClient):
+    def test_search_by_subnet_id_filters_results(self):
         """?subnet_id=2 returns only records in subnet 2."""
         rec1 = dict(_MOCK_RESERVATION_V4)  # subnet-id=1
         rec2 = dict(_MOCK_RESERVATION_V4)
         rec2["subnet-id"] = 2
         rec2["ip-address"] = "10.0.0.200"
-        MockKeaClient.return_value.reservation_get_page.return_value = ([rec1, rec2], 0, 0)
-        url = reverse("plugins:netbox_kea:combined_reservations4") + f"?server={self.v4_server.pk}&subnet_id=2"
-        response = self.client.get(url)
+        with stub_kea({"reservation-get-page": _res_page([rec1, rec2]), "lease4-get-all": _LEASE_NONE}):
+            url = reverse("plugins:netbox_kea:combined_reservations4") + f"?server={self.v4_server.pk}&subnet_id=2"
+            response = self.client.get(url)
         self.assertNotContains(response, "10.0.0.100")
         self.assertContains(response, "10.0.0.200")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_search_no_match_returns_empty_table(self, MockKeaClient):
+    def test_search_no_match_returns_empty_table(self):
         """?q=zzz with no matching records renders an empty table (no 500)."""
-        rec = dict(_MOCK_RESERVATION_V4)
-        MockKeaClient.return_value.reservation_get_page.return_value = ([rec], 0, 0)
-        url = reverse("plugins:netbox_kea:combined_reservations4") + f"?server={self.v4_server.pk}&q=zzz-no-match"
-        response = self.client.get(url)
+        with stub_kea({"reservation-get-page": _res_page([dict(_MOCK_RESERVATION_V4)]), "lease4-get-all": _LEASE_NONE}):
+            url = reverse("plugins:netbox_kea:combined_reservations4") + f"?server={self.v4_server.pk}&q=zzz-no-match"
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
 
@@ -413,11 +435,10 @@ class TestCombinedReservations4View(_CombinedViewBase):
 class TestCombinedReservations6View(_CombinedViewBase):
     """GET /plugins/kea/combined/reservations6/ — all DHCPv6 reservations."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_returns_200(self, MockKeaClient):
-        MockKeaClient.return_value.reservation_get_page.return_value = ([], 0, 0)
-        url = reverse("plugins:netbox_kea:combined_reservations6")
-        response = self.client.get(url)
+    def test_get_returns_200(self):
+        with stub_kea({"reservation-get-page": _RES_EMPTY_PAGE}):
+            url = reverse("plugins:netbox_kea:combined_reservations6")
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
     def test_unauthenticated_redirects_to_login(self):
@@ -427,51 +448,42 @@ class TestCombinedReservations6View(_CombinedViewBase):
         self.assertEqual(response.status_code, 302)
         self.assertIn("login", response.url)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_queries_all_v6_servers(self, MockKeaClient):
-        MockKeaClient.return_value.reservation_get_page.return_value = (
-            [dict(_MOCK_RESERVATION_V6)],
-            0,
-            0,
-        )
-        url = reverse("plugins:netbox_kea:combined_reservations6")
-        self.client.get(url)
-        self.assertGreaterEqual(MockKeaClient.return_value.reservation_get_page.call_count, 2)
+    def test_queries_all_v6_servers(self):
+        with stub_kea(
+            {"reservation-get-page": _res_page([dict(_MOCK_RESERVATION_V6)]), "lease6-get-all": _LEASE_NONE}
+        ) as kea:
+            url = reverse("plugins:netbox_kea:combined_reservations6")
+            self.client.get(url)
+        self.assertGreaterEqual(kea.commands().count("reservation-get-page"), 2)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_server_filter_limits_queried_servers(self, MockKeaClient):
-        MockKeaClient.return_value.reservation_get_page.return_value = ([], 0, 0)
-        url = reverse("plugins:netbox_kea:combined_reservations6") + f"?server={self.v6_server.pk}"
-        self.client.get(url)
-        self.assertEqual(MockKeaClient.return_value.reservation_get_page.call_count, 1)
+    def test_server_filter_limits_queried_servers(self):
+        with stub_kea({"reservation-get-page": _RES_EMPTY_PAGE}) as kea:
+            url = reverse("plugins:netbox_kea:combined_reservations6") + f"?server={self.v6_server.pk}"
+            self.client.get(url)
+        self.assertEqual(kea.commands().count("reservation-get-page"), 1)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_unreachable_server_returns_200_with_warning(self, MockKeaClient):
-        MockKeaClient.return_value.reservation_get_page.side_effect = Exception("refused")
-        url = reverse("plugins:netbox_kea:combined_reservations6")
-        response = self.client.get(url)
+    def test_unreachable_server_returns_200_with_warning(self):
+        with stub_kea({"reservation-get-page": requests.ConnectionError("refused")}):
+            url = reverse("plugins:netbox_kea:combined_reservations6")
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_export_returns_csv(self, MockKeaClient):
+    def test_export_returns_csv(self):
         """?export=table returns a CSV download of the v6 reservations table."""
-        rec = dict(_MOCK_RESERVATION_V6)
-        MockKeaClient.return_value.reservation_get_page.return_value = ([rec], 0, 0)
-        url = reverse("plugins:netbox_kea:combined_reservations6") + f"?server={self.v6_server.pk}&export=table"
-        response = self.client.get(url)
+        with stub_kea({"reservation-get-page": _res_page([dict(_MOCK_RESERVATION_V6)]), "lease6-get-all": _LEASE_NONE}):
+            url = reverse("plugins:netbox_kea:combined_reservations6") + f"?server={self.v6_server.pk}&export=table"
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertIn("text/csv", response.get("Content-Type", ""))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_search_form_in_context(self, MockKeaClient):
+    def test_search_form_in_context(self):
         """Response context must contain search_form."""
-        MockKeaClient.return_value.reservation_get_page.return_value = ([], 0, 0)
-        url = reverse("plugins:netbox_kea:combined_reservations6")
-        response = self.client.get(url)
+        with stub_kea({"reservation-get-page": _RES_EMPTY_PAGE}):
+            url = reverse("plugins:netbox_kea:combined_reservations6")
+            response = self.client.get(url)
         self.assertIn("search_form", response.context)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_search_by_hostname_filters_results(self, MockKeaClient):
+    def test_search_by_hostname_filters_results(self):
         """?q=host-v6 returns only records whose hostname matches."""
         rec_match = dict(_MOCK_RESERVATION_V6)  # hostname="host-v6"
         rec_nomatch = {
@@ -480,15 +492,14 @@ class TestCombinedReservations6View(_CombinedViewBase):
             "ip-addresses": ["2001:db8::2"],
             "hostname": "other-v6",
         }
-        MockKeaClient.return_value.reservation_get_page.return_value = ([rec_match, rec_nomatch], 0, 0)
-        url = reverse("plugins:netbox_kea:combined_reservations6") + f"?server={self.v6_server.pk}&q=host-v6"
-        response = self.client.get(url)
+        with stub_kea({"reservation-get-page": _res_page([rec_match, rec_nomatch]), "lease6-get-all": _LEASE_NONE}):
+            url = reverse("plugins:netbox_kea:combined_reservations6") + f"?server={self.v6_server.pk}&q=host-v6"
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "host-v6")
         self.assertNotContains(response, "other-v6")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_search_by_duid_filters_results(self, MockKeaClient):
+    def test_search_by_duid_filters_results(self):
         """?q=00:01:aa:bb returns only the matching DUID record."""
         rec = dict(_MOCK_RESERVATION_V6)  # duid="00:01:aa:bb"
         rec2 = {
@@ -497,9 +508,9 @@ class TestCombinedReservations6View(_CombinedViewBase):
             "ip-addresses": ["2001:db8::99"],
             "hostname": "other",
         }
-        MockKeaClient.return_value.reservation_get_page.return_value = ([rec, rec2], 0, 0)
-        url = reverse("plugins:netbox_kea:combined_reservations6") + f"?server={self.v6_server.pk}&q=00:01:aa:bb"
-        response = self.client.get(url)
+        with stub_kea({"reservation-get-page": _res_page([rec, rec2]), "lease6-get-all": _LEASE_NONE}):
+            url = reverse("plugins:netbox_kea:combined_reservations6") + f"?server={self.v6_server.pk}&q=00:01:aa:bb"
+            response = self.client.get(url)
         self.assertContains(response, "00:01:aa:bb")
         self.assertNotContains(response, "ff:ff:ff:ff")
 
@@ -514,9 +525,11 @@ class TestCombinedLeases4View(_CombinedViewBase):
     """GET /plugins/kea/combined/leases4/ — DHCPv4 leases with cross-server search."""
 
     def test_get_without_search_returns_200(self):
-        url = reverse("plugins:netbox_kea:combined_leases4")
-        response = self.client.get(url)
+        with stub_kea({}) as kea:
+            url = reverse("plugins:netbox_kea:combined_leases4")
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(kea.commands(), [])
 
     def test_unauthenticated_redirects_to_login(self):
         self.client.logout()
@@ -526,61 +539,50 @@ class TestCombinedLeases4View(_CombinedViewBase):
         self.assertIn("login", response.url)
 
     def test_no_kea_calls_without_search_query(self):
-        with patch("netbox_kea.models.KeaClient") as MockKeaClient:
+        with stub_kea({}) as kea:
             url = reverse("plugins:netbox_kea:combined_leases4")
             self.client.get(url)
-        MockKeaClient.assert_not_called()
+        self.assertEqual(kea.commands(), [])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_search_broadcasts_to_all_v4_servers(self, MockKeaClient):
-        MockKeaClient.return_value.command.return_value = [
-            {"result": 0, "arguments": {"leases": [dict(_MOCK_LEASE_V4)]}}
-        ]
-
-        url = reverse("plugins:netbox_kea:combined_leases4") + f"?q=lease-host-v4&by={constants.BY_HOSTNAME}"
-        response = self.client.get(url)
+    def test_search_broadcasts_to_all_v4_servers(self):
+        with stub_kea(
+            {"lease4-get-by-hostname": _leases([dict(_MOCK_LEASE_V4)]), "reservation-get": _RES_NOT_FOUND}
+        ) as kea:
+            url = reverse("plugins:netbox_kea:combined_leases4") + f"?q=lease-host-v4&by={constants.BY_HOSTNAME}"
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertGreaterEqual(MockKeaClient.return_value.command.call_count, 2)
+        self.assertGreaterEqual(kea.commands().count("lease4-get-by-hostname"), 2)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_search_with_server_filter_limits_calls(self, MockKeaClient):
-        MockKeaClient.return_value.command.return_value = [{"result": 0, "arguments": {"leases": []}}]
+    def test_search_with_server_filter_limits_calls(self):
+        with stub_kea({"lease4-get-by-hostname": _leases([])}) as kea:
+            url = (
+                reverse("plugins:netbox_kea:combined_leases4")
+                + f"?server={self.v4_server.pk}&q=test&by={constants.BY_HOSTNAME}"
+            )
+            self.client.get(url)
+        # One server, no leases returned → exactly one lease search, no enrichment.
+        self.assertEqual(kea.commands(), ["lease4-get-by-hostname"])
 
-        url = (
-            reverse("plugins:netbox_kea:combined_leases4")
-            + f"?server={self.v4_server.pk}&q=test&by={constants.BY_HOSTNAME}"
-        )
-        self.client.get(url)
-        self.assertEqual(MockKeaClient.return_value.command.call_count, 1)
-
-    @patch("netbox_kea.models.KeaClient")
-    def test_unreachable_server_returns_200_with_warning(self, MockKeaClient):
-        MockKeaClient.return_value.command.side_effect = Exception("refused")
-
-        url = reverse("plugins:netbox_kea:combined_leases4") + f"?q=test&by={constants.BY_HOSTNAME}"
-        response = self.client.get(url)
+    def test_unreachable_server_returns_200_with_warning(self):
+        with stub_kea({"lease4-get-by-hostname": requests.ConnectionError("refused")}):
+            url = reverse("plugins:netbox_kea:combined_leases4") + f"?q=test&by={constants.BY_HOSTNAME}"
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_merged_results_include_server_name(self, MockKeaClient):
-        MockKeaClient.return_value.command.return_value = [
-            {"result": 0, "arguments": {"leases": [dict(_MOCK_LEASE_V4)]}}
-        ]
-
-        url = (
-            reverse("plugins:netbox_kea:combined_leases4")
-            + f"?server={self.v4_server.pk}&q=test&by={constants.BY_HOSTNAME}"
-        )
-        response = self.client.get(url)
+    def test_merged_results_include_server_name(self):
+        with stub_kea({"lease4-get-by-hostname": _leases([dict(_MOCK_LEASE_V4)]), "reservation-get": _RES_NOT_FOUND}):
+            url = (
+                reverse("plugins:netbox_kea:combined_leases4")
+                + f"?server={self.v4_server.pk}&q=test&by={constants.BY_HOSTNAME}"
+            )
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "v4-server")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_context_active_tab(self, MockKeaClient):
-        MockKeaClient.return_value.command.return_value = [{"result": 0, "arguments": {"leases": []}}]
-
-        url = reverse("plugins:netbox_kea:combined_leases4") + f"?q=x&by={constants.BY_HOSTNAME}"
-        response = self.client.get(url)
+    def test_context_active_tab(self):
+        with stub_kea({"lease4-get-by-hostname": _leases([])}):
+            url = reverse("plugins:netbox_kea:combined_leases4") + f"?q=x&by={constants.BY_HOSTNAME}"
+            response = self.client.get(url)
         self.assertEqual(response.context["active_tab"], "leases4")
 
 
@@ -594,9 +596,11 @@ class TestCombinedLeases6View(_CombinedViewBase):
     """GET /plugins/kea/combined/leases6/ — DHCPv6 leases with cross-server search."""
 
     def test_get_without_search_returns_200(self):
-        url = reverse("plugins:netbox_kea:combined_leases6")
-        response = self.client.get(url)
+        with stub_kea({}) as kea:
+            url = reverse("plugins:netbox_kea:combined_leases6")
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(kea.commands(), [])
 
     def test_unauthenticated_redirects_to_login(self):
         self.client.logout()
@@ -606,41 +610,33 @@ class TestCombinedLeases6View(_CombinedViewBase):
         self.assertIn("login", response.url)
 
     def test_no_kea_calls_without_search_query(self):
-        with patch("netbox_kea.models.KeaClient") as MockKeaClient:
+        with stub_kea({}) as kea:
             url = reverse("plugins:netbox_kea:combined_leases6")
             self.client.get(url)
-        MockKeaClient.assert_not_called()
+        self.assertEqual(kea.commands(), [])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_search_broadcasts_to_all_v6_servers(self, MockKeaClient):
-        MockKeaClient.return_value.command.return_value = [
-            {"result": 0, "arguments": {"leases": [dict(_MOCK_LEASE_V6)]}}
-        ]
-
-        url = reverse("plugins:netbox_kea:combined_leases6") + f"?q=lease-host-v6&by={constants.BY_HOSTNAME}"
-        response = self.client.get(url)
+    def test_search_broadcasts_to_all_v6_servers(self):
+        with stub_kea(
+            {"lease6-get-by-hostname": _leases([dict(_MOCK_LEASE_V6)]), "reservation-get": _RES_NOT_FOUND}
+        ) as kea:
+            url = reverse("plugins:netbox_kea:combined_leases6") + f"?q=lease-host-v6&by={constants.BY_HOSTNAME}"
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertGreaterEqual(MockKeaClient.return_value.command.call_count, 2)
+        self.assertGreaterEqual(kea.commands().count("lease6-get-by-hostname"), 2)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_unreachable_server_returns_200_with_warning(self, MockKeaClient):
-        MockKeaClient.return_value.command.side_effect = Exception("refused")
-
-        url = reverse("plugins:netbox_kea:combined_leases6") + f"?q=test&by={constants.BY_HOSTNAME}"
-        response = self.client.get(url)
+    def test_unreachable_server_returns_200_with_warning(self):
+        with stub_kea({"lease6-get-by-hostname": requests.ConnectionError("refused")}):
+            url = reverse("plugins:netbox_kea:combined_leases6") + f"?q=test&by={constants.BY_HOSTNAME}"
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_merged_results_include_server_name(self, MockKeaClient):
-        MockKeaClient.return_value.command.return_value = [
-            {"result": 0, "arguments": {"leases": [dict(_MOCK_LEASE_V6)]}}
-        ]
-
-        url = (
-            reverse("plugins:netbox_kea:combined_leases6")
-            + f"?server={self.v6_server.pk}&q=test&by={constants.BY_HOSTNAME}"
-        )
-        response = self.client.get(url)
+    def test_merged_results_include_server_name(self):
+        with stub_kea({"lease6-get-by-hostname": _leases([dict(_MOCK_LEASE_V6)]), "reservation-get": _RES_NOT_FOUND}):
+            url = (
+                reverse("plugins:netbox_kea:combined_leases6")
+                + f"?server={self.v6_server.pk}&q=test&by={constants.BY_HOSTNAME}"
+            )
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "v6-server")
 
@@ -654,11 +650,10 @@ class TestCombinedLeases6View(_CombinedViewBase):
 class TestCombinedSubnets4View(_CombinedViewBase):
     """GET /plugins/kea/combined/subnets4/ — DHCPv4 subnets across all servers."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_returns_200(self, MockKeaClient):
-        MockKeaClient.return_value.command.return_value = _MOCK_CONFIG_V4
-        url = reverse("plugins:netbox_kea:combined_subnets4")
-        response = self.client.get(url)
+    def test_get_returns_200(self):
+        with stub_kea({"config-get": _MOCK_CONFIG_V4, "stat-lease4-get": _STAT_EMPTY}):
+            url = reverse("plugins:netbox_kea:combined_subnets4")
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
     def test_unauthenticated_redirects_to_login(self):
@@ -668,64 +663,56 @@ class TestCombinedSubnets4View(_CombinedViewBase):
         self.assertEqual(response.status_code, 302)
         self.assertIn("login", response.url)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_queries_all_v4_servers(self, MockKeaClient):
+    def test_queries_all_v4_servers(self):
         """Without a filter, every dhcp4-enabled server is queried for config-get."""
-        MockKeaClient.return_value.command.return_value = _MOCK_CONFIG_V4
-        url = reverse("plugins:netbox_kea:combined_subnets4")
-        self.client.get(url)
-        # v4_server + dual_server → 2 calls
-        self.assertGreaterEqual(MockKeaClient.return_value.command.call_count, 2)
+        with stub_kea({"config-get": _MOCK_CONFIG_V4, "stat-lease4-get": _STAT_EMPTY}) as kea:
+            url = reverse("plugins:netbox_kea:combined_subnets4")
+            self.client.get(url)
+        # v4_server + dual_server → at least 2 config-get calls
+        self.assertGreaterEqual(kea.commands().count("config-get"), 2)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_server_filter_limits_queried_servers(self, MockKeaClient):
-        MockKeaClient.return_value.command.return_value = _MOCK_CONFIG_V4
-        url = reverse("plugins:netbox_kea:combined_subnets4") + f"?server={self.v4_server.pk}"
-        self.client.get(url)
-        # 1 server filtered × 2 commands (config-get + stat-lease4-get) = 2
-        self.assertEqual(MockKeaClient.return_value.command.call_count, 2)
+    def test_server_filter_limits_queried_servers(self):
+        with stub_kea({"config-get": _MOCK_CONFIG_V4, "stat-lease4-get": _STAT_EMPTY}) as kea:
+            url = reverse("plugins:netbox_kea:combined_subnets4") + f"?server={self.v4_server.pk}"
+            self.client.get(url)
+        # 1 server → config-get (subnets) then stat-lease4-get (utilisation).
+        self.assertEqual(kea.commands(), ["config-get", "stat-lease4-get"])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_unreachable_server_returns_200_with_warning(self, MockKeaClient):
-        MockKeaClient.return_value.command.side_effect = Exception("refused")
-        url = reverse("plugins:netbox_kea:combined_subnets4")
-        response = self.client.get(url)
+    def test_unreachable_server_returns_200_with_warning(self):
+        with stub_kea({"config-get": requests.ConnectionError("refused")}):
+            url = reverse("plugins:netbox_kea:combined_subnets4")
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_results_include_server_name(self, MockKeaClient):
-        MockKeaClient.return_value.command.return_value = _MOCK_CONFIG_V4
-        url = reverse("plugins:netbox_kea:combined_subnets4") + f"?server={self.v4_server.pk}"
-        response = self.client.get(url)
+    def test_results_include_server_name(self):
+        with stub_kea({"config-get": _MOCK_CONFIG_V4, "stat-lease4-get": _STAT_EMPTY}):
+            url = reverse("plugins:netbox_kea:combined_subnets4") + f"?server={self.v4_server.pk}"
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "v4-server")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_context_active_tab(self, MockKeaClient):
-        MockKeaClient.return_value.command.return_value = _MOCK_CONFIG_V4
-        url = reverse("plugins:netbox_kea:combined_subnets4")
-        response = self.client.get(url)
+    def test_context_active_tab(self):
+        with stub_kea({"config-get": _MOCK_CONFIG_V4, "stat-lease4-get": _STAT_EMPTY}):
+            url = reverse("plugins:netbox_kea:combined_subnets4")
+            response = self.client.get(url)
         self.assertEqual(response.context["active_tab"], "subnets4")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_export_returns_csv(self, MockKeaClient):
+    def test_export_returns_csv(self):
         """?export=table returns a CSV download of the subnet table."""
-        MockKeaClient.return_value.command.return_value = _MOCK_CONFIG_V4
-        url = reverse("plugins:netbox_kea:combined_subnets4") + f"?server={self.v4_server.pk}&export=table"
-        response = self.client.get(url)
+        with stub_kea({"config-get": _MOCK_CONFIG_V4, "stat-lease4-get": _STAT_EMPTY}):
+            url = reverse("plugins:netbox_kea:combined_subnets4") + f"?server={self.v4_server.pk}&export=table"
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertIn("text/csv", response.get("Content-Type", ""))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_search_form_in_context(self, MockKeaClient):
+    def test_search_form_in_context(self):
         """Response context must contain search_form."""
-        MockKeaClient.return_value.command.return_value = _MOCK_CONFIG_V4
-        url = reverse("plugins:netbox_kea:combined_subnets4")
-        response = self.client.get(url)
+        with stub_kea({"config-get": _MOCK_CONFIG_V4, "stat-lease4-get": _STAT_EMPTY}):
+            url = reverse("plugins:netbox_kea:combined_subnets4")
+            response = self.client.get(url)
         self.assertIn("search_form", response.context)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_search_by_cidr_filters_results(self, MockKeaClient):
+    def test_search_by_cidr_filters_results(self):
         """?q=10.0 returns subnets whose CIDR contains '10.0', excludes others."""
         config_with_two_subnets = [
             {
@@ -741,15 +728,14 @@ class TestCombinedSubnets4View(_CombinedViewBase):
                 },
             }
         ]
-        MockKeaClient.return_value.command.return_value = config_with_two_subnets
-        url = reverse("plugins:netbox_kea:combined_subnets4") + f"?server={self.v4_server.pk}&q=10.0"
-        response = self.client.get(url)
+        with stub_kea({"config-get": config_with_two_subnets, "stat-lease4-get": _STAT_EMPTY}):
+            url = reverse("plugins:netbox_kea:combined_subnets4") + f"?server={self.v4_server.pk}&q=10.0"
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "10.0.1.0/24")
         self.assertNotContains(response, "192.168.0.0/24")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_search_by_subnet_id_filters_results(self, MockKeaClient):
+    def test_search_by_subnet_id_filters_results(self):
         """?subnet_id=2 returns only the subnet with id=2."""
         config_with_two_subnets = [
             {
@@ -765,18 +751,17 @@ class TestCombinedSubnets4View(_CombinedViewBase):
                 },
             }
         ]
-        MockKeaClient.return_value.command.return_value = config_with_two_subnets
-        url = reverse("plugins:netbox_kea:combined_subnets4") + f"?server={self.v4_server.pk}&subnet_id=2"
-        response = self.client.get(url)
+        with stub_kea({"config-get": config_with_two_subnets, "stat-lease4-get": _STAT_EMPTY}):
+            url = reverse("plugins:netbox_kea:combined_subnets4") + f"?server={self.v4_server.pk}&subnet_id=2"
+            response = self.client.get(url)
         self.assertNotContains(response, "10.0.1.0/24")
         self.assertContains(response, "192.168.0.0/24")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_search_no_match_returns_empty_table(self, MockKeaClient):
+    def test_search_no_match_returns_empty_table(self):
         """?q=zzz with no matching subnets renders 200 with empty table."""
-        MockKeaClient.return_value.command.return_value = _MOCK_CONFIG_V4
-        url = reverse("plugins:netbox_kea:combined_subnets4") + f"?server={self.v4_server.pk}&q=zzz-no-match"
-        response = self.client.get(url)
+        with stub_kea({"config-get": _MOCK_CONFIG_V4, "stat-lease4-get": _STAT_EMPTY}):
+            url = reverse("plugins:netbox_kea:combined_subnets4") + f"?server={self.v4_server.pk}&q=zzz-no-match"
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
 
@@ -789,11 +774,10 @@ class TestCombinedSubnets4View(_CombinedViewBase):
 class TestCombinedSubnets6View(_CombinedViewBase):
     """GET /plugins/kea/combined/subnets6/ — DHCPv6 subnets across all servers."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_returns_200(self, MockKeaClient):
-        MockKeaClient.return_value.command.return_value = _MOCK_CONFIG_V6
-        url = reverse("plugins:netbox_kea:combined_subnets6")
-        response = self.client.get(url)
+    def test_get_returns_200(self):
+        with stub_kea({"config-get": _MOCK_CONFIG_V6, "stat-lease6-get": _STAT_EMPTY}):
+            url = reverse("plugins:netbox_kea:combined_subnets6")
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
     def test_unauthenticated_redirects_to_login(self):
@@ -803,39 +787,34 @@ class TestCombinedSubnets6View(_CombinedViewBase):
         self.assertEqual(response.status_code, 302)
         self.assertIn("login", response.url)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_queries_all_v6_servers(self, MockKeaClient):
-        MockKeaClient.return_value.command.return_value = _MOCK_CONFIG_V6
-        url = reverse("plugins:netbox_kea:combined_subnets6")
-        self.client.get(url)
-        self.assertGreaterEqual(MockKeaClient.return_value.command.call_count, 2)
+    def test_queries_all_v6_servers(self):
+        with stub_kea({"config-get": _MOCK_CONFIG_V6, "stat-lease6-get": _STAT_EMPTY}) as kea:
+            url = reverse("plugins:netbox_kea:combined_subnets6")
+            self.client.get(url)
+        self.assertGreaterEqual(kea.commands().count("config-get"), 2)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_unreachable_server_returns_200_with_warning(self, MockKeaClient):
-        MockKeaClient.return_value.command.side_effect = Exception("refused")
-        url = reverse("plugins:netbox_kea:combined_subnets6")
-        response = self.client.get(url)
+    def test_unreachable_server_returns_200_with_warning(self):
+        with stub_kea({"config-get": requests.ConnectionError("refused")}):
+            url = reverse("plugins:netbox_kea:combined_subnets6")
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_export_returns_csv(self, MockKeaClient):
+    def test_export_returns_csv(self):
         """?export=table returns a CSV download of the v6 subnet table."""
-        MockKeaClient.return_value.command.return_value = _MOCK_CONFIG_V6
-        url = reverse("plugins:netbox_kea:combined_subnets6") + f"?server={self.v6_server.pk}&export=table"
-        response = self.client.get(url)
+        with stub_kea({"config-get": _MOCK_CONFIG_V6, "stat-lease6-get": _STAT_EMPTY}):
+            url = reverse("plugins:netbox_kea:combined_subnets6") + f"?server={self.v6_server.pk}&export=table"
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertIn("text/csv", response.get("Content-Type", ""))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_search_form_in_context(self, MockKeaClient):
+    def test_search_form_in_context(self):
         """Response context must contain search_form."""
-        MockKeaClient.return_value.command.return_value = _MOCK_CONFIG_V6
-        url = reverse("plugins:netbox_kea:combined_subnets6")
-        response = self.client.get(url)
+        with stub_kea({"config-get": _MOCK_CONFIG_V6, "stat-lease6-get": _STAT_EMPTY}):
+            url = reverse("plugins:netbox_kea:combined_subnets6")
+            response = self.client.get(url)
         self.assertIn("search_form", response.context)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_search_by_cidr_filters_results(self, MockKeaClient):
+    def test_search_by_cidr_filters_results(self):
         """?q=2001:db8 returns only matching v6 subnets."""
         config_with_two_subnets = [
             {
@@ -851,9 +830,9 @@ class TestCombinedSubnets6View(_CombinedViewBase):
                 },
             }
         ]
-        MockKeaClient.return_value.command.return_value = config_with_two_subnets
-        url = reverse("plugins:netbox_kea:combined_subnets6") + f"?server={self.v6_server.pk}&q=2001:db8"
-        response = self.client.get(url)
+        with stub_kea({"config-get": config_with_two_subnets, "stat-lease6-get": _STAT_EMPTY}):
+            url = reverse("plugins:netbox_kea:combined_subnets6") + f"?server={self.v6_server.pk}&q=2001:db8"
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "2001:db8::/32")
         self.assertNotContains(response, "fd00::/8")
@@ -884,84 +863,44 @@ class TestCombinedLeases4Enrichment(_CombinedViewBase):
     def _lease_url(self, q="10.20.0.5", by="ip"):
         return reverse("plugins:netbox_kea:combined_leases4") + f"?q={q}&by={by}&server={self.v4_server.pk}"
 
-    def _mock_command(self, mock_client, leases, reservations=()):
-        """Configure client mock: lease command + reservation_get_page."""
-
-        def command_side_effect(cmd, **kwargs):
-            if "lease" in cmd:
-                args = kwargs.get("arguments", {})
-                ip = args.get("ip-address")
-                if ip:
-                    matching = [entry for entry in leases if entry["ip-address"] == ip]
-                    if not matching:
-                        return [{"result": 3, "arguments": None}]
-                    return [{"result": 0, "arguments": matching[0]}]
-                return [{"result": 0, "arguments": {"leases": list(leases), "count": len(leases)}}]
-            return [{"result": 2, "arguments": {}}]
-
-        mock_client.command.side_effect = command_side_effect
-        mock_client.reservation_get.return_value = reservations[0] if reservations else None
-        # Wire clone() so ThreadPoolExecutor workers see the same reservation_get mock.
-        mock_client.clone.return_value = mock_client
-        mock_client.__enter__ = lambda self: self
-        mock_client.__exit__ = lambda self, *a: None
-
-    @patch("netbox_kea.models.KeaClient")
-    def test_reserved_badge_appears_when_reservation_exists(self, MockKeaClient):
+    def test_reserved_badge_appears_when_reservation_exists(self):
         """A lease with a matching reservation must show the 'Reserved' badge."""
-        self._mock_command(
-            MockKeaClient.return_value,
-            leases=[dict(_MOCK_LEASE_V4_ENRICHMENT)],
-            reservations=[dict(_MOCK_RESERVATION_ENRICHED)],
-        )
-        response = self.client.get(self._lease_url())
+        with stub_kea(
+            {
+                "lease4-get": _lease_one(_MOCK_LEASE_V4_ENRICHMENT),
+                "reservation-get": _res_get(_MOCK_RESERVATION_ENRICHED),
+            }
+        ):
+            response = self.client.get(self._lease_url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Reserved")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_create_reservation_link_when_no_reservation(self, MockKeaClient):
+    def test_create_reservation_link_when_no_reservation(self):
         """A lease without a matching reservation must show a create-reservation link."""
-        self._mock_command(
-            MockKeaClient.return_value,
-            leases=[dict(_MOCK_LEASE_V4_ENRICHMENT)],
-            reservations=[],
-        )
-        response = self.client.get(self._lease_url())
+        with stub_kea({"lease4-get": _lease_one(_MOCK_LEASE_V4_ENRICHMENT), "reservation-get": _RES_NOT_FOUND}):
+            response = self.client.get(self._lease_url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "reservations4/add")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_netbox_ip_synced_link_when_ip_in_netbox(self, MockKeaClient):
+    def test_netbox_ip_synced_link_when_ip_in_netbox(self):
         """When the lease IP exists in NetBox IPAM, a 'Synced' link must appear."""
-        from ipam.models import IPAddress
-
         IPAddress.objects.create(address="10.20.0.5/32")
-        self._mock_command(
-            MockKeaClient.return_value,
-            leases=[dict(_MOCK_LEASE_V4_ENRICHMENT)],
-            reservations=[],
-        )
-        response = self.client.get(self._lease_url())
+        with stub_kea({"lease4-get": _lease_one(_MOCK_LEASE_V4_ENRICHMENT), "reservation-get": _RES_NOT_FOUND}):
+            response = self.client.get(self._lease_url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Synced")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_netbox_ip_sync_button_when_ip_not_in_netbox(self, MockKeaClient):
+    def test_netbox_ip_sync_button_when_ip_not_in_netbox(self):
         """When the lease IP is not in NetBox IPAM, a 'Sync' button must appear."""
-        self._mock_command(
-            MockKeaClient.return_value,
-            leases=[dict(_MOCK_LEASE_V4_ENRICHMENT)],
-            reservations=[],
-        )
-        response = self.client.get(self._lease_url())
+        with stub_kea({"lease4-get": _lease_one(_MOCK_LEASE_V4_ENRICHMENT), "reservation-get": _RES_NOT_FOUND}):
+            response = self.client.get(self._lease_url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Sync")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_combined_default_columns_include_reserved_and_netbox_ip(self, MockKeaClient):
+    def test_combined_default_columns_include_reserved_and_netbox_ip(self):
         """GlobalLeaseTable4 default columns must include reserved and netbox_ip."""
-        self._mock_command(MockKeaClient.return_value, leases=[], reservations=[])
-        response = self.client.get(self._lease_url(q="nomatch"))
+        with stub_kea({"lease4-get": _LEASE_NONE}):
+            response = self.client.get(self._lease_url(q="nomatch"))
         self.assertEqual(response.status_code, 200)
         # Column headers should appear
         self.assertContains(response, "NetBox IP")
@@ -975,59 +914,50 @@ class TestCombinedReservations4Enrichment(_CombinedViewBase):
     def _url(self):
         return reverse("plugins:netbox_kea:combined_reservations4") + f"?server={self.v4_server.pk}"
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_active_lease_badge_when_lease_exists(self, MockKeaClient):
+    def test_active_lease_badge_when_lease_exists(self):
         """A reservation with an active lease must show 'Active Lease' badge."""
-        clone_mock = MagicMock(spec=KeaClient)
-        clone_mock.command.return_value = [{"result": 0, "arguments": {"leases": [{"ip-address": "10.20.0.5"}]}}]
-        clone_mock.__enter__ = lambda s: s
-        clone_mock.__exit__ = lambda s, *a: None
-        MockKeaClient.return_value.clone.return_value = clone_mock
-        MockKeaClient.return_value.reservation_get_page.return_value = ([dict(_MOCK_RESERVATION_ENRICHED)], 0, 0)
-        response = self.client.get(self._url())
+        with stub_kea(
+            {
+                "reservation-get-page": _res_page([dict(_MOCK_RESERVATION_ENRICHED)]),
+                "lease4-get-all": _leases([{"ip-address": "10.20.0.5"}]),
+            }
+        ):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Active Lease")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_no_lease_badge_when_no_active_lease(self, MockKeaClient):
+    def test_no_lease_badge_when_no_active_lease(self):
         """A reservation without active lease must show 'No Lease' badge."""
-        clone_mock = MagicMock(spec=KeaClient)
-        clone_mock.command.return_value = [{"result": 0, "arguments": {"leases": []}}]
-        clone_mock.__enter__ = lambda s: s
-        clone_mock.__exit__ = lambda s, *a: None
-        MockKeaClient.return_value.clone.return_value = clone_mock
-        MockKeaClient.return_value.reservation_get_page.return_value = ([dict(_MOCK_RESERVATION_ENRICHED)], 0, 0)
-        response = self.client.get(self._url())
+        with stub_kea(
+            {"reservation-get-page": _res_page([dict(_MOCK_RESERVATION_ENRICHED)]), "lease4-get-all": _leases([])}
+        ):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "No Lease")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_lease_column_header_present(self, MockKeaClient):
+    def test_lease_column_header_present(self):
         """GlobalReservationTable4 must render a 'Lease' column header."""
-        MockKeaClient.return_value.reservation_get_page.return_value = ([], 0, 0)
-        MockKeaClient.return_value.command.return_value = [{"result": 0, "arguments": {"leases": []}}]
-        response = self.client.get(self._url())
+        with stub_kea({"reservation-get-page": _RES_EMPTY_PAGE}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Lease")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_netbox_ip_synced_link_when_ip_in_netbox(self, MockKeaClient):
+    def test_netbox_ip_synced_link_when_ip_in_netbox(self):
         """Reservation IP in NetBox IPAM → 'Synced' link in combined table."""
-        from ipam.models import IPAddress
-
         IPAddress.objects.create(address="10.20.0.5/32")
-        MockKeaClient.return_value.reservation_get_page.return_value = ([dict(_MOCK_RESERVATION_ENRICHED)], 0, 0)
-        MockKeaClient.return_value.command.return_value = [{"result": 0, "arguments": {"leases": []}}]
-        response = self.client.get(self._url())
+        with stub_kea(
+            {"reservation-get-page": _res_page([dict(_MOCK_RESERVATION_ENRICHED)]), "lease4-get-all": _leases([])}
+        ):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Synced")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_edit_action_links_use_server_pk(self, MockKeaClient):
+    def test_edit_action_links_use_server_pk(self):
         """Each combined reservation row must have an edit link pointing to the correct server."""
-        MockKeaClient.return_value.reservation_get_page.return_value = ([dict(_MOCK_RESERVATION_ENRICHED)], 0, 0)
-        MockKeaClient.return_value.command.return_value = [{"result": 0, "arguments": {"leases": []}}]
-        response = self.client.get(self._url())
+        with stub_kea(
+            {"reservation-get-page": _res_page([dict(_MOCK_RESERVATION_ENRICHED)]), "lease4-get-all": _leases([])}
+        ):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         expected = f"/plugins/kea/servers/{self.v4_server.pk}/reservations4/"
         self.assertContains(response, expected)
@@ -1063,73 +993,37 @@ class TestCombinedLeases6Enrichment(_CombinedViewBase):
     def _lease_url(self, q="2001:db8::5", by="ip"):
         return reverse("plugins:netbox_kea:combined_leases6") + f"?q={q}&by={by}&server={self.v6_server.pk}"
 
-    def _mock_command(self, mock_client, leases, reservations=()):
-        def command_side_effect(cmd, **kwargs):
-            if "lease" in cmd:
-                args = kwargs.get("arguments", {})
-                ip = args.get("ip-address")
-                if ip:
-                    matching = [entry for entry in leases if entry["ip-address"] == ip]
-                    if not matching:
-                        return [{"result": 3, "arguments": None}]
-                    return [{"result": 0, "arguments": matching[0]}]
-                return [{"result": 0, "arguments": {"leases": list(leases), "count": len(leases)}}]
-            return [{"result": 2, "arguments": {}}]
-
-        mock_client.command.side_effect = command_side_effect
-        mock_client.reservation_get.return_value = reservations[0] if reservations else None
-        mock_client.clone.return_value = mock_client
-        mock_client.__enter__ = lambda self: self
-        mock_client.__exit__ = lambda self, *a: None
-
-    @patch("netbox_kea.models.KeaClient")
-    def test_reserved_badge_appears_when_reservation_exists(self, MockKeaClient):
+    def test_reserved_badge_appears_when_reservation_exists(self):
         """A v6 lease with a matching reservation must show the 'Reserved' badge."""
-        self._mock_command(
-            MockKeaClient.return_value,
-            leases=[dict(_MOCK_LEASE_V6_ENRICHMENT)],
-            reservations=[dict(_MOCK_RESERVATION_V6_ENRICHED)],
-        )
-        response = self.client.get(self._lease_url())
+        with stub_kea(
+            {
+                "lease6-get": _lease_one(_MOCK_LEASE_V6_ENRICHMENT),
+                "reservation-get": _res_get(_MOCK_RESERVATION_V6_ENRICHED),
+            }
+        ):
+            response = self.client.get(self._lease_url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Reserved")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_create_reservation_link_when_no_reservation(self, MockKeaClient):
+    def test_create_reservation_link_when_no_reservation(self):
         """A v6 lease without a matching reservation must show a create-reservation link."""
-        self._mock_command(
-            MockKeaClient.return_value,
-            leases=[dict(_MOCK_LEASE_V6_ENRICHMENT)],
-            reservations=[],
-        )
-        response = self.client.get(self._lease_url())
+        with stub_kea({"lease6-get": _lease_one(_MOCK_LEASE_V6_ENRICHMENT), "reservation-get": _RES_NOT_FOUND}):
+            response = self.client.get(self._lease_url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "reservations6/add")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_netbox_ip_synced_link_when_ip_in_netbox(self, MockKeaClient):
+    def test_netbox_ip_synced_link_when_ip_in_netbox(self):
         """When the v6 lease IP exists in NetBox IPAM, a 'Synced' link must appear."""
-        from ipam.models import IPAddress
-
         IPAddress.objects.create(address="2001:db8::5/128")
-        self._mock_command(
-            MockKeaClient.return_value,
-            leases=[dict(_MOCK_LEASE_V6_ENRICHMENT)],
-            reservations=[],
-        )
-        response = self.client.get(self._lease_url())
+        with stub_kea({"lease6-get": _lease_one(_MOCK_LEASE_V6_ENRICHMENT), "reservation-get": _RES_NOT_FOUND}):
+            response = self.client.get(self._lease_url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Synced")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_netbox_ip_sync_button_when_ip_not_in_netbox(self, MockKeaClient):
+    def test_netbox_ip_sync_button_when_ip_not_in_netbox(self):
         """When the v6 lease IP is not in NetBox IPAM, a 'Sync' button must appear."""
-        self._mock_command(
-            MockKeaClient.return_value,
-            leases=[dict(_MOCK_LEASE_V6_ENRICHMENT)],
-            reservations=[],
-        )
-        response = self.client.get(self._lease_url())
+        with stub_kea({"lease6-get": _lease_one(_MOCK_LEASE_V6_ENRICHMENT), "reservation-get": _RES_NOT_FOUND}):
+            response = self.client.get(self._lease_url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Sync")
 
@@ -1141,50 +1035,39 @@ class TestCombinedReservations6Enrichment(_CombinedViewBase):
     def _url(self):
         return reverse("plugins:netbox_kea:combined_reservations6") + f"?server={self.v6_server.pk}"
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_active_lease_badge_when_lease_exists(self, MockKeaClient):
+    def test_active_lease_badge_when_lease_exists(self):
         """A v6 reservation with an active lease must show 'Active Lease' badge."""
-        clone_mock = MagicMock(spec=KeaClient)
-        clone_mock.command.return_value = [{"result": 0, "arguments": {"leases": [{"ip-address": "2001:db8::5"}]}}]
-        clone_mock.__enter__ = lambda s: s
-        clone_mock.__exit__ = lambda s, *a: None
-        MockKeaClient.return_value.clone.return_value = clone_mock
-        MockKeaClient.return_value.reservation_get_page.return_value = (
-            [dict(_MOCK_RESERVATION_V6_ENRICHED)],
-            0,
-            0,
-        )
-        response = self.client.get(self._url())
+        with stub_kea(
+            {
+                "reservation-get-page": _res_page([dict(_MOCK_RESERVATION_V6_ENRICHED)]),
+                "lease6-get-all": _leases([{"ip-address": "2001:db8::5"}]),
+            }
+        ):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Active Lease")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_no_lease_badge_when_no_active_lease(self, MockKeaClient):
+    def test_no_lease_badge_when_no_active_lease(self):
         """A v6 reservation without active lease must show 'No Lease' badge."""
-        clone_mock = MagicMock(spec=KeaClient)
-        clone_mock.command.return_value = [{"result": 0, "arguments": {"leases": []}}]
-        clone_mock.__enter__ = lambda s: s
-        clone_mock.__exit__ = lambda s, *a: None
-        MockKeaClient.return_value.clone.return_value = clone_mock
-        MockKeaClient.return_value.reservation_get_page.return_value = (
-            [dict(_MOCK_RESERVATION_V6_ENRICHED)],
-            0,
-            0,
-        )
-        response = self.client.get(self._url())
+        with stub_kea(
+            {
+                "reservation-get-page": _res_page([dict(_MOCK_RESERVATION_V6_ENRICHED)]),
+                "lease6-get-all": _leases([]),
+            }
+        ):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "No Lease")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_edit_action_links_use_server_pk(self, MockKeaClient):
+    def test_edit_action_links_use_server_pk(self):
         """Each combined v6 reservation row must have an edit link pointing to the correct server."""
-        MockKeaClient.return_value.reservation_get_page.return_value = (
-            [dict(_MOCK_RESERVATION_V6_ENRICHED)],
-            0,
-            0,
-        )
-        MockKeaClient.return_value.command.return_value = [{"result": 0, "arguments": {"leases": []}}]
-        response = self.client.get(self._url())
+        with stub_kea(
+            {
+                "reservation-get-page": _res_page([dict(_MOCK_RESERVATION_V6_ENRICHED)]),
+                "lease6-get-all": _leases([]),
+            }
+        ):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         expected = f"/plugins/kea/servers/{self.v6_server.pk}/reservations6/"
         self.assertContains(response, expected)
@@ -1218,108 +1101,98 @@ class TestCombinedLeasesStateFilter(_CombinedViewBase):
         "hw-address": "aa:bb:cc:dd:ee:00",
     }
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_state_filter_excludes_other_states(self, MockKeaClient):
+    def test_state_filter_excludes_other_states(self):
         """state=1 (Declined) must exclude Active leases from merged results."""
-        MockKeaClient.return_value.command.return_value = [
-            {"result": 0, "arguments": {"leases": [dict(self._ACTIVE_LEASE), dict(self._DECLINED_LEASE)]}}
-        ]
-        MockKeaClient.return_value.reservation_get_page.return_value = ([], 0, 0)
-        url = (
-            reverse("plugins:netbox_kea:combined_leases4")
-            + f"?server={self.v4_server.pk}&q=host&by={constants.BY_HOSTNAME}&state=1"
-        )
-        response = self.client.get(url)
+        with stub_kea(
+            {
+                "lease4-get-by-hostname": _leases([dict(self._ACTIVE_LEASE), dict(self._DECLINED_LEASE)]),
+                "reservation-get": _RES_NOT_FOUND,
+            }
+        ):
+            url = (
+                reverse("plugins:netbox_kea:combined_leases4")
+                + f"?server={self.v4_server.pk}&q=host&by={constants.BY_HOSTNAME}&state=1"
+            )
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, "active-host")
         self.assertContains(response, "declined-host")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_state_filter_none_returns_all(self, MockKeaClient):
+    def test_state_filter_none_returns_all(self):
         """Empty state (no filter) must return both Active and Declined leases."""
-        MockKeaClient.return_value.command.return_value = [
-            {"result": 0, "arguments": {"leases": [dict(self._ACTIVE_LEASE), dict(self._DECLINED_LEASE)]}}
-        ]
-        MockKeaClient.return_value.reservation_get_page.return_value = ([], 0, 0)
-        url = (
-            reverse("plugins:netbox_kea:combined_leases4")
-            + f"?server={self.v4_server.pk}&q=host&by={constants.BY_HOSTNAME}"
-        )
-        response = self.client.get(url)
+        with stub_kea(
+            {
+                "lease4-get-by-hostname": _leases([dict(self._ACTIVE_LEASE), dict(self._DECLINED_LEASE)]),
+                "reservation-get": _RES_NOT_FOUND,
+            }
+        ):
+            url = (
+                reverse("plugins:netbox_kea:combined_leases4")
+                + f"?server={self.v4_server.pk}&q=host&by={constants.BY_HOSTNAME}"
+            )
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "active-host")
         self.assertContains(response, "declined-host")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_export_table_returns_csv(self, MockKeaClient):
+    def test_export_table_returns_csv(self):
         """?export=table returns a CSV download when search results are available."""
-        MockKeaClient.return_value.command.return_value = [
-            {"result": 0, "arguments": {"leases": [dict(self._ACTIVE_LEASE)]}}
-        ]
-        MockKeaClient.return_value.reservation_get_page.return_value = ([], 0, 0)
-        url = (
-            reverse("plugins:netbox_kea:combined_leases4")
-            + f"?server={self.v4_server.pk}&q=host&by={constants.BY_HOSTNAME}&export=table"
-        )
-        response = self.client.get(url)
+        with stub_kea(
+            {"lease4-get-by-hostname": _leases([dict(self._ACTIVE_LEASE)]), "reservation-get": _RES_NOT_FOUND}
+        ):
+            url = (
+                reverse("plugins:netbox_kea:combined_leases4")
+                + f"?server={self.v4_server.pk}&q=host&by={constants.BY_HOSTNAME}&export=table"
+            )
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertIn("text/csv", response.get("Content-Type", ""))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_export_without_query_returns_empty_csv(self, MockKeaClient):
+    def test_export_without_query_returns_empty_csv(self):
         """?export=table without a search query returns an empty CSV (no 500)."""
-        url = reverse("plugins:netbox_kea:combined_leases4") + "?export=table"
-        response = self.client.get(url)
+        with stub_kea({}):
+            url = reverse("plugins:netbox_kea:combined_leases4") + "?export=table"
+            response = self.client.get(url)
         self.assertIn(response.status_code, (200, 400))  # must not 500
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_state_only_no_q_returns_200(self, MockKeaClient):
+    def test_state_only_no_q_returns_200(self):
         """?state=1 without q must return 200 (uses lease4-get-page)."""
-        MockKeaClient.return_value.command.return_value = [{"result": 0, "arguments": {"count": 0, "leases": []}}]
-        url = reverse("plugins:netbox_kea:combined_leases4") + f"?server={self.v4_server.pk}&state=1"
-        response = self.client.get(url)
+        with stub_kea({"lease4-get-page": _leases([])}):
+            url = reverse("plugins:netbox_kea:combined_leases4") + f"?server={self.v4_server.pk}&state=1"
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_state_only_no_q_calls_get_page(self, MockKeaClient):
+    def test_state_only_no_q_calls_get_page(self):
         """?state=1 without q must call lease4-get-page (enumerate all)."""
-        MockKeaClient.return_value.command.return_value = [{"result": 0, "arguments": {"count": 0, "leases": []}}]
-        url = reverse("plugins:netbox_kea:combined_leases4") + f"?server={self.v4_server.pk}&state=1"
-        self.client.get(url)
-        call_args_list = MockKeaClient.return_value.command.call_args_list
-        called_commands = [c[0][0] for c in call_args_list]
-        self.assertIn("lease4-get-page", called_commands)
+        with stub_kea({"lease4-get-page": _leases([])}) as kea:
+            url = reverse("plugins:netbox_kea:combined_leases4") + f"?server={self.v4_server.pk}&state=1"
+            self.client.get(url)
+        self.assertIn("lease4-get-page", kea.commands())
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_state_only_no_q_filters_by_state(self, MockKeaClient):
+    def test_state_only_no_q_filters_by_state(self):
         """?state=1 without q must show declined leases and exclude active ones."""
-        MockKeaClient.return_value.command.return_value = [
+        with stub_kea(
             {
-                "result": 0,
-                "arguments": {
-                    "count": 2,
-                    "leases": [dict(self._ACTIVE_LEASE), dict(self._DECLINED_LEASE)],
-                },
+                "lease4-get-page": _leases([dict(self._ACTIVE_LEASE), dict(self._DECLINED_LEASE)]),
+                "reservation-get": _RES_NOT_FOUND,
             }
-        ]
-        MockKeaClient.return_value.reservation_get.return_value = None
-        url = reverse("plugins:netbox_kea:combined_leases4") + f"?server={self.v4_server.pk}&state=1"
-        response = self.client.get(url)
+        ):
+            url = reverse("plugins:netbox_kea:combined_leases4") + f"?server={self.v4_server.pk}&state=1"
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, "active-host")
         self.assertContains(response, "declined-host")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_state_only_no_q_server_error_graceful(self, MockKeaClient):
+    def test_state_only_no_q_server_error_graceful(self):
         """?state=1 without q handles unreachable server gracefully (no 500)."""
-        MockKeaClient.return_value.command.side_effect = Exception("refused")
-        url = reverse("plugins:netbox_kea:combined_leases4") + f"?server={self.v4_server.pk}&state=1"
-        response = self.client.get(url)
+        with stub_kea({"lease4-get-page": requests.ConnectionError("refused")}):
+            url = reverse("plugins:netbox_kea:combined_leases4") + f"?server={self.v4_server.pk}&state=1"
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
 
 # ---------------------------------------------------------------------------
-# Mock config fixture with shared networks
+# Kea config fixture with shared networks
 # ---------------------------------------------------------------------------
 
 _MOCK_CONFIG_WITH_SHARED_NET_V4 = [
@@ -1368,11 +1241,10 @@ _MOCK_CONFIG_WITH_SHARED_NET_V6 = [
 class TestCombinedSharedNetworks4View(_CombinedViewBase):
     """GET /plugins/kea/combined/shared-networks4/ — DHCPv4 shared networks across all servers."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_returns_200(self, MockKeaClient):
-        MockKeaClient.return_value.command.return_value = _MOCK_CONFIG_WITH_SHARED_NET_V4
-        url = reverse("plugins:netbox_kea:combined_shared_networks4")
-        response = self.client.get(url)
+    def test_get_returns_200(self):
+        with stub_kea({"config-get": _MOCK_CONFIG_WITH_SHARED_NET_V4}):
+            url = reverse("plugins:netbox_kea:combined_shared_networks4")
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
     def test_unauthenticated_redirects_to_login(self):
@@ -1382,52 +1254,46 @@ class TestCombinedSharedNetworks4View(_CombinedViewBase):
         self.assertEqual(response.status_code, 302)
         self.assertIn("login", response.url)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_queries_all_v4_servers(self, MockKeaClient):
+    def test_queries_all_v4_servers(self):
         """Without a filter, every dhcp4-enabled server is queried for config-get."""
-        MockKeaClient.return_value.command.return_value = _MOCK_CONFIG_WITH_SHARED_NET_V4
-        url = reverse("plugins:netbox_kea:combined_shared_networks4")
-        self.client.get(url)
-        # v4_server + dual_server → at least 2 calls
-        self.assertGreaterEqual(MockKeaClient.return_value.command.call_count, 2)
+        with stub_kea({"config-get": _MOCK_CONFIG_WITH_SHARED_NET_V4}) as kea:
+            url = reverse("plugins:netbox_kea:combined_shared_networks4")
+            self.client.get(url)
+        # v4_server + dual_server → at least 2 config-get calls
+        self.assertGreaterEqual(kea.commands().count("config-get"), 2)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_unreachable_server_returns_200_with_warning(self, MockKeaClient):
-        MockKeaClient.return_value.command.side_effect = requests.RequestException("refused")
-        url = reverse("plugins:netbox_kea:combined_shared_networks4")
-        response = self.client.get(url)
+    def test_unreachable_server_returns_200_with_warning(self):
+        with stub_kea({"config-get": requests.ConnectionError("refused")}):
+            url = reverse("plugins:netbox_kea:combined_shared_networks4")
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_results_include_server_name(self, MockKeaClient):
+    def test_results_include_server_name(self):
         """Shared network rows must include the server name they came from."""
-        MockKeaClient.return_value.command.return_value = _MOCK_CONFIG_WITH_SHARED_NET_V4
-        url = reverse("plugins:netbox_kea:combined_shared_networks4") + f"?server={self.v4_server.pk}"
-        response = self.client.get(url)
+        with stub_kea({"config-get": _MOCK_CONFIG_WITH_SHARED_NET_V4}):
+            url = reverse("plugins:netbox_kea:combined_shared_networks4") + f"?server={self.v4_server.pk}"
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "v4-server")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_context_active_tab(self, MockKeaClient):
-        MockKeaClient.return_value.command.return_value = _MOCK_CONFIG_WITH_SHARED_NET_V4
-        url = reverse("plugins:netbox_kea:combined_shared_networks4")
-        response = self.client.get(url)
+    def test_context_active_tab(self):
+        with stub_kea({"config-get": _MOCK_CONFIG_WITH_SHARED_NET_V4}):
+            url = reverse("plugins:netbox_kea:combined_shared_networks4")
+            response = self.client.get(url)
         self.assertEqual(response.context["active_tab"], "shared_networks4")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_shared_network_name_in_response(self, MockKeaClient):
+    def test_shared_network_name_in_response(self):
         """The shared network name must appear in the rendered table."""
-        MockKeaClient.return_value.command.return_value = _MOCK_CONFIG_WITH_SHARED_NET_V4
-        url = reverse("plugins:netbox_kea:combined_shared_networks4") + f"?server={self.v4_server.pk}"
-        response = self.client.get(url)
+        with stub_kea({"config-get": _MOCK_CONFIG_WITH_SHARED_NET_V4}):
+            url = reverse("plugins:netbox_kea:combined_shared_networks4") + f"?server={self.v4_server.pk}"
+            response = self.client.get(url)
         self.assertContains(response, "test-shared-net-v4")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_export_returns_csv(self, MockKeaClient):
+    def test_export_returns_csv(self):
         """?export=table returns a CSV download of shared network data."""
-        MockKeaClient.return_value.command.return_value = _MOCK_CONFIG_WITH_SHARED_NET_V4
-        url = reverse("plugins:netbox_kea:combined_shared_networks4") + f"?server={self.v4_server.pk}&export=table"
-        response = self.client.get(url)
+        with stub_kea({"config-get": _MOCK_CONFIG_WITH_SHARED_NET_V4}):
+            url = reverse("plugins:netbox_kea:combined_shared_networks4") + f"?server={self.v4_server.pk}&export=table"
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertIn("text/csv", response.get("Content-Type", ""))
 
@@ -1441,11 +1307,10 @@ class TestCombinedSharedNetworks4View(_CombinedViewBase):
 class TestCombinedSharedNetworks6View(_CombinedViewBase):
     """GET /plugins/kea/combined/shared-networks6/ — DHCPv6 shared networks across all servers."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_returns_200(self, MockKeaClient):
-        MockKeaClient.return_value.command.return_value = _MOCK_CONFIG_WITH_SHARED_NET_V6
-        url = reverse("plugins:netbox_kea:combined_shared_networks6")
-        response = self.client.get(url)
+    def test_get_returns_200(self):
+        with stub_kea({"config-get": _MOCK_CONFIG_WITH_SHARED_NET_V6}):
+            url = reverse("plugins:netbox_kea:combined_shared_networks6")
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
     def test_unauthenticated_redirects_to_login(self):
@@ -1455,32 +1320,28 @@ class TestCombinedSharedNetworks6View(_CombinedViewBase):
         self.assertEqual(response.status_code, 302)
         self.assertIn("login", response.url)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_queries_all_v6_servers(self, MockKeaClient):
+    def test_queries_all_v6_servers(self):
         """Without a filter, every dhcp6-enabled server is queried."""
-        MockKeaClient.return_value.command.return_value = _MOCK_CONFIG_WITH_SHARED_NET_V6
-        url = reverse("plugins:netbox_kea:combined_shared_networks6")
-        self.client.get(url)
-        self.assertGreaterEqual(MockKeaClient.return_value.command.call_count, 2)
+        with stub_kea({"config-get": _MOCK_CONFIG_WITH_SHARED_NET_V6}) as kea:
+            url = reverse("plugins:netbox_kea:combined_shared_networks6")
+            self.client.get(url)
+        self.assertGreaterEqual(kea.commands().count("config-get"), 2)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_unreachable_server_returns_200_with_warning(self, MockKeaClient):
-        MockKeaClient.return_value.command.side_effect = requests.RequestException("refused")
-        url = reverse("plugins:netbox_kea:combined_shared_networks6")
-        response = self.client.get(url)
+    def test_unreachable_server_returns_200_with_warning(self):
+        with stub_kea({"config-get": requests.ConnectionError("refused")}):
+            url = reverse("plugins:netbox_kea:combined_shared_networks6")
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_context_active_tab(self, MockKeaClient):
-        MockKeaClient.return_value.command.return_value = _MOCK_CONFIG_WITH_SHARED_NET_V6
-        url = reverse("plugins:netbox_kea:combined_shared_networks6")
-        response = self.client.get(url)
+    def test_context_active_tab(self):
+        with stub_kea({"config-get": _MOCK_CONFIG_WITH_SHARED_NET_V6}):
+            url = reverse("plugins:netbox_kea:combined_shared_networks6")
+            response = self.client.get(url)
         self.assertEqual(response.context["active_tab"], "shared_networks6")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_shared_network_name_in_response(self, MockKeaClient):
+    def test_shared_network_name_in_response(self):
         """The v6 shared network name must appear in the rendered table."""
-        MockKeaClient.return_value.command.return_value = _MOCK_CONFIG_WITH_SHARED_NET_V6
-        url = reverse("plugins:netbox_kea:combined_shared_networks6") + f"?server={self.v6_server.pk}"
-        response = self.client.get(url)
+        with stub_kea({"config-get": _MOCK_CONFIG_WITH_SHARED_NET_V6}):
+            url = reverse("plugins:netbox_kea:combined_shared_networks6") + f"?server={self.v6_server.pk}"
+            response = self.client.get(url)
         self.assertContains(response, "test-shared-net-v6")

--- a/netbox_kea/tests/test_jobs.py
+++ b/netbox_kea/tests/test_jobs.py
@@ -31,6 +31,14 @@ from netbox_kea.jobs import KeaIpamSyncJob
 from netbox_kea.kea import KeaClient, KeaException
 from netbox_kea.models import Server, SyncConfig
 
+from .kea_stub import stub_kea
+
+
+def _res_page(hosts):
+    """A single exhausted ``reservation-get-page`` payload carrying *hosts*."""
+    return {"result": 0, "arguments": {"hosts": list(hosts), "next": {"from": 0, "source-index": 0}}}
+
+
 _PLUGINS_CONFIG = {
     "netbox_kea": {
         "kea_timeout": 30,
@@ -1141,113 +1149,114 @@ _DHCP6_CONFIG_WITH_SHARED = [
 class TestFetchKeaSubnets(SimpleTestCase):
     """_fetch_kea_subnets fetches + parses the Kea subnet list, returning None on failure."""
 
-    def _make_server(self, name="kea1"):
-        server = MagicMock(spec=Server)
+    def _server(self, name="kea1"):
+        # Server is a plain container here (only .name + .get_client are read); the
+        # client it returns is a REAL KeaClient whose HTTP boundary stub_kea covers.
+        server = MagicMock(spec=Server)  # mock-ok: Server container for a job helper (name + get_client)
         server.name = name
+        server.get_client.return_value = KeaClient(url="https://kea.example.com")
         return server
 
-    def _server_returning(self, command_return=None, command_side_effect=None, get_client_side_effect=None):
-        server = self._make_server()
-        if get_client_side_effect is not None:
-            server.get_client.side_effect = get_client_side_effect
-            return server
-        client = MagicMock(spec=KeaClient)
-        if command_side_effect is not None:
-            client.command.side_effect = command_side_effect
-        else:
-            client.command.return_value = command_return
-        server.get_client.return_value = client
-        return server
+    @contextmanager
+    def _config_get(self, response):
+        """Yield a server whose real client answers ``config-get`` with *response*.
+
+        *response* is a raw Kea payload (list) or an exception instance the stub
+        raises at the HTTP boundary.
+        """
+        with stub_kea({"config-get": response}):
+            yield self._server()
 
     def test_returns_subnet_list(self):
         from netbox_kea.jobs import _fetch_kea_subnets
 
-        server = self._server_returning(_DHCP4_CONFIG_RESPONSE)
-        self.assertEqual(len(_fetch_kea_subnets(server, 4)), 2)
+        with self._config_get(_DHCP4_CONFIG_RESPONSE) as server:
+            self.assertEqual(len(_fetch_kea_subnets(server, 4)), 2)
 
     def test_shared_network_subnets_included(self):
         from netbox_kea.jobs import _fetch_kea_subnets
 
-        server = self._server_returning(_DHCP4_CONFIG_WITH_SHARED)
-        # 1 top-level subnet + 1 in shared-network = 2
-        self.assertEqual(len(_fetch_kea_subnets(server, 4)), 2)
+        with self._config_get(_DHCP4_CONFIG_WITH_SHARED) as server:
+            # 1 top-level subnet + 1 in shared-network = 2
+            self.assertEqual(len(_fetch_kea_subnets(server, 4)), 2)
 
     def test_shared_network_subnets_v6_included(self):
         from netbox_kea.jobs import _fetch_kea_subnets
 
-        server = self._server_returning(_DHCP6_CONFIG_WITH_SHARED)
-        self.assertEqual(len(_fetch_kea_subnets(server, 6)), 2)
+        with self._config_get(_DHCP6_CONFIG_WITH_SHARED) as server:
+            self.assertEqual(len(_fetch_kea_subnets(server, 6)), 2)
 
     def test_get_client_exception_returns_none(self):
         from netbox_kea.jobs import _fetch_kea_subnets
 
-        server = self._server_returning(get_client_side_effect=ValueError("no url"))
-        self.assertIsNone(_fetch_kea_subnets(server, 4))
+        # cert-without-key makes the real get_client() raise ValueError → helper returns None.
+        server = Server(name="kea1", ca_url="https://kea.example.com", dhcp4=True, client_cert_path="/x.pem")
+        with stub_kea({}):
+            self.assertIsNone(_fetch_kea_subnets(server, 4))
 
     def test_command_exception_returns_none(self):
         from netbox_kea.jobs import _fetch_kea_subnets
 
-        server = self._server_returning(command_side_effect=Exception("timeout"))
-        self.assertIsNone(_fetch_kea_subnets(server, 4))
-
-    def test_malformed_non_list_returns_none(self):
-        from netbox_kea.jobs import _fetch_kea_subnets
-
-        server = self._server_returning("not-a-list")
-        self.assertIsNone(_fetch_kea_subnets(server, 4))
+        # A transport error at the boundary propagates through command() → helper returns None.
+        with self._config_get(Exception("timeout")) as server:
+            self.assertIsNone(_fetch_kea_subnets(server, 4))
 
     def test_result_nonzero_returns_none(self):
         from netbox_kea.jobs import _fetch_kea_subnets
 
-        server = self._server_returning([{"result": 1, "text": "internal error"}])
-        self.assertIsNone(_fetch_kea_subnets(server, 4))
+        with self._config_get([{"result": 1, "text": "internal error"}]) as server:
+            self.assertIsNone(_fetch_kea_subnets(server, 4))
 
     def test_arguments_not_dict_returns_none(self):
         from netbox_kea.jobs import _fetch_kea_subnets
 
-        server = self._server_returning([{"result": 0, "arguments": "not-a-dict"}])
-        self.assertIsNone(_fetch_kea_subnets(server, 4))
+        with self._config_get([{"result": 0, "arguments": "not-a-dict"}]) as server:
+            self.assertIsNone(_fetch_kea_subnets(server, 4))
 
     def test_arguments_none_returns_empty_list(self):
         from netbox_kea.jobs import _fetch_kea_subnets
 
-        server = self._server_returning([{"result": 0, "arguments": None}])
-        self.assertEqual(_fetch_kea_subnets(server, 4), [])
+        with self._config_get([{"result": 0, "arguments": None}]) as server:
+            self.assertEqual(_fetch_kea_subnets(server, 4), [])
 
     def test_dhcp_config_not_dict_returns_none(self):
         from netbox_kea.jobs import _fetch_kea_subnets
 
-        server = self._server_returning([{"result": 0, "arguments": {"Dhcp4": "not-a-dict"}}])
-        self.assertIsNone(_fetch_kea_subnets(server, 4))
+        with self._config_get([{"result": 0, "arguments": {"Dhcp4": "not-a-dict"}}]) as server:
+            self.assertIsNone(_fetch_kea_subnets(server, 4))
 
     def test_empty_subnet_list_returns_empty(self):
         from netbox_kea.jobs import _fetch_kea_subnets
 
-        server = self._server_returning([{"result": 0, "arguments": {"Dhcp4": {"subnet4": []}}}])
-        self.assertEqual(_fetch_kea_subnets(server, 4), [])
+        with self._config_get([{"result": 0, "arguments": {"Dhcp4": {"subnet4": []}}}]) as server:
+            self.assertEqual(_fetch_kea_subnets(server, 4), [])
 
     def test_non_dict_shared_network_entry_is_skipped(self):
         from netbox_kea.jobs import _fetch_kea_subnets
 
-        server = self._server_returning(
-            [
-                {
-                    "result": 0,
-                    "arguments": {
-                        "Dhcp4": {
-                            "subnet4": [],
-                            "shared-networks": [
-                                "not-a-dict",
-                                {"name": "net-a", "subnet4": [{"subnet": "10.1.0.0/24", "pools": []}]},
-                            ],
-                        }
-                    },
-                }
-            ]
-        )
-        subnets = _fetch_kea_subnets(server, 4)
+        config = [
+            {
+                "result": 0,
+                "arguments": {
+                    "Dhcp4": {
+                        "subnet4": [],
+                        "shared-networks": [
+                            "not-a-dict",
+                            {"name": "net-a", "subnet4": [{"subnet": "10.1.0.0/24", "pools": []}]},
+                        ],
+                    }
+                },
+            }
+        ]
+        with self._config_get(config) as server:
+            subnets = _fetch_kea_subnets(server, 4)
         self.assertEqual(len(subnets), 1)
         self.assertEqual(subnets[0]["subnet"], "10.1.0.0/24")
+
+    # NOTE: the old test_malformed_non_list_returns_none was removed — a non-list Kea
+    # response is unreachable through the real client (KeaClient.command() raises
+    # ValueError on a non-list body, which _fetch_kea_subnets catches → None). That
+    # None outcome is already covered by test_command_exception_returns_none.
 
 
 class TestBuildSubnetPrefixMap(SimpleTestCase):
@@ -1283,16 +1292,15 @@ class TestSyncServerReservationsReturnValue(TestCase):
     def test_returns_false_when_a_row_fails(self):
         from netbox_kea.jobs import _sync_server_reservations
 
-        server = MagicMock(spec=Server)
+        server = MagicMock(spec=Server)  # mock-ok: Server container (name/pk/get_client) for a job helper
         server.name = "kea-fail"
-        client = MagicMock(spec=KeaClient)
-        # A reservation with no ip-address makes sync_reservation_to_netbox raise
-        # ValueError, which the loop catches and counts as an error.
-        client.reservation_get_page.return_value = ([{"hostname": "bad", "subnet-id": 1}], 0, 0)
-        server.get_client.return_value = client
-
+        server.pk = 1
+        server.get_client.return_value = KeaClient(url="https://kea.example.com")
+        # A reservation with no ip-address makes the REAL sync_reservation_to_netbox
+        # raise ValueError, which the loop catches and counts as an error.
         stats = {"created": 0, "updated": 0, "errors": 0, "prefix_errors": 0, "conflicts": 0}
-        ok = _sync_server_reservations(server, 4, stats=stats, all_synced=[])
+        with stub_kea({"reservation-get-page": _res_page([{"hostname": "bad", "subnet-id": 1}])}):
+            ok = _sync_server_reservations(server, 4, stats=stats, all_synced=[])
 
         self.assertFalse(ok)
         self.assertEqual(stats["errors"], 1)
@@ -1518,12 +1526,10 @@ class TestPrefetchReservationIpsEdgeCases(SimpleTestCase):
         from netbox_kea.jobs import _prefetch_reservation_ips
 
         server = self._make_server()
-        client = MagicMock(spec=KeaClient)
+        server.get_client.return_value = KeaClient(url="https://kea.example.com")
         page = ["not-a-dict", {"ip-address": "10.0.0.1"}]
-        client.reservation_get_page.return_value = (page, 0, 0)
-        server.get_client.return_value = client
-
-        result = _prefetch_reservation_ips(server, version=4)
+        with stub_kea({"reservation-get-page": _res_page(page)}):
+            result = _prefetch_reservation_ips(server, version=4)
 
         self.assertIsNotNone(result)
         self.assertIn("10.0.0.1", result)
@@ -1534,12 +1540,10 @@ class TestPrefetchReservationIpsEdgeCases(SimpleTestCase):
         from netbox_kea.jobs import _prefetch_reservation_ips
 
         server = self._make_server()
-        client = MagicMock(spec=KeaClient)
+        server.get_client.return_value = KeaClient(url="https://kea.example.com")
         page = [{"ip-addresses": ["2001:db8::1", "2001:db8::2"]}]
-        client.reservation_get_page.return_value = (page, 0, 0)
-        server.get_client.return_value = client
-
-        result = _prefetch_reservation_ips(server, version=6)
+        with stub_kea({"reservation-get-page": _res_page(page)}):
+            result = _prefetch_reservation_ips(server, version=6)
 
         self.assertIsNotNone(result)
         self.assertIn("2001:db8::1", result)
@@ -1565,13 +1569,13 @@ class TestSyncServerReservationsUpdated(SimpleTestCase):
         from netbox_kea.jobs import _sync_server_reservations
 
         server = self._make_server()
-        client = MagicMock(spec=KeaClient)
-        client.reservation_get_page.return_value = ([_RESV4], 0, 0)
-        server.get_client.return_value = client
+        server.pk = 1
+        server.get_client.return_value = KeaClient(url="https://kea.example.com")
 
         stats = {"created": 0, "updated": 0, "errors": 0, "prefix_errors": 0}
         all_synced: list = []
-        result = _sync_server_reservations(server, version=4, stats=stats, all_synced=all_synced)
+        with stub_kea({"reservation-get-page": _res_page([_RESV4])}):
+            result = _sync_server_reservations(server, version=4, stats=stats, all_synced=all_synced)
 
         self.assertTrue(result)
         self.assertEqual(stats["updated"], 1)

--- a/netbox_kea/tests/test_jobs.py
+++ b/netbox_kea/tests/test_jobs.py
@@ -31,13 +31,7 @@ from netbox_kea.jobs import KeaIpamSyncJob
 from netbox_kea.kea import KeaClient, KeaException
 from netbox_kea.models import Server, SyncConfig
 
-from .kea_stub import stub_kea
-
-
-def _res_page(hosts):
-    """A single exhausted ``reservation-get-page`` payload carrying *hosts*."""
-    return {"result": 0, "arguments": {"hosts": list(hosts), "next": {"from": 0, "source-index": 0}}}
-
+from .kea_stub import _res_page, stub_kea
 
 _PLUGINS_CONFIG = {
     "netbox_kea": {

--- a/netbox_kea/tests/test_kea_stub.py
+++ b/netbox_kea/tests/test_kea_stub.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: 2025 Marcin Zieba <marcinpsk@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the command-aware Kea HTTP stub itself (``kea_stub``).
+
+The stub is test infrastructure, so these verify its dispatch contract directly:
+a plain ``list`` is a verbatim multi-service payload, ``queued()`` sequences
+responses, and both request recording and queue dispatch are thread-safe (the
+enrichment views POST from cloned clients on worker threads).
+"""
+
+import threading
+
+import pytest
+import requests
+
+from netbox_kea.tests.kea_stub import KeaHttpStub, queued
+
+
+def _call(stub, command="x"):
+    return stub("https://kea.example.com/api/v1/", json={"command": command}).json()
+
+
+def test_dict_payload_is_wrapped_in_single_entry_list():
+    """A dict value is the single ``.json()`` entry (Kea returns a list)."""
+    stub = KeaHttpStub({"x": {"result": 0}})
+    assert _call(stub) == [{"result": 0}]
+
+
+def test_plain_multi_entry_list_returned_verbatim():
+    """A real multi-service response is a list and must NOT be treated as a queue."""
+    multi = [{"result": 0}, {"result": 3}]
+    stub = KeaHttpStub({"x": multi})
+    # Every call returns the full list, unchanged — not truncated to one entry.
+    assert _call(stub) == multi
+    assert _call(stub) == multi
+
+
+def test_empty_list_payload_returned_not_indexerror():
+    """An empty list is a valid empty payload, not an IndexError."""
+    stub = KeaHttpStub({"x": []})
+    assert _call(stub) == []
+
+
+def test_queued_dispatches_in_order_then_repeats_last():
+    stub = KeaHttpStub({"x": queued({"result": 0}, {"result": 3})})
+    assert _call(stub) == [{"result": 0}]
+    assert _call(stub) == [{"result": 3}]
+    assert _call(stub) == [{"result": 3}]  # last response repeats once exhausted
+
+
+def test_queued_requires_at_least_one_response():
+    with pytest.raises(ValueError):
+        queued()
+
+
+def test_unregistered_command_raises_assertion_error():
+    stub = KeaHttpStub({})
+    with pytest.raises(AssertionError):
+        _call(stub, "not-registered")
+
+
+def test_callable_resolves_against_request_body():
+    stub = KeaHttpStub({"x": lambda body: {"echo": body["command"]}})
+    assert _call(stub) == [{"echo": "x"}]
+
+
+def test_exception_value_is_raised():
+    stub = KeaHttpStub({"x": requests.ConnectionError("down")})
+    with pytest.raises(requests.ConnectionError):
+        _call(stub)
+
+
+def test_callable_returning_exception_is_raised():
+    stub = KeaHttpStub({"x": lambda body: ValueError("bad json")})
+    with pytest.raises(ValueError):
+        _call(stub)
+
+
+def test_concurrent_requests_are_all_recorded():
+    """Request recording under the lock loses no entries across worker threads."""
+    stub = KeaHttpStub({"x": {"result": 0}})
+    threads = [threading.Thread(target=_call, args=(stub,)) for _ in range(50)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert stub.commands().count("x") == 50
+
+
+def test_queue_dispatch_is_thread_safe():
+    """Each queued response is consumed exactly once across concurrent callers.
+
+    Without the dispatch lock, the non-atomic length-check-then-pop would let two
+    threads pop the same entry or skip one, so this would flake.
+    """
+    n = 20
+    stub = KeaHttpStub({"x": queued(*[{"n": i} for i in range(n)])})
+    seen: list[int] = []
+    seen_lock = threading.Lock()
+
+    def worker():
+        result = _call(stub)
+        with seen_lock:
+            seen.append(result[0]["n"])
+
+    threads = [threading.Thread(target=worker) for _ in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert sorted(seen) == list(range(n))

--- a/netbox_kea/tests/test_kea_stub.py
+++ b/netbox_kea/tests/test_kea_stub.py
@@ -72,6 +72,27 @@ def test_urls_records_endpoints_in_order():
     assert stub.urls() == ["http://v4:1", "http://v6:2"]
 
 
+def test_shared_response_builders_shape():
+    """Lock the shape of the shared reservation builders so callers can't drift."""
+    from netbox_kea.tests.kea_stub import _res_get, _res_page, _subnet_get
+
+    host = {"ip-address": "10.0.0.1", "subnet-id": 1}
+    # _res_page: hosts snapshot + pagination cursor (both 0 == source exhausted).
+    assert _res_page([host]) == {
+        "result": 0,
+        "arguments": {"hosts": [host], "next": {"from": 0, "source-index": 0}},
+    }
+    assert _res_page([], next_from=2, next_source=1)["arguments"]["next"] == {"from": 2, "source-index": 1}
+    # _res_get: host fields returned directly under arguments.
+    assert _res_get(host) == {"result": 0, "arguments": host}
+    # _subnet_get: subnet{v} list carrying id + pools for the pool-overlap probe.
+    assert _subnet_get(4, pools=["10.0.0.10-10.0.0.20"], subnet_id=7) == {
+        "result": 0,
+        "arguments": {"subnet4": [{"id": 7, "pools": [{"pool": "10.0.0.10-10.0.0.20"}]}]},
+    }
+    assert _subnet_get(6)["arguments"]["subnet6"][0]["pools"] == []
+
+
 def test_exception_value_is_raised():
     stub = KeaHttpStub({"x": requests.ConnectionError("down")})
     with pytest.raises(requests.ConnectionError):

--- a/netbox_kea/tests/test_kea_stub.py
+++ b/netbox_kea/tests/test_kea_stub.py
@@ -74,7 +74,7 @@ def test_urls_records_endpoints_in_order():
 
 def test_shared_response_builders_shape():
     """Lock the shape of the shared reservation builders so callers can't drift."""
-    from netbox_kea.tests.kea_stub import _res_get, _res_page, _subnet_get
+    from netbox_kea.tests.kea_stub import _res_get, _res_page, _subnet_get, _subnet_list
 
     host = {"ip-address": "10.0.0.1", "subnet-id": 1}
     # _res_page: hosts snapshot + pagination cursor (both 0 == source exhausted).
@@ -91,6 +91,10 @@ def test_shared_response_builders_shape():
         "arguments": {"subnet4": [{"id": 7, "pools": [{"pool": "10.0.0.10-10.0.0.20"}]}]},
     }
     assert _subnet_get(6)["arguments"]["subnet6"][0]["pools"] == []
+    # _subnet_list: the candidate-subnet list reservation_get_by_ip scans.
+    subnets = [{"id": 1, "subnet": "10.0.0.0/24"}]
+    assert _subnet_list(4, subnets) == {"result": 0, "arguments": {"subnets": subnets}}
+    assert _subnet_list(6, []) == {"result": 0, "arguments": {"subnets": []}}
 
 
 def test_exception_value_is_raised():

--- a/netbox_kea/tests/test_kea_stub.py
+++ b/netbox_kea/tests/test_kea_stub.py
@@ -64,6 +64,14 @@ def test_callable_resolves_against_request_body():
     assert _call(stub) == [{"echo": "x"}]
 
 
+def test_urls_records_endpoints_in_order():
+    """``urls()`` records each POST endpoint in call order (for dual-URL routing asserts)."""
+    stub = KeaHttpStub({"x": {"result": 0}})
+    stub("http://v4:1", json={"command": "x"})
+    stub("http://v6:2", json={"command": "x"})
+    assert stub.urls() == ["http://v4:1", "http://v6:2"]
+
+
 def test_exception_value_is_raised():
     stub = KeaHttpStub({"x": requests.ConnectionError("down")})
     with pytest.raises(requests.ConnectionError):

--- a/netbox_kea/tests/test_models.py
+++ b/netbox_kea/tests/test_models.py
@@ -5,7 +5,7 @@
 All Kea HTTP calls are mocked; these tests require no running services.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import requests
 from django.core.exceptions import ValidationError
@@ -14,7 +14,10 @@ from netbox.models import NetBoxModel
 
 from netbox_kea.kea import KeaClient
 from netbox_kea.models import Server, SyncConfig, _get_kea_timeout
+from netbox_kea.tests.kea_stub import stub_kea
 from netbox_kea.tests.utils import _make_db_server
+
+_VERSION_OK = {"result": 0, "arguments": {"version": "2.5.0"}}
 
 # Default PLUGINS_CONFIG used across model tests so we don't need full NetBox config.
 _PLUGINS_CONFIG = {"netbox_kea": {"kea_timeout": 30}}
@@ -298,121 +301,88 @@ class TestServerCleanConnectivity(SimpleTestCase):
         self.addCleanup(patcher.stop)
         patcher.start()
 
-    def _make_mock_client(self):
-        mock_client = MagicMock(spec=KeaClient)
-        mock_client.command.return_value = [{"result": 0, "arguments": {"version": "2.5.0"}}]
-        return mock_client
-
     @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
-    @patch("netbox_kea.models.KeaClient")
-    def test_valid_dhcp4_only_passes(self, mock_kea_cls):
-        mock_kea_cls.return_value = self._make_mock_client()
+    def test_valid_dhcp4_only_passes(self):
         server = _make_server(dhcp4=True, dhcp6=False)
-        server.clean()  # must not raise
+        with stub_kea({"version-get": _VERSION_OK}):
+            server.clean()  # must not raise
 
     @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
-    @patch("netbox_kea.models.KeaClient")
-    def test_valid_dhcp6_only_passes(self, mock_kea_cls):
-        mock_kea_cls.return_value = self._make_mock_client()
+    def test_valid_dhcp6_only_passes(self):
         server = _make_server(dhcp4=False, dhcp6=True)
-        server.clean()  # must not raise
+        with stub_kea({"version-get": _VERSION_OK}):
+            server.clean()  # must not raise
 
     @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
-    @patch("netbox_kea.models.KeaClient")
-    def test_valid_both_protocols_passes(self, mock_kea_cls):
-        mock_kea_cls.return_value = self._make_mock_client()
+    def test_valid_both_protocols_passes(self):
         server = _make_server(dhcp4=True, dhcp6=True)
-        server.clean()  # must not raise
+        with stub_kea({"version-get": _VERSION_OK}):
+            server.clean()  # must not raise
 
     @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
-    @patch("netbox_kea.models.KeaClient")
-    def test_dhcp6_connection_failure_raises(self, mock_kea_cls):
-        mock_client = MagicMock(spec=KeaClient)
-        mock_client.command.side_effect = requests.exceptions.ConnectionError("Connection refused")
-        mock_kea_cls.return_value = mock_client
+    def test_dhcp6_connection_failure_raises(self):
         server = _make_server(dhcp4=False, dhcp6=True)
-        with self.assertRaises(ValidationError) as ctx:
-            server.clean()
+        with stub_kea({"version-get": requests.exceptions.ConnectionError("Connection refused")}):
+            with self.assertRaises(ValidationError) as ctx:
+                server.clean()
         self.assertIn("dhcp6", ctx.exception.message_dict)
 
     @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
-    @patch("netbox_kea.models.KeaClient")
-    def test_dhcp4_connection_failure_raises(self, mock_kea_cls):
-        mock_client = MagicMock(spec=KeaClient)
-        mock_client.command.side_effect = requests.exceptions.Timeout("Timeout")
-        mock_kea_cls.return_value = mock_client
+    def test_dhcp4_connection_failure_raises(self):
         server = _make_server(dhcp4=True, dhcp6=False)
-        with self.assertRaises(ValidationError) as ctx:
-            server.clean()
+        with stub_kea({"version-get": requests.exceptions.Timeout("Timeout")}):
+            with self.assertRaises(ValidationError) as ctx:
+                server.clean()
         self.assertIn("dhcp4", ctx.exception.message_dict)
 
     @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
-    @patch("netbox_kea.models.KeaClient")
-    def test_connectivity_check_uses_version_specific_url(self, mock_kea_cls):
-        """get_client(version=4|6) must be called during clean(), not get_client()."""
-        mock_kea_cls.return_value = self._make_mock_client()
+    def test_connectivity_check_uses_version_specific_url(self):
+        """clean() must reach each daemon at its protocol-specific URL, not the shared CA URL."""
         server = _make_server(dhcp4=True, dhcp6=True, dhcp4_url="http://v4:1", dhcp6_url="http://v6:2")
-        server.clean()
-
-        # Verify KeaClient was constructed with the protocol-specific URLs
-        calls = [call.kwargs.get("url") or call.args[0] for call in mock_kea_cls.call_args_list]
-        self.assertIn("http://v4:1", calls)
-        self.assertIn("http://v6:2", calls)
+        with stub_kea({"version-get": _VERSION_OK}) as kea:
+            server.clean()
+        # The real per-version clients POST to the dual-URL endpoints.
+        self.assertIn("http://v4:1", kea.urls())
+        self.assertIn("http://v6:2", kea.urls())
 
     @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
-    @patch("netbox_kea.models.KeaClient")
-    def test_dhcp6_kea_exception_raises_unable_to_reach(self, mock_kea_cls):
+    def test_dhcp6_kea_exception_raises_unable_to_reach(self):
         """KeaException during DHCPv6 check → 'Unable to reach' ValidationError."""
-        from netbox_kea.kea import KeaException
-
-        mock_client = MagicMock(spec=KeaClient)
-        mock_client.command.side_effect = KeaException({"result": 1, "text": "error"})
-        mock_kea_cls.return_value = mock_client
         server = _make_server(dhcp4=False, dhcp6=True)
-        with self.assertRaises(ValidationError) as ctx:
-            server.clean()
+        with stub_kea({"version-get": {"result": 1, "text": "error"}}):
+            with self.assertRaises(ValidationError) as ctx:
+                server.clean()
         self.assertIn("dhcp6", ctx.exception.message_dict)
         self.assertIn("Unable to reach", ctx.exception.message_dict["dhcp6"][0])
 
     @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
-    @patch("netbox_kea.models.KeaClient")
-    def test_dhcp4_kea_exception_raises_unable_to_reach(self, mock_kea_cls):
+    def test_dhcp4_kea_exception_raises_unable_to_reach(self):
         """KeaException during DHCPv4 check → 'Unable to reach' ValidationError."""
-        from netbox_kea.kea import KeaException
-
-        mock_client = MagicMock(spec=KeaClient)
-        mock_client.command.side_effect = KeaException({"result": 1, "text": "error"})
-        mock_kea_cls.return_value = mock_client
         server = _make_server(dhcp4=True, dhcp6=False)
-        with self.assertRaises(ValidationError) as ctx:
-            server.clean()
+        with stub_kea({"version-get": {"result": 1, "text": "error"}}):
+            with self.assertRaises(ValidationError) as ctx:
+                server.clean()
         self.assertIn("dhcp4", ctx.exception.message_dict)
         self.assertIn("Unable to reach", ctx.exception.message_dict["dhcp4"][0])
 
     @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
-    @patch("netbox_kea.models.KeaClient")
-    def test_dhcp6_json_decode_error_raises_internal_error(self, mock_kea_cls):
+    def test_dhcp6_json_decode_error_raises_internal_error(self):
         """JSONDecodeError during DHCPv6 check → 'An internal error occurred' ValidationError."""
-        mock_client = MagicMock(spec=KeaClient)
-        mock_client.command.side_effect = requests.exceptions.JSONDecodeError("bad json", "", 0)
-        mock_kea_cls.return_value = mock_client
         server = _make_server(dhcp4=False, dhcp6=True)
-        with self.assertRaises(ValidationError) as ctx:
-            server.clean()
+        with stub_kea({"version-get": requests.exceptions.JSONDecodeError("bad json", "", 0)}):
+            with self.assertRaises(ValidationError) as ctx:
+                server.clean()
         self.assertIn("dhcp6", ctx.exception.message_dict)
         self.assertIn("internal error", ctx.exception.message_dict["dhcp6"][0])
         self.assertNotIn("bad json", ctx.exception.message_dict["dhcp6"][0])
 
     @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
-    @patch("netbox_kea.models.KeaClient")
-    def test_dhcp4_json_decode_error_raises_internal_error(self, mock_kea_cls):
+    def test_dhcp4_json_decode_error_raises_internal_error(self):
         """JSONDecodeError during DHCPv4 check → 'An internal error occurred' ValidationError."""
-        mock_client = MagicMock(spec=KeaClient)
-        mock_client.command.side_effect = requests.exceptions.JSONDecodeError("bad json", "", 0)
-        mock_kea_cls.return_value = mock_client
         server = _make_server(dhcp4=True, dhcp6=False)
-        with self.assertRaises(ValidationError) as ctx:
-            server.clean()
+        with stub_kea({"version-get": requests.exceptions.JSONDecodeError("bad json", "", 0)}):
+            with self.assertRaises(ValidationError) as ctx:
+                server.clean()
         self.assertIn("dhcp4", ctx.exception.message_dict)
         self.assertIn("internal error", ctx.exception.message_dict["dhcp4"][0])
         self.assertNotIn("bad json", ctx.exception.message_dict["dhcp4"][0])
@@ -521,56 +491,44 @@ class TestServerCleanExceptionRouting(SimpleTestCase):
         patcher.start()
 
     @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
-    @patch("netbox_kea.models.KeaClient")
-    def test_dhcp6_value_error_raises_reachability_message(self, mock_kea_cls):
+    def test_dhcp6_value_error_raises_reachability_message(self):
         """ValueError during DHCPv6 check must raise 'Unable to reach' message."""
-        mock_client = MagicMock(spec=KeaClient)
-        mock_client.command.side_effect = ValueError("bad response")
-        mock_kea_cls.return_value = mock_client
         server = _make_server(dhcp4=False, dhcp6=True)
-        with self.assertRaises(ValidationError) as ctx:
-            server.clean()
+        with stub_kea({"version-get": ValueError("bad response")}):
+            with self.assertRaises(ValidationError) as ctx:
+                server.clean()
         msg = str(ctx.exception.message_dict.get("dhcp6", [""])[0])
         self.assertIn("Unable to reach", msg)
         self.assertNotIn("internal error", msg)
 
     @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
-    @patch("netbox_kea.models.KeaClient")
-    def test_dhcp4_value_error_raises_reachability_message(self, mock_kea_cls):
+    def test_dhcp4_value_error_raises_reachability_message(self):
         """ValueError during DHCPv4 check must raise 'Unable to reach' message."""
-        mock_client = MagicMock(spec=KeaClient)
-        mock_client.command.side_effect = ValueError("bad response")
-        mock_kea_cls.return_value = mock_client
         server = _make_server(dhcp4=True, dhcp6=False)
-        with self.assertRaises(ValidationError) as ctx:
-            server.clean()
+        with stub_kea({"version-get": ValueError("bad response")}):
+            with self.assertRaises(ValidationError) as ctx:
+                server.clean()
         msg = str(ctx.exception.message_dict.get("dhcp4", [""])[0])
         self.assertIn("Unable to reach", msg)
         self.assertNotIn("internal error", msg)
 
     @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
-    @patch("netbox_kea.models.KeaClient")
-    def test_dhcp6_json_decode_error_raises_internal_error_message(self, mock_kea_cls):
+    def test_dhcp6_json_decode_error_raises_internal_error_message(self):
         """JSONDecodeError during DHCPv6 check must raise 'An internal error occurred' message."""
-        mock_client = MagicMock(spec=KeaClient)
-        mock_client.command.side_effect = requests.exceptions.JSONDecodeError("Expecting value", "", 0)
-        mock_kea_cls.return_value = mock_client
         server = _make_server(dhcp4=False, dhcp6=True)
-        with self.assertRaises(ValidationError) as ctx:
-            server.clean()
+        with stub_kea({"version-get": requests.exceptions.JSONDecodeError("Expecting value", "", 0)}):
+            with self.assertRaises(ValidationError) as ctx:
+                server.clean()
         msg = str(ctx.exception.message_dict.get("dhcp6", [""])[0])
         self.assertIn("internal error", msg)
 
     @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
-    @patch("netbox_kea.models.KeaClient")
-    def test_dhcp4_json_decode_error_raises_internal_error_message(self, mock_kea_cls):
+    def test_dhcp4_json_decode_error_raises_internal_error_message(self):
         """JSONDecodeError during DHCPv4 check must raise 'An internal error occurred' message."""
-        mock_client = MagicMock(spec=KeaClient)
-        mock_client.command.side_effect = requests.exceptions.JSONDecodeError("Expecting value", "", 0)
-        mock_kea_cls.return_value = mock_client
         server = _make_server(dhcp4=True, dhcp6=False)
-        with self.assertRaises(ValidationError) as ctx:
-            server.clean()
+        with stub_kea({"version-get": requests.exceptions.JSONDecodeError("Expecting value", "", 0)}):
+            with self.assertRaises(ValidationError) as ctx:
+                server.clean()
         msg = str(ctx.exception.message_dict.get("dhcp4", [""])[0])
         self.assertIn("internal error", msg)
 

--- a/netbox_kea/tests/test_reservation_views.py
+++ b/netbox_kea/tests/test_reservation_views.py
@@ -140,6 +140,92 @@ def _res_get(reservation):
 _RES_NOT_FOUND = {"result": 3}
 _LEASE_NOT_FOUND = {"result": 3}
 
+# Pool add/del and subnet add/del mutate Kea config, so they persist:
+# config-get → config-test → config-write. list-commands selects the pool command.
+_EMPTY_CONFIG4 = {"result": 0, "arguments": {"Dhcp4": {"subnet4": [], "shared-networks": []}}}
+_EMPTY_CONFIG6 = {"result": 0, "arguments": {"Dhcp6": {"subnet6": [], "shared-networks": []}}}
+_STAT_ABSENT4 = {"result": 2, "text": "unknown command 'stat-lease4-get'"}
+_STAT_ABSENT6 = {"result": 2, "text": "unknown command 'stat-lease6-get'"}
+
+
+def _empty_config(version):
+    return _EMPTY_CONFIG4 if version == 4 else _EMPTY_CONFIG6
+
+
+def _stat_absent(version):
+    return _STAT_ABSENT4 if version == 4 else _STAT_ABSENT6
+
+
+def _pool_add_stub(version, overlap_page=_RES_EMPTY_PAGE, **overrides):
+    """pool_add chain: reservation-get-page (overlap probe) → list-commands → subnet{v}-pool-add → persist.
+
+    ``stat-lease{v}-get`` + ``config-get`` also answer the followed subnets list (``follow=True``).
+    """
+    base = {
+        "reservation-get-page": overlap_page,
+        "list-commands": {
+            "result": 0,
+            "arguments": [f"subnet{version}-pool-add", "config-get", "config-test", "config-write"],
+        },
+        f"subnet{version}-pool-add": {"result": 0},
+        "config-get": _empty_config(version),
+        "config-test": {"result": 0},
+        "config-write": {"result": 0},
+        f"stat-lease{version}-get": _stat_absent(version),
+    }
+    base.update(overrides)
+    return stub_kea(base)
+
+
+def _pool_del_stub(version, **overrides):
+    """pool_del chain: list-commands → subnet{v}-pool-del → persist."""
+    base = {
+        "list-commands": {
+            "result": 0,
+            "arguments": [f"subnet{version}-pool-del", "config-get", "config-test", "config-write"],
+        },
+        f"subnet{version}-pool-del": {"result": 0},
+        "config-get": _empty_config(version),
+        "config-test": {"result": 0},
+        "config-write": {"result": 0},
+        f"stat-lease{version}-get": _stat_absent(version),
+    }
+    base.update(overrides)
+    return stub_kea(base)
+
+
+def _subnet_add_stub(version, **overrides):
+    """subnet_add chain: config-get (form choices + persist read-back) → subnet{v}-list (auto-id)
+    → subnet{v}-add (echoes id 1) → persist.
+    """
+    base = {
+        "config-get": _empty_config(version),
+        f"subnet{version}-list": {"result": 0, "arguments": {"subnets": []}},
+        f"subnet{version}-add": {"result": 0, "arguments": {"subnets": [{"id": 1}]}},
+        "config-test": {"result": 0},
+        "config-write": {"result": 0},
+        f"stat-lease{version}-get": _stat_absent(version),
+    }
+    base.update(overrides)
+    return stub_kea(base)
+
+
+def _subnet_del_stub(version, subnet_cidr="10.99.0.0/24", subnet_id=5, **overrides):
+    """subnet delete: GET confirmation issues subnet{v}-get; POST issues subnet{v}-del → persist."""
+    base = {
+        f"subnet{version}-get": {
+            "result": 0,
+            "arguments": {f"subnet{version}": [{"id": subnet_id, "subnet": subnet_cidr, "pools": []}]},
+        },
+        f"subnet{version}-del": {"result": 0},
+        "config-get": _empty_config(version),
+        "config-test": {"result": 0},
+        "config-write": {"result": 0},
+        f"stat-lease{version}-get": _stat_absent(version),
+    }
+    base.update(overrides)
+    return stub_kea(base)
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Shared base
@@ -1078,31 +1164,31 @@ class TestServerSubnet4PoolAddView(_ReservationViewBase):
             args=[self.server.pk, self._SUBNET_ID],
         )
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_renders_form(self, MockKeaClient):
+    def test_get_renders_form(self):
+        # GET renders the pool-add form only — no Kea traffic.
         response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "pool")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_valid_adds_pool_and_redirects(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.pool_add.return_value = None
-        response = self.client.post(self._url(), {"pool": "10.0.0.50-10.0.0.99"})
+    def test_post_valid_adds_pool_and_redirects(self):
+        with _pool_add_stub(4) as kea:
+            response = self.client.post(self._url(), {"pool": "10.0.0.50-10.0.0.99"})
         self.assertEqual(response.status_code, 302)
         self.assertNotIn("None", response.url)
-        mock_client.pool_add.assert_called_once_with(version=4, subnet_id=self._SUBNET_ID, pool="10.0.0.50-10.0.0.99")
+        self.assertEqual(kea.commands().count("subnet4-pool-add"), 1)
+        added = kea.bodies("subnet4-pool-add")[0]["arguments"]["subnet4"][0]
+        self.assertEqual(added["id"], self._SUBNET_ID)
+        self.assertEqual(added["pools"][0]["pool"], "10.0.0.50-10.0.0.99")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_invalid_rerenders_form(self, MockKeaClient):
+    def test_post_invalid_rerenders_form(self):
+        # Empty POST — the form is invalid before any Kea call.
         response = self.client.post(self._url(), {})
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_kea_error_shows_message(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.pool_add.side_effect = KeaException({"result": 1, "text": "Pool overlap detected."}, index=0)
-        response = self.client.post(self._url(), {"pool": "10.0.0.50-10.0.0.99"})
+    def test_post_kea_error_shows_message(self):
+        # subnet4-pool-add result 1 → real KeaClient raises KeaException → the view handles it.
+        with _pool_add_stub(4, **{"subnet4-pool-add": {"result": 1, "text": "Pool overlap detected."}}):
+            response = self.client.post(self._url(), {"pool": "10.0.0.50-10.0.0.99"})
         self.assertIn(response.status_code, (200, 302))
 
     def test_requires_login(self):
@@ -1112,38 +1198,26 @@ class TestServerSubnet4PoolAddView(_ReservationViewBase):
 
     # ── F4: pool-reservation overlap warning ─────────────────────────────────
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_warns_when_new_pool_overlaps_existing_reservation(self, MockKeaClient):
+    def test_post_warns_when_new_pool_overlaps_existing_reservation(self):
         """F4: POST adding a pool overlapping an existing reservation shows a non-blocking warning."""
-        mock_client = MockKeaClient.return_value
-        mock_client.pool_add.return_value = None
-        # reservation_get_page returns one reservation whose IP is in the new pool range
-        mock_client.reservation_get_page.return_value = (
-            [{"subnet-id": self._SUBNET_ID, "ip-address": "10.0.0.55"}],
-            0,
-            0,
-        )
-        response = self.client.post(self._url(), {"pool": "10.0.0.50-10.0.0.99"})
+        # The overlap probe finds a reservation (10.0.0.55) inside the new pool range.
+        overlap = _res_page([{"subnet-id": self._SUBNET_ID, "ip-address": "10.0.0.55"}])
+        with _pool_add_stub(4, overlap_page=overlap) as kea:
+            response = self.client.post(self._url(), {"pool": "10.0.0.50-10.0.0.99"})
         # Non-blocking: pool is still added and view redirects
         self.assertEqual(response.status_code, 302)
-        mock_client.pool_add.assert_called_once()
+        self.assertEqual(kea.commands().count("subnet4-pool-add"), 1)
         storage = list(get_messages(response.wsgi_request))
         self.assertTrue(any(m.level == WARNING for m in storage))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_no_warning_when_no_reservations_in_pool(self, MockKeaClient):
+    def test_post_no_warning_when_no_reservations_in_pool(self):
         """F4: No warning when no reservations fall within the new pool range."""
-        mock_client = MockKeaClient.return_value
-        mock_client.pool_add.return_value = None
-        # reservation_get_page returns a reservation OUTSIDE the new pool
-        mock_client.reservation_get_page.return_value = (
-            [{"subnet-id": self._SUBNET_ID, "ip-address": "10.0.0.10"}],
-            0,
-            0,
-        )
-        response = self.client.post(self._url(), {"pool": "10.0.0.50-10.0.0.99"})
+        # The reservation (10.0.0.10) is outside the new pool range → no overlap warning.
+        overlap = _res_page([{"subnet-id": self._SUBNET_ID, "ip-address": "10.0.0.10"}])
+        with _pool_add_stub(4, overlap_page=overlap) as kea:
+            response = self.client.post(self._url(), {"pool": "10.0.0.50-10.0.0.99"})
         self.assertEqual(response.status_code, 302)
-        mock_client.pool_add.assert_called_once()
+        self.assertEqual(kea.commands().count("subnet4-pool-add"), 1)
         storage = list(get_messages(response.wsgi_request))
         # Should have success message but no overlap warning
         self.assertFalse(any(m.level == WARNING for m in storage))
@@ -1162,26 +1236,26 @@ class TestServerSubnet4PoolDeleteView(_ReservationViewBase):
             args=[self.server.pk, self._SUBNET_ID, self._POOL],
         )
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_renders_confirmation(self, MockKeaClient):
+    def test_get_renders_confirmation(self):
+        # GET renders the delete-confirmation page only — no Kea traffic.
         response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, self._POOL)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_deletes_pool_and_redirects(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.pool_del.return_value = None
-        response = self.client.post(self._url())
+    def test_post_deletes_pool_and_redirects(self):
+        with _pool_del_stub(4) as kea:
+            response = self.client.post(self._url())
         self.assertEqual(response.status_code, 302)
         self.assertNotIn("None", response.url)
-        mock_client.pool_del.assert_called_once_with(version=4, subnet_id=self._SUBNET_ID, pool=self._POOL)
+        self.assertEqual(kea.commands().count("subnet4-pool-del"), 1)
+        deleted = kea.bodies("subnet4-pool-del")[0]["arguments"]["subnet4"][0]
+        self.assertEqual(deleted["id"], self._SUBNET_ID)
+        self.assertEqual(deleted["pools"][0]["pool"], self._POOL)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_kea_error_redirects_with_message(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.pool_del.side_effect = KeaException({"result": 3, "text": "Pool not found."}, index=0)
-        response = self.client.post(self._url())
+    def test_post_kea_error_redirects_with_message(self):
+        # subnet4-pool-del result 3 → real KeaClient raises KeaException → the view handles it.
+        with _pool_del_stub(4, **{"subnet4-pool-del": {"result": 3, "text": "Pool not found."}}):
+            response = self.client.post(self._url())
         self.assertIn(response.status_code, (200, 302))
 
     def test_requires_login(self):
@@ -1202,20 +1276,19 @@ class TestServerSubnet6PoolAddView(_ReservationViewBase):
             args=[self.server.pk, self._SUBNET_ID],
         )
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_renders_form(self, MockKeaClient):
+    def test_get_renders_form(self):
+        # GET renders the pool-add form only — no Kea traffic.
         response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_valid_adds_pool_and_redirects(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.pool_add.return_value = None
-        response = self.client.post(self._url(), {"pool": "2001:db8::10-2001:db8::ff"})
+    def test_post_valid_adds_pool_and_redirects(self):
+        with _pool_add_stub(6) as kea:
+            response = self.client.post(self._url(), {"pool": "2001:db8::10-2001:db8::ff"})
         self.assertEqual(response.status_code, 302)
-        mock_client.pool_add.assert_called_once_with(
-            version=6, subnet_id=self._SUBNET_ID, pool="2001:db8::10-2001:db8::ff"
-        )
+        self.assertEqual(kea.commands().count("subnet6-pool-add"), 1)
+        added = kea.bodies("subnet6-pool-add")[0]["arguments"]["subnet6"][0]
+        self.assertEqual(added["id"], self._SUBNET_ID)
+        self.assertEqual(added["pools"][0]["pool"], "2001:db8::10-2001:db8::ff")
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
@@ -1231,18 +1304,19 @@ class TestServerSubnet6PoolDeleteView(_ReservationViewBase):
             args=[self.server.pk, self._SUBNET_ID, self._POOL],
         )
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_renders_confirmation(self, MockKeaClient):
+    def test_get_renders_confirmation(self):
+        # GET renders the delete-confirmation page only — no Kea traffic.
         response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_deletes_pool_and_redirects(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.pool_del.return_value = None
-        response = self.client.post(self._url())
+    def test_post_deletes_pool_and_redirects(self):
+        with _pool_del_stub(6) as kea:
+            response = self.client.post(self._url())
         self.assertEqual(response.status_code, 302)
-        mock_client.pool_del.assert_called_once_with(version=6, subnet_id=self._SUBNET_ID, pool=self._POOL)
+        self.assertEqual(kea.commands().count("subnet6-pool-del"), 1)
+        deleted = kea.bodies("subnet6-pool-del")[0]["arguments"]["subnet6"][0]
+        self.assertEqual(deleted["id"], self._SUBNET_ID)
+        self.assertEqual(deleted["pools"][0]["pool"], self._POOL)
 
 
 # ---------------------------------------------------------------------------
@@ -1257,15 +1331,13 @@ class TestServerSubnet4AddView(_ReservationViewBase):
         return reverse("plugins:netbox_kea:server_subnet4_add", args=[self.server.pk])
 
     def test_get_renders_form(self):
-        resp = self.client.get(self._add_url())
+        with stub_kea({"config-get": _EMPTY_CONFIG4}):
+            resp = self.client.get(self._add_url())
         self.assertEqual(resp.status_code, 200)
         self.assertContains(resp, "id_subnet")
 
     def test_post_valid_calls_subnet_add_and_redirects(self):
-        mock_client = MagicMock(spec=KeaClient)
-        mock_client.subnet_add.return_value = None
-        mock_client.command.return_value = [{"result": 0, "arguments": {"Dhcp4": {"shared-networks": []}}}]
-        with patch("netbox_kea.models.KeaClient", return_value=mock_client):
+        with _subnet_add_stub(4) as kea:
             resp = self.client.post(
                 self._add_url(),
                 data={
@@ -1280,22 +1352,15 @@ class TestServerSubnet4AddView(_ReservationViewBase):
         self.assertRedirects(
             resp, reverse("plugins:netbox_kea:server_subnets4", args=[self.server.pk]), fetch_redirect_response=False
         )
-        mock_client.subnet_add.assert_called_once_with(
-            version=4,
-            subnet_cidr="10.99.0.0/24",
-            subnet_id=None,
-            pools=[],
-            gateway=None,
-            dns_servers=[],
-            ntp_servers=[],
-            ddns_qualifying_suffix=None,
-        )
+        self.assertEqual(kea.commands().count("subnet4-add"), 1)
+        added = kea.bodies("subnet4-add")[0]["arguments"]["subnet4"][0]
+        self.assertEqual(added["subnet"], "10.99.0.0/24")
+        # No pools / options supplied → they must not appear in the payload.
+        self.assertNotIn("pools", added)
+        self.assertNotIn("option-data", added)
 
     def test_post_with_options_passes_them_to_subnet_add(self):
-        mock_client = MagicMock(spec=KeaClient)
-        mock_client.subnet_add.return_value = None
-        mock_client.command.return_value = [{"result": 0, "arguments": {"Dhcp4": {"shared-networks": []}}}]
-        with patch("netbox_kea.models.KeaClient", return_value=mock_client):
+        with _subnet_add_stub(4) as kea:
             self.client.post(
                 self._add_url(),
                 data={
@@ -1307,22 +1372,16 @@ class TestServerSubnet4AddView(_ReservationViewBase):
                     "ntp_servers": "",
                 },
             )
-        mock_client.subnet_add.assert_called_once_with(
-            version=4,
-            subnet_cidr="10.99.0.0/24",
-            subnet_id=42,
-            pools=["10.99.0.100-10.99.0.200"],
-            gateway="10.99.0.1",
-            dns_servers=["8.8.8.8"],
-            ntp_servers=[],
-            ddns_qualifying_suffix=None,
-        )
+        added = kea.bodies("subnet4-add")[0]["arguments"]["subnet4"][0]
+        self.assertEqual(added["id"], 42)
+        self.assertEqual(added["subnet"], "10.99.0.0/24")
+        self.assertEqual(added["pools"], [{"pool": "10.99.0.100-10.99.0.200"}])
+        opts = {o["name"]: o["data"] for o in added["option-data"]}
+        self.assertEqual(opts["routers"], "10.99.0.1")
+        self.assertEqual(opts["domain-name-servers"], "8.8.8.8")
 
     def test_post_with_ddns_suffix_passes_it_to_subnet_add(self):
-        mock_client = MagicMock(spec=KeaClient)
-        mock_client.subnet_add.return_value = None
-        mock_client.command.return_value = [{"result": 0, "arguments": {"Dhcp4": {"shared-networks": []}}}]
-        with patch("netbox_kea.models.KeaClient", return_value=mock_client):
+        with _subnet_add_stub(4) as kea:
             self.client.post(
                 self._add_url(),
                 data={
@@ -1335,37 +1394,29 @@ class TestServerSubnet4AddView(_ReservationViewBase):
                     "ddns_qualifying_suffix": "example.com.",
                 },
             )
-        mock_client.subnet_add.assert_called_once_with(
-            version=4,
-            subnet_cidr="10.99.0.0/24",
-            subnet_id=None,
-            pools=[],
-            gateway=None,
-            dns_servers=[],
-            ntp_servers=[],
-            ddns_qualifying_suffix="example.com.",
-        )
+        added = kea.bodies("subnet4-add")[0]["arguments"]["subnet4"][0]
+        self.assertEqual(added["ddns-qualifying-suffix"], "example.com.")
 
     def test_post_invalid_cidr_rerenders_form(self):
-        resp = self.client.post(
-            self._add_url(),
-            data={
-                "subnet": "not-a-cidr",
-                "subnet_id": "",
-                "pools": "",
-                "gateway": "",
-                "dns_servers": "",
-                "ntp_servers": "",
-            },
-        )
+        # Invalid CIDR → the form is invalid; config-get answers the re-render's choice lookup.
+        with stub_kea({"config-get": _EMPTY_CONFIG4}):
+            resp = self.client.post(
+                self._add_url(),
+                data={
+                    "subnet": "not-a-cidr",
+                    "subnet_id": "",
+                    "pools": "",
+                    "gateway": "",
+                    "dns_servers": "",
+                    "ntp_servers": "",
+                },
+            )
         self.assertEqual(resp.status_code, 200)
         self.assertContains(resp, "Invalid subnet CIDR")
 
     def test_post_kea_error_shows_message_and_rerenders(self):
-        mock_client = MagicMock(spec=KeaClient)
-        mock_client.subnet_add.side_effect = KeaException({"result": 1, "text": "subnet already exists"}, index=0)
-        mock_client.command.return_value = [{"result": 0, "arguments": {"Dhcp4": {"shared-networks": []}}}]
-        with patch("netbox_kea.models.KeaClient", return_value=mock_client):
+        # subnet4-add result 1 → real KeaClient raises KeaException → the view redirects with an error.
+        with _subnet_add_stub(4, **{"subnet4-add": {"result": 1, "text": "subnet already exists"}}):
             resp = self.client.post(
                 self._add_url(),
                 data={
@@ -1389,29 +1440,24 @@ class TestServerSubnet4DeleteView(_ReservationViewBase):
         return reverse("plugins:netbox_kea:server_subnet4_delete", args=[self.server.pk, subnet_id])
 
     def test_get_renders_confirmation(self):
-        mock_client = MagicMock(spec=KeaClient)
-        mock_client.command.return_value = [
-            {"result": 0, "arguments": {"subnet4": [{"id": 5, "subnet": "10.99.0.0/24", "pools": []}]}}
-        ]
-        with patch("netbox_kea.models.KeaClient", return_value=mock_client):
+        # GET issues subnet4-get to show the CIDR on the confirmation page.
+        with _subnet_del_stub(4):
             resp = self.client.get(self._delete_url())
         self.assertEqual(resp.status_code, 200)
         self.assertContains(resp, "10.99.0.0/24")
 
     def test_post_calls_subnet_del_and_redirects(self):
-        mock_client = MagicMock(spec=KeaClient)
-        mock_client.subnet_del.return_value = None
-        with patch("netbox_kea.models.KeaClient", return_value=mock_client):
+        with _subnet_del_stub(4) as kea:
             resp = self.client.post(self._delete_url())
         self.assertRedirects(
             resp, reverse("plugins:netbox_kea:server_subnets4", args=[self.server.pk]), fetch_redirect_response=False
         )
-        mock_client.subnet_del.assert_called_once_with(version=4, subnet_id=5)
+        self.assertEqual(kea.commands().count("subnet4-del"), 1)
+        self.assertEqual(kea.bodies("subnet4-del")[0]["arguments"]["id"], 5)
 
     def test_post_kea_error_shows_message(self):
-        mock_client = MagicMock(spec=KeaClient)
-        mock_client.subnet_del.side_effect = KeaException({"result": 1, "text": "subnet not found"}, index=0)
-        with patch("netbox_kea.models.KeaClient", return_value=mock_client):
+        # subnet4-del result 1 → real KeaClient raises KeaException → the view redirects with an error.
+        with _subnet_del_stub(4, **{"subnet4-del": {"result": 1, "text": "subnet not found"}}):
             resp = self.client.post(self._delete_url())
         self.assertRedirects(
             resp, reverse("plugins:netbox_kea:server_subnets4", args=[self.server.pk]), fetch_redirect_response=False
@@ -1425,10 +1471,7 @@ class TestServerSubnet6AddView(_ReservationViewBase):
         return reverse("plugins:netbox_kea:server_subnet6_add", args=[self.server.pk])
 
     def test_post_valid_uses_version_6(self):
-        mock_client = MagicMock(spec=KeaClient)
-        mock_client.subnet_add.return_value = None
-        mock_client.command.return_value = [{"result": 0, "arguments": {"Dhcp6": {"shared-networks": []}}}]
-        with patch("netbox_kea.models.KeaClient", return_value=mock_client):
+        with _subnet_add_stub(6) as kea:
             resp = self.client.post(
                 self._add_url(),
                 data={
@@ -1443,22 +1486,12 @@ class TestServerSubnet6AddView(_ReservationViewBase):
         self.assertRedirects(
             resp, reverse("plugins:netbox_kea:server_subnets6", args=[self.server.pk]), fetch_redirect_response=False
         )
-        mock_client.subnet_add.assert_called_once_with(
-            version=6,
-            subnet_cidr="2001:db8:99::/48",
-            subnet_id=None,
-            pools=[],
-            gateway=None,
-            dns_servers=[],
-            ntp_servers=[],
-            ddns_qualifying_suffix=None,
-        )
+        # Version routing: the v6 view issues subnet6-add (not subnet4-add).
+        self.assertEqual(kea.commands().count("subnet6-add"), 1)
+        self.assertEqual(kea.bodies("subnet6-add")[0]["arguments"]["subnet6"][0]["subnet"], "2001:db8:99::/48")
 
     def test_post_with_ddns_suffix_passes_it_to_subnet_add(self):
-        mock_client = MagicMock(spec=KeaClient)
-        mock_client.subnet_add.return_value = None
-        mock_client.command.return_value = [{"result": 0, "arguments": {"Dhcp6": {"shared-networks": []}}}]
-        with patch("netbox_kea.models.KeaClient", return_value=mock_client):
+        with _subnet_add_stub(6) as kea:
             self.client.post(
                 self._add_url(),
                 data={
@@ -1471,16 +1504,8 @@ class TestServerSubnet6AddView(_ReservationViewBase):
                     "ddns_qualifying_suffix": "example.com.",
                 },
             )
-        mock_client.subnet_add.assert_called_once_with(
-            version=6,
-            subnet_cidr="2001:db8:99::/48",
-            subnet_id=None,
-            pools=[],
-            gateway=None,
-            dns_servers=[],
-            ntp_servers=[],
-            ddns_qualifying_suffix="example.com.",
-        )
+        added = kea.bodies("subnet6-add")[0]["arguments"]["subnet6"][0]
+        self.assertEqual(added["ddns-qualifying-suffix"], "example.com.")
 
 
 class TestServerSubnet6DeleteView(_ReservationViewBase):
@@ -1490,11 +1515,11 @@ class TestServerSubnet6DeleteView(_ReservationViewBase):
         return reverse("plugins:netbox_kea:server_subnet6_delete", args=[self.server.pk, subnet_id])
 
     def test_post_calls_subnet_del_v6(self):
-        mock_client = MagicMock(spec=KeaClient)
-        mock_client.subnet_del.return_value = None
-        with patch("netbox_kea.models.KeaClient", return_value=mock_client):
+        with _subnet_del_stub(6, subnet_id=7, subnet_cidr="2001:db8:99::/48") as kea:
             resp = self.client.post(self._delete_url())
-        mock_client.subnet_del.assert_called_once_with(version=6, subnet_id=7)
+        # Version routing: the v6 view issues subnet6-del (not subnet4-del) for subnet 7.
+        self.assertEqual(kea.commands().count("subnet6-del"), 1)
+        self.assertEqual(kea.bodies("subnet6-del")[0]["arguments"]["id"], 7)
         self.assertRedirects(
             resp, reverse("plugins:netbox_kea:server_subnets6", args=[self.server.pk]), fetch_redirect_response=False
         )

--- a/netbox_kea/tests/test_reservation_views.py
+++ b/netbox_kea/tests/test_reservation_views.py
@@ -1668,67 +1668,58 @@ class TestReservationSearch4View(_ReservationViewBase):
             return f"{base}?{urlencode(params)}"
         return base
 
-    def _mock_two_reservations(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.get_available_commands.return_value = _RESERVATION_COMMANDS
-        mock_client.reservation_get_page.return_value = (
-            [dict(_SAMPLE_RESERVATION4), dict(_EXTRA_RESERVATION4)],
-            0,
-            0,
+    def _stub(self):
+        """Reservations4-list stub with two reservations (subnets 1 and 2) + lease enrichment."""
+        return stub_kea(
+            {
+                "reservation-get-page": _res_page([dict(_SAMPLE_RESERVATION4), dict(_EXTRA_RESERVATION4)]),
+                "lease4-get-all": _LEASE_NONE4,
+            }
         )
-        mock_client.command.return_value = [{"result": 0, "arguments": {"leases": [], "count": 0}}]
-        return mock_client
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_no_params_shows_all_reservations(self, MockKeaClient):
-        self._mock_two_reservations(MockKeaClient)
-        response = self.client.get(self._url())
+    def test_no_params_shows_all_reservations(self):
+        with self._stub():
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, _SAMPLE_RESERVATION4["ip-address"])
         self.assertContains(response, _EXTRA_RESERVATION4["ip-address"])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_q_filters_by_hostname(self, MockKeaClient):
-        self._mock_two_reservations(MockKeaClient)
-        response = self.client.get(self._url(q="testhost"))
+    def test_q_filters_by_hostname(self):
+        with self._stub():
+            response = self.client.get(self._url(q="testhost"))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, _SAMPLE_RESERVATION4["ip-address"])
         self.assertNotContains(response, _EXTRA_RESERVATION4["ip-address"])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_q_filters_by_ip(self, MockKeaClient):
-        self._mock_two_reservations(MockKeaClient)
-        response = self.client.get(self._url(q="10.0.0.99"))
+    def test_q_filters_by_ip(self):
+        with self._stub():
+            response = self.client.get(self._url(q="10.0.0.99"))
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, _SAMPLE_RESERVATION4["ip-address"])
         self.assertContains(response, _EXTRA_RESERVATION4["ip-address"])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_subnet_id_filter(self, MockKeaClient):
-        self._mock_two_reservations(MockKeaClient)
-        response = self.client.get(self._url(subnet_id=1))
+    def test_subnet_id_filter(self):
+        with self._stub():
+            response = self.client.get(self._url(subnet_id=1))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, _SAMPLE_RESERVATION4["ip-address"])
         self.assertNotContains(response, _EXTRA_RESERVATION4["ip-address"])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_search_form_in_context(self, MockKeaClient):
-        self._mock_two_reservations(MockKeaClient)
-        response = self.client.get(self._url(q="testhost"))
+    def test_search_form_in_context(self):
+        with self._stub():
+            response = self.client.get(self._url(q="testhost"))
         self.assertIn("search_form", response.context)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_empty_q_shows_all(self, MockKeaClient):
-        self._mock_two_reservations(MockKeaClient)
-        response = self.client.get(self._url(q=""))
+    def test_empty_q_shows_all(self):
+        with self._stub():
+            response = self.client.get(self._url(q=""))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, _SAMPLE_RESERVATION4["ip-address"])
         self.assertContains(response, _EXTRA_RESERVATION4["ip-address"])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_no_match_shows_no_ips(self, MockKeaClient):
-        self._mock_two_reservations(MockKeaClient)
-        response = self.client.get(self._url(q="zzz-no-match-zzz"))
+    def test_no_match_shows_no_ips(self):
+        with self._stub():
+            response = self.client.get(self._url(q="zzz-no-match-zzz"))
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, _SAMPLE_RESERVATION4["ip-address"])
         self.assertNotContains(response, _EXTRA_RESERVATION4["ip-address"])
@@ -1744,59 +1735,51 @@ class TestReservationSearch6View(_ReservationViewBase):
             return f"{base}?{urlencode(params)}"
         return base
 
-    def _mock_two_reservations(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.get_available_commands.return_value = _RESERVATION_COMMANDS
-        mock_client.reservation_get_page.return_value = (
-            [dict(_SAMPLE_RESERVATION6), dict(_EXTRA_RESERVATION6)],
-            0,
-            0,
+    def _stub(self):
+        """Reservations6-list stub with two reservations (subnets 1 and 20) + lease enrichment."""
+        return stub_kea(
+            {
+                "reservation-get-page": _res_page([dict(_SAMPLE_RESERVATION6), dict(_EXTRA_RESERVATION6)]),
+                "lease6-get-all": _LEASE_NONE6,
+            }
         )
-        mock_client.command.return_value = [{"result": 0, "arguments": {"leases": [], "count": 0}}]
-        return mock_client
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_no_params_shows_all_reservations(self, MockKeaClient):
-        self._mock_two_reservations(MockKeaClient)
-        response = self.client.get(self._url())
+    def test_no_params_shows_all_reservations(self):
+        with self._stub():
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, _SAMPLE_RESERVATION6["ip-addresses"][0])
         self.assertContains(response, _EXTRA_RESERVATION6["ip-addresses"][0])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_q_filters_by_hostname(self, MockKeaClient):
-        self._mock_two_reservations(MockKeaClient)
-        response = self.client.get(self._url(q="testhost6"))
+    def test_q_filters_by_hostname(self):
+        with self._stub():
+            response = self.client.get(self._url(q="testhost6"))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, _SAMPLE_RESERVATION6["ip-addresses"][0])
         self.assertNotContains(response, _EXTRA_RESERVATION6["ip-addresses"][0])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_q_filters_by_duid(self, MockKeaClient):
-        self._mock_two_reservations(MockKeaClient)
-        response = self.client.get(self._url(q="ff:ee:dd"))
+    def test_q_filters_by_duid(self):
+        with self._stub():
+            response = self.client.get(self._url(q="ff:ee:dd"))
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, _SAMPLE_RESERVATION6["ip-addresses"][0])
         self.assertContains(response, _EXTRA_RESERVATION6["ip-addresses"][0])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_subnet_id_filter(self, MockKeaClient):
-        self._mock_two_reservations(MockKeaClient)
-        response = self.client.get(self._url(subnet_id=1))
+    def test_subnet_id_filter(self):
+        with self._stub():
+            response = self.client.get(self._url(subnet_id=1))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, _SAMPLE_RESERVATION6["ip-addresses"][0])
         self.assertNotContains(response, _EXTRA_RESERVATION6["ip-addresses"][0])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_search_form_in_context(self, MockKeaClient):
-        self._mock_two_reservations(MockKeaClient)
-        response = self.client.get(self._url(q="testhost6"))
+    def test_search_form_in_context(self):
+        with self._stub():
+            response = self.client.get(self._url(q="testhost6"))
         self.assertIn("search_form", response.context)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_no_match_shows_no_ips(self, MockKeaClient):
-        self._mock_two_reservations(MockKeaClient)
-        response = self.client.get(self._url(q="zzz-no-match-zzz"))
+    def test_no_match_shows_no_ips(self):
+        with self._stub():
+            response = self.client.get(self._url(q="zzz-no-match-zzz"))
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, _SAMPLE_RESERVATION6["ip-addresses"][0])
         self.assertNotContains(response, _EXTRA_RESERVATION6["ip-addresses"][0])
@@ -1833,85 +1816,67 @@ class TestBulkReservationImport(_ReservationViewBase):
         url = _import_url(self.server.pk, 6)
         self.assertIn("import", url)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_renders_form(self, MockKeaClient):
-        """GET renders the import form (200 OK)."""
-        MockKeaClient.return_value.get_available_commands.return_value = _RESERVATION_COMMANDS
+    def test_get_renders_form(self):
+        """GET renders the import form (200 OK) — no Kea traffic."""
         response = self.client.get(_import_url(self.server.pk, 4))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "import", msg_prefix="", html=False)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_valid_v4_csv_creates_reservations(self, MockKeaClient):
-        """POST valid v4 CSV creates two reservations and shows created count."""
-        mock_client = MockKeaClient.return_value
-        mock_client.get_available_commands.return_value = _RESERVATION_COMMANDS
-        mock_client.reservation_add.return_value = None
-        csv_file = io.BytesIO(_BULK_IMPORT_V4_CSV.encode())
+    def _csv_upload(self, csv_text):
+        csv_file = io.BytesIO(csv_text.encode())
         csv_file.name = "import.csv"
-        response = self.client.post(
-            _import_url(self.server.pk, 4),
-            {"csv_file": csv_file},
-            format="multipart",
-        )
+        return csv_file
+
+    def test_post_valid_v4_csv_creates_reservations(self):
+        """POST valid v4 CSV creates two reservations and shows created count."""
+        # The import loops reservation_add per row → one reservation-add command each.
+        with stub_kea({"reservation-add": {"result": 0}}) as kea:
+            response = self.client.post(
+                _import_url(self.server.pk, 4),
+                {"csv_file": self._csv_upload(_BULK_IMPORT_V4_CSV)},
+                format="multipart",
+            )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(mock_client.reservation_add.call_count, 2)
+        self.assertEqual(kea.commands().count("reservation-add"), 2)
         self.assertContains(response, "Created")  # result summary shown
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_valid_v6_csv_creates_reservation(self, MockKeaClient):
+    def test_post_valid_v6_csv_creates_reservation(self):
         """POST valid v6 CSV creates one reservation."""
-        mock_client = MockKeaClient.return_value
-        mock_client.get_available_commands.return_value = _RESERVATION_COMMANDS
-        mock_client.reservation_add.return_value = None
-        csv_file = io.BytesIO(_BULK_IMPORT_V6_CSV.encode())
-        csv_file.name = "import.csv"
-        response = self.client.post(
-            _import_url(self.server.pk, 6),
-            {"csv_file": csv_file},
-            format="multipart",
-        )
+        with stub_kea({"reservation-add": {"result": 0}}) as kea:
+            response = self.client.post(
+                _import_url(self.server.pk, 6),
+                {"csv_file": self._csv_upload(_BULK_IMPORT_V6_CSV)},
+                format="multipart",
+            )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(mock_client.reservation_add.call_count, 1)
+        self.assertEqual(kea.commands().count("reservation-add"), 1)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_skips_duplicate_reservations(self, MockKeaClient):
+    def test_post_skips_duplicate_reservations(self):
         """result=1 with 'already exists' text is counted as skipped, not error."""
-        mock_client = MockKeaClient.return_value
-        mock_client.get_available_commands.return_value = _RESERVATION_COMMANDS
-        dup_exc = KeaException({"result": 1, "text": "Host already exists."}, index=0)
-        mock_client.reservation_add.side_effect = dup_exc
-        csv_file = io.BytesIO(_BULK_IMPORT_V4_CSV.encode())
-        csv_file.name = "import.csv"
-        response = self.client.post(
-            _import_url(self.server.pk, 4),
-            {"csv_file": csv_file},
-            format="multipart",
-        )
+        # reservation-add result 1 "already exists" → real KeaException → counted as skipped.
+        with stub_kea({"reservation-add": {"result": 1, "text": "Host already exists."}}):
+            response = self.client.post(
+                _import_url(self.server.pk, 4),
+                {"csv_file": self._csv_upload(_BULK_IMPORT_V4_CSV)},
+                format="multipart",
+            )
         self.assertEqual(response.status_code, 200)
         # No hard error — page still 200 with skipped count shown
         self.assertContains(response, "Skipped (already exist)")  # skipped summary shown
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_shows_errors_on_kea_failure(self, MockKeaClient):
+    def test_post_shows_errors_on_kea_failure(self):
         """KeaException (non-duplicate) is counted as error and shown on page."""
-        mock_client = MockKeaClient.return_value
-        mock_client.get_available_commands.return_value = _RESERVATION_COMMANDS
-        mock_client.reservation_add.side_effect = KeaException({"result": 1, "text": "subnet not found"})
-        csv_file = io.BytesIO(_BULK_IMPORT_V4_CSV.encode())
-        csv_file.name = "import.csv"
-        response = self.client.post(
-            _import_url(self.server.pk, 4),
-            {"csv_file": csv_file},
-            format="multipart",
-        )
+        with stub_kea({"reservation-add": {"result": 1, "text": "subnet not found"}}):
+            response = self.client.post(
+                _import_url(self.server.pk, 4),
+                {"csv_file": self._csv_upload(_BULK_IMPORT_V4_CSV)},
+                format="multipart",
+            )
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "error", msg_prefix="", html=False)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_requires_file(self, MockKeaClient):
-        """POST without csv_file shows form with error."""
-        MockKeaClient.return_value.get_available_commands.return_value = _RESERVATION_COMMANDS
+    def test_post_requires_file(self):
+        """POST without csv_file shows form with error — the form is invalid before any Kea call."""
         response = self.client.post(_import_url(self.server.pk, 4), {})
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "required", msg_prefix="", html=False)
@@ -1922,10 +1887,9 @@ class TestBulkReservationImport(_ReservationViewBase):
         response = self.client.get(_import_url(self.server.pk, 4))
         self.assertIn(response.status_code, (302, 403))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_invalid_csv_shows_error(self, MockKeaClient):
+    def test_post_invalid_csv_shows_error(self):
         """Uploading a CSV with missing required column shows error without crashing."""
-        MockKeaClient.return_value.get_available_commands.return_value = _RESERVATION_COMMANDS
+        # The CSV fails to parse before a client is built → no Kea traffic.
         bad_csv = b"some-random-column,another\nvalue1,value2\n"
         csv_file = io.BytesIO(bad_csv)
         csv_file.name = "bad.csv"
@@ -1937,22 +1901,15 @@ class TestBulkReservationImport(_ReservationViewBase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "error", msg_prefix="", html=False)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_summary_shows_created_skipped_errors_counts(self, MockKeaClient):
+    def test_summary_shows_created_skipped_errors_counts(self):
         """Result page shows three distinct count values: created, skipped, errors."""
-        mock_client = MockKeaClient.return_value
-        mock_client.get_available_commands.return_value = _RESERVATION_COMMANDS
-
-        # row 1 → success, row 2 → already exists (skip)
-        dup_exc = KeaException({"result": 1, "text": "Host already exists."}, index=0)
-        mock_client.reservation_add.side_effect = [None, dup_exc]
-        csv_file = io.BytesIO(_BULK_IMPORT_V4_CSV.encode())
-        csv_file.name = "import.csv"
-        response = self.client.post(
-            _import_url(self.server.pk, 4),
-            {"csv_file": csv_file},
-            format="multipart",
-        )
+        # row 1 → success, row 2 → already exists (skip).
+        with stub_kea({"reservation-add": queued({"result": 0}, {"result": 1, "text": "Host already exists."})}):
+            response = self.client.post(
+                _import_url(self.server.pk, 4),
+                {"csv_file": self._csv_upload(_BULK_IMPORT_V4_CSV)},
+                format="multipart",
+            )
         self.assertEqual(response.status_code, 200)
         self.assertIn("created", response.content.decode().lower())
         self.assertIn("skipped", response.content.decode().lower())

--- a/netbox_kea/tests/test_reservation_views.py
+++ b/netbox_kea/tests/test_reservation_views.py
@@ -716,62 +716,33 @@ class TestActiveLeaseStatusOnReservations(_ReservationViewBase):
         "valid-lft": 86400,
     }
 
-    def _prepare_mock_client(self, MockKeaClient, reservation_page=None):
-        """Wire the common mock_client context manager and reservation_get_page."""
-        mock_client = MockKeaClient.return_value
-        _wire_mock_clone(mock_client)
-        mock_client.reservation_get_page.return_value = (
-            reservation_page if reservation_page is not None else ([dict(_SAMPLE_RESERVATION4)], 0, 0)
-        )
-        return mock_client
+    def _stub(self, lease_all):
+        """Reservations-list stub: one reservation + a given ``lease4-get-all`` response."""
+        return stub_kea({"reservation-get-page": _res_page([dict(_SAMPLE_RESERVATION4)]), "lease4-get-all": lease_all})
 
-    def _mock_with_lease(self, MockKeaClient):
-        """Reservation + matching active lease for 192.168.1.100."""
-        mock_client = self._prepare_mock_client(MockKeaClient)
-        # lease4-get-all returns a lease matching the reservation IP
-        mock_client.command.return_value = [
-            {
-                "result": 0,
-                "arguments": {"leases": [self._LEASE4], "count": 1},
-            }
-        ]
-        return mock_client
-
-    def _mock_with_no_lease(self, MockKeaClient):
-        """Reservation present but no active lease."""
-        mock_client = self._prepare_mock_client(MockKeaClient)
-        mock_client.command.return_value = [{"result": 0, "arguments": {"leases": [], "count": 0}}]
-        return mock_client
-
-    @patch("netbox_kea.models.KeaClient")
-    def test_active_lease_badge_shown(self, MockKeaClient):
+    def test_active_lease_badge_shown(self):
         """When a matching lease exists the 'Active Lease' badge must be rendered."""
-        self._mock_with_lease(MockKeaClient)
         url = reverse("plugins:netbox_kea:server_reservations4", args=[self.server.pk])
-        response = self.client.get(url)
+        with self._stub({"result": 0, "arguments": {"leases": [self._LEASE4], "count": 1}}):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Active Lease")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_no_active_lease_badge_shown_when_no_lease(self, MockKeaClient):
+    def test_no_active_lease_badge_shown_when_no_lease(self):
         """When no lease exists for the reservation IP 'No Lease' must be rendered."""
-        self._mock_with_no_lease(MockKeaClient)
         url = reverse("plugins:netbox_kea:server_reservations4", args=[self.server.pk])
-        response = self.client.get(url)
+        with self._stub({"result": 0, "arguments": {"leases": [], "count": 0}}):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "No Lease")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_no_crash_when_lease_cmds_unavailable(self, MockKeaClient):
+    def test_no_crash_when_lease_cmds_unavailable(self):
         """When lease_cmds hook is missing the reservation page must still load."""
-        mock_client = self._prepare_mock_client(MockKeaClient)
-        # lease4-get-all unknown → KeaException result=2
-        mock_client.command.side_effect = KeaException(
-            {"result": 2, "text": "unknown command 'lease4-get-all'"},
-            index=0,
-        )
+        # lease4-get-all unknown → result 2 → real KeaClient raises KeaException →
+        # enrichment leaves has_active_lease unset, so no badge is rendered.
         url = reverse("plugins:netbox_kea:server_reservations4", args=[self.server.pk])
-        response = self.client.get(url)
+        with self._stub({"result": 2, "text": "unknown command 'lease4-get-all'"}):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         # No "Active Lease" or "No Lease" badge when hook unavailable
         self.assertNotContains(response, "Active Lease")
@@ -796,26 +767,23 @@ class TestReservation4EditGetPrefill(_ReservationViewBase):
             args=[self.server.pk, self._SUBNET_ID, self._IP],
         )
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_edit_get_returns_200_and_shows_ip(self, MockKeaClient):
-        """reservation_get must return the reservation dict so the form is pre-filled."""
-        MockKeaClient.return_value.reservation_get.return_value = _SAMPLE_RESERVATION4
-        response = self.client.get(self._edit_url())
+    def test_edit_get_returns_200_and_shows_ip(self):
+        """reservation-get must return the reservation dict so the form is pre-filled."""
+        with stub_kea({"reservation-get": _res_get(_SAMPLE_RESERVATION4), "lease4-get": _LEASE_NOT_FOUND}):
+            response = self.client.get(self._edit_url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, self._IP)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_edit_get_shows_hostname_in_form(self, MockKeaClient):
+    def test_edit_get_shows_hostname_in_form(self):
         """Form must be pre-filled with hostname from the existing reservation."""
-        MockKeaClient.return_value.reservation_get.return_value = _SAMPLE_RESERVATION4
-        response = self.client.get(self._edit_url())
+        with stub_kea({"reservation-get": _res_get(_SAMPLE_RESERVATION4), "lease4-get": _LEASE_NOT_FOUND}):
+            response = self.client.get(self._edit_url())
         self.assertContains(response, "testhost.example.com")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_edit_get_404_when_reservation_get_returns_none(self, MockKeaClient):
-        """If reservation_get returns None (not found) the view must 404."""
-        MockKeaClient.return_value.reservation_get.return_value = None
-        response = self.client.get(self._edit_url())
+    def test_edit_get_404_when_reservation_get_returns_none(self):
+        """If reservation-get returns not-found (result 3) the view must 404."""
+        with stub_kea({"reservation-get": _RES_NOT_FOUND}):
+            response = self.client.get(self._edit_url())
         self.assertEqual(response.status_code, 404)
 
 
@@ -828,14 +796,13 @@ class TestReservation4EditGetPrefill(_ReservationViewBase):
 class TestReservation4AddPrefill(_ReservationViewBase):
     """GET /reservations4/add/?ip_address=...&identifier=... must pre-fill the form."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_add_get_no_params_renders_empty_form(self, MockKeaClient):
+    def test_add_get_no_params_renders_empty_form(self):
+        # GET add renders the form only — no Kea traffic.
         url = reverse("plugins:netbox_kea:server_reservation4_add", args=[self.server.pk])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_add_get_with_ip_and_mac_prefills_form(self, MockKeaClient):
+    def test_add_get_with_ip_and_mac_prefills_form(self):
         """Query params must pre-fill the form fields."""
         url = (
             reverse("plugins:netbox_kea:server_reservation4_add", args=[self.server.pk])
@@ -868,31 +835,39 @@ class TestLeaseReserveBadge(_ReservationViewBase):
         "valid-lft": 3600,
         "state": 0,
     }
+    # The lease-search page fetches the subnet quick-select via config-get first.
+    _CONFIG4 = {"result": 0, "arguments": {"Dhcp4": {"subnet4": [{"id": 1, "subnet": "192.168.1.0/24"}]}}}
 
     def _htmx_get(self, data):
         url = reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
         return self.client.get(url, data=data, HTTP_HX_REQUEST="true")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_reserve_badge_shown_when_no_reservation(self, MockKeaClient):
+    def test_reserve_badge_shown_when_no_reservation(self):
         """A lease without a matching reservation must show '+ Reserve' link."""
-        mock = MockKeaClient.return_value
-        mock.reservation_get.return_value = None
-        mock.command.return_value = [{"result": 0, "arguments": {**self._LEASE}}]
-        response = self._htmx_get({"by": "ip", "q": "192.168.1.200"})
+        # reservation-get result 3 → no reservation → the row offers "+ Reserve".
+        with stub_kea(
+            {
+                "config-get": self._CONFIG4,
+                "lease4-get": {"result": 0, "arguments": {**self._LEASE}},
+                "reservation-get": {"result": 3},
+            }
+        ):
+            response = self._htmx_get({"by": "ip", "q": "192.168.1.200"})
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Reserve")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_reserved_badge_shown_when_reservation_exists(self, MockKeaClient):
+    def test_reserved_badge_shown_when_reservation_exists(self):
         """A lease WITH a matching reservation must show 'Reserved' link, not '+ Reserve'."""
-        mock = MockKeaClient.return_value
-        _wire_mock_clone(mock)
         reservation = dict(_SAMPLE_RESERVATION4)
         reservation["ip-address"] = "192.168.1.200"
-        mock.reservation_get.return_value = reservation
-        mock.command.return_value = [{"result": 0, "arguments": {**self._LEASE}}]
-        response = self._htmx_get({"by": "ip", "q": "192.168.1.200"})
+        with stub_kea(
+            {
+                "config-get": self._CONFIG4,
+                "lease4-get": {"result": 0, "arguments": {**self._LEASE}},
+                "reservation-get": {"result": 0, "arguments": reservation},
+            }
+        ):
+            response = self._htmx_get({"by": "ip", "q": "192.168.1.200"})
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Reserved")
         self.assertNotContains(response, "+ Reserve")
@@ -926,14 +901,19 @@ class TestActiveLeaseBadgeLink(TestCase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_reservations4", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_active_lease_badge_is_link_to_lease_search(self, MockKeaClient):
+    def _stub(self, leases):
+        """Reservations-list stub: one reservation + a ``lease4-get-all`` leases payload."""
+        return stub_kea(
+            {
+                "reservation-get-page": _res_page([dict(_SAMPLE_RESERVATION4_WITH_IP)]),
+                "lease4-get-all": {"result": 0, "arguments": {"leases": leases}},
+            }
+        )
+
+    def test_active_lease_badge_is_link_to_lease_search(self):
         """When active lease exists the badge must be an <a> linking to lease search by IP."""
-        mock_client = MockKeaClient.return_value
-        _wire_mock_clone(mock_client)
-        mock_client.reservation_get_page.return_value = ([dict(_SAMPLE_RESERVATION4_WITH_IP)], 0, 0)
-        mock_client.command.return_value = [{"result": 0, "arguments": {"leases": [{"ip-address": "10.50.0.9"}]}}]
-        response = self.client.get(self._url())
+        with self._stub([{"ip-address": "10.50.0.9"}]):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         # Badge must be a link, not a plain span
         self.assertContains(response, "Active Lease</a>")
@@ -941,14 +921,10 @@ class TestActiveLeaseBadgeLink(TestCase):
         expected_href = reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk]) + "?q=10.50.0.9&by=ip"
         self.assertContains(response, expected_href)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_no_lease_badge_is_not_a_link(self, MockKeaClient):
+    def test_no_lease_badge_is_not_a_link(self):
         """'No Lease' badge must remain a plain non-clickable element."""
-        mock_client = MockKeaClient.return_value
-        _wire_mock_clone(mock_client)
-        mock_client.reservation_get_page.return_value = ([dict(_SAMPLE_RESERVATION4_WITH_IP)], 0, 0)
-        mock_client.command.return_value = [{"result": 0, "arguments": {"leases": []}}]
-        response = self.client.get(self._url())
+        with self._stub([]):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "No Lease")
         # Must NOT be a link
@@ -990,42 +966,32 @@ class TestActiveLeaseSyncButton(TestCase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_reservations4", args=[self.server.pk])
 
-    @patch("netbox_kea.sync.bulk_fetch_netbox_ips")
-    @patch("netbox_kea.models.KeaClient")
-    def test_sync_button_shown_when_active_lease_and_no_netbox_ip(self, MockKeaClient, mock_bulk_fetch):
-        """When active lease and no NetBox IP: 'Active Lease' badge AND Sync button rendered."""
-        mock_client = MockKeaClient.return_value
-        _wire_mock_clone(mock_client)
-        mock_client.reservation_get_page.return_value = (
-            [dict(_SAMPLE_RESERVATION4_FOR_SYNC)],
-            0,
-            0,
+    def _stub(self):
+        """Reservations-list stub: the sync reservation + a matching active lease."""
+        return stub_kea(
+            {
+                "reservation-get-page": _res_page([dict(_SAMPLE_RESERVATION4_FOR_SYNC)]),
+                "lease4-get-all": {"result": 0, "arguments": {"leases": [{"ip-address": "10.60.0.5"}]}},
+            }
         )
-        mock_client.command.return_value = [{"result": 0, "arguments": {"leases": [{"ip-address": "10.60.0.5"}]}}]
-        mock_bulk_fetch.return_value = {}  # no NetBox IPs found
-        response = self.client.get(self._url())
+
+    def test_sync_button_shown_when_active_lease_and_no_netbox_ip(self):
+        """When active lease and no NetBox IP: 'Active Lease' badge AND Sync button rendered."""
+        # No NetBox IPAddress exists for 10.60.0.5 → the real bulk_fetch returns nothing.
+        with self._stub():
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Active Lease</a>")
         # Sync button must link to the specific reservation4 sync endpoint
         sync_url = reverse("plugins:netbox_kea:server_reservation4_sync", args=[self.server.pk])
         self.assertContains(response, sync_url)
 
-    @patch("netbox_kea.sync.bulk_fetch_netbox_ips")
-    @patch("netbox_kea.models.KeaClient")
-    def test_sync_button_not_shown_when_active_lease_and_netbox_ip_exists(self, MockKeaClient, mock_bulk_fetch):
+    def test_sync_button_not_shown_when_active_lease_and_netbox_ip_exists(self):
         """When active lease AND NetBox IP already synced: no Sync button in lease_status cell."""
-        mock_client = MockKeaClient.return_value
-        _wire_mock_clone(mock_client)
-        mock_client.reservation_get_page.return_value = (
-            [dict(_SAMPLE_RESERVATION4_FOR_SYNC)],
-            0,
-            0,
-        )
-        mock_client.command.return_value = [{"result": 0, "arguments": {"leases": [{"ip-address": "10.60.0.5"}]}}]
-        nb_ip = MagicMock(spec=NbIP)
-        nb_ip.get_absolute_url.return_value = "/ipam/ip-addresses/42/"
-        mock_bulk_fetch.return_value = {"10.60.0.5": nb_ip}
-        response = self.client.get(self._url())
+        # A real NetBox IPAddress makes the reservation appear synced.
+        NbIP.objects.create(address="10.60.0.5/32")
+        with self._stub():
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Active Lease</a>")
         # Synced link shown in netbox_ip column — but NO individual reservation4 sync button
@@ -1049,62 +1015,46 @@ class TestMultiIPv6ReservationBadgeEnrichment(TestCase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_reservations6", args=[self.server.pk])
 
-    def _mock_client(self, MockKeaClient, reservation):
-        mock_client = MockKeaClient.return_value
-        _wire_mock_clone(mock_client)
-        mock_client.reservation_get_page.return_value = ([dict(reservation)], 0, 0)
-        # Lease lookup — KeaException so we skip lease enrichment cleanly.
-        mock_client.command.side_effect = KeaException(
-            {"result": 2, "text": "unknown command 'lease6-get-all'"}, index=0
+    def _stub(self, reservation):
+        """Reservations6-list stub: one reservation; lease6-get-all absent (hook not loaded)."""
+        return stub_kea(
+            {
+                "reservation-get-page": _res_page([dict(reservation)]),
+                # lease6-get-all unknown → KeaException → lease enrichment cleanly skipped.
+                "lease6-get-all": {"result": 2, "text": "unknown command 'lease6-get-all'"},
+            }
         )
-        return mock_client
 
-    @patch("netbox_kea.sync.bulk_fetch_netbox_ips")
-    @patch("netbox_kea.models.KeaClient")
-    def test_multi_ip_all_synced_shows_synced_badge(self, MockKeaClient, mock_bulk_fetch):
-        """v6 reservation with extra_ips — ALL IPs in NetBox → Synced shown, no sync button."""
-        self._mock_client(MockKeaClient, _SAMPLE_RESERVATION6_MULTI_IP)
-        nb1, nb2, nb3 = MagicMock(spec=NbIP), MagicMock(spec=NbIP), MagicMock(spec=NbIP)
-        nb1.get_absolute_url.return_value = "/ipam/ip-addresses/101/"
-        nb2.get_absolute_url.return_value = "/ipam/ip-addresses/102/"
-        nb3.get_absolute_url.return_value = "/ipam/ip-addresses/103/"
-        mock_bulk_fetch.return_value = {"2001:db8::1": nb1, "2001:db8::2": nb2, "2001:db8::3": nb3}
+    def test_multi_ip_all_synced_shows_synced_badge(self):
+        """v6 reservation with extra_ips — ALL IPs in NetBox → Synced shown, no sync button.
 
-        response = self.client.get(self._url())
+        Creating a NetBox IPAddress for every reservation address (primary + extras)
+        proves the badge enrichment builds its lookup list from all of them.
+        """
+        for addr in _SAMPLE_RESERVATION6_MULTI_IP["ip-addresses"]:
+            NbIP.objects.create(address=f"{addr}/128")
+        with self._stub(_SAMPLE_RESERVATION6_MULTI_IP):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Synced</a>")
         sync_url = reverse("plugins:netbox_kea:server_reservation6_sync", args=[self.server.pk])
         self.assertNotContains(response, sync_url)
-        # Verify that ALL reservation IPs were passed to bulk_fetch_netbox_ips
-        called_ips = mock_bulk_fetch.call_args[0][0]
-        self.assertIn("2001:db8::1", called_ips)
-        self.assertIn("2001:db8::2", called_ips)
-        self.assertIn("2001:db8::3", called_ips)
 
-    @patch("netbox_kea.sync.bulk_fetch_netbox_ips")
-    @patch("netbox_kea.models.KeaClient")
-    def test_multi_ip_partial_sync_shows_sync_button(self, MockKeaClient, mock_bulk_fetch):
+    def test_multi_ip_partial_sync_shows_sync_button(self):
         """v6 reservation with extra_ips — only primary in NetBox → shows Synced AND sync button."""
-        self._mock_client(MockKeaClient, _SAMPLE_RESERVATION6_MULTI_IP)
-        nb1 = MagicMock(spec=NbIP)
-        nb1.get_absolute_url.return_value = "/ipam/ip-addresses/101/"
-        # Only the first IP is in NetBox; 2001:db8::2 and ::3 are missing.
-        mock_bulk_fetch.return_value = {"2001:db8::1": nb1}
-
-        response = self.client.get(self._url())
+        # Only the first IP is in NetBox; 2001:db8::2 and ::3 are missing → partial sync.
+        NbIP.objects.create(address="2001:db8::1/128")
+        with self._stub(_SAMPLE_RESERVATION6_MULTI_IP):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Synced</a>")
         sync_url = reverse("plugins:netbox_kea:server_reservation6_sync", args=[self.server.pk])
         self.assertContains(response, sync_url)
 
-    @patch("netbox_kea.sync.bulk_fetch_netbox_ips")
-    @patch("netbox_kea.models.KeaClient")
-    def test_multi_ip_none_synced_shows_sync_button(self, MockKeaClient, mock_bulk_fetch):
+    def test_multi_ip_none_synced_shows_sync_button(self):
         """v6 reservation with extra_ips — no IPs in NetBox → sync button shown."""
-        self._mock_client(MockKeaClient, _SAMPLE_RESERVATION6_MULTI_IP)
-        mock_bulk_fetch.return_value = {}
-
-        response = self.client.get(self._url())
+        with self._stub(_SAMPLE_RESERVATION6_MULTI_IP):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, "Synced</a>")
         sync_url = reverse("plugins:netbox_kea:server_reservation6_sync", args=[self.server.pk])

--- a/netbox_kea/tests/test_reservation_views.py
+++ b/netbox_kea/tests/test_reservation_views.py
@@ -22,7 +22,7 @@ from django.test import SimpleTestCase, TestCase, override_settings
 from django.urls import reverse
 from ipam.models import IPAddress as NbIP
 
-from netbox_kea.kea import KeaClient, KeaException
+from netbox_kea.kea import KeaClient
 from netbox_kea.models import Server
 from netbox_kea.views import _filter_reservations
 
@@ -46,30 +46,6 @@ _SAMPLE_RESERVATION6 = {
     "ip-addresses": ["2001:db8::100"],
     "hostname": "testhost6.example.com",
 }
-
-_RESERVATION_COMMANDS = {
-    "reservation-add",
-    "reservation-get-page",
-    "reservation-del",
-    "reservation-update",
-    "reservation-get",
-}
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Helpers
-# ─────────────────────────────────────────────────────────────────────────────
-
-
-def _wire_mock_clone(mock_client):
-    """Wire clone/context-manager on a mock KeaClient so worker threads see the same instance.
-
-    Temporary: retained only until the last mock-based class below is de-mocked.
-    """
-    mock_client.clone.return_value = mock_client
-    mock_client.__enter__ = lambda s: s
-    mock_client.__exit__ = lambda s, *a: None
-    return mock_client
-
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Shared stub responses (real KeaClient + HTTP-boundary stub)
@@ -2341,31 +2317,22 @@ class TestSyncReservationCleanupFalse(_ReservationViewBase):
 class TestKeaExceptionResult1OnFetch(_ReservationViewBase):
     """KeaException with result=1 returns 200 with error message, not a crash."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_v4_fetch_kea_error_result1_returns_200(self, MockKeaClient):
+    def test_v4_fetch_kea_error_result1_returns_200(self):
         """Result=1 shows error message and keeps hook_available=True."""
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_get_page.side_effect = KeaException(
-            {"result": 1, "text": "error"},
-            index=0,
-        )
+        # reservation-get-page result 1 → real KeaException with result != 2.
         url = reverse("plugins:netbox_kea:server_reservations4", args=[self.server.pk])
-        response = self.client.get(url)
+        with stub_kea({"reservation-get-page": {"result": 1, "text": "error"}}):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.context["hook_available"])
         msgs = [str(m) for m in response.context["messages"]]
         self.assertTrue(any("Failed to load" in m for m in msgs))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_v6_fetch_kea_error_result1_returns_200(self, MockKeaClient):
+    def test_v6_fetch_kea_error_result1_returns_200(self):
         """Result=1 shows error message and keeps hook_available=True for DHCPv6."""
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_get_page.side_effect = KeaException(
-            {"result": 1, "text": "error"},
-            index=0,
-        )
         url = reverse("plugins:netbox_kea:server_reservations6", args=[self.server.pk])
-        response = self.client.get(url)
+        with stub_kea({"reservation-get-page": {"result": 1, "text": "error"}}):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.context["hook_available"])
         msgs = [str(m) for m in response.context["messages"]]
@@ -2390,65 +2357,40 @@ class TestV6EditPostPreservesFormIPs(_ReservationViewBase):
             args=[self.server.pk, self._SUBNET_ID, self._IP],
         )
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_preserves_existing_ip_addresses(self, MockKeaClient):
-        """POST ignores posted ip_addresses (disabled field) and preserves existing IPs from reservation_get."""
-        mock_client = MockKeaClient.return_value
+    def _post_data(self, ip_addresses="2001:db8::100"):
+        return {
+            "subnet_id": self._SUBNET_ID,
+            "ip_addresses": ip_addresses,
+            "identifier_type": "duid",
+            "identifier": "00:01:02:03:04:05",
+            "hostname": "testhost6.example.com",
+        }
+
+    def test_post_preserves_existing_ip_addresses(self):
+        """POST ignores posted ip_addresses (disabled field) and preserves existing IPs from reservation-get."""
         existing = {**_SAMPLE_RESERVATION6, "ip-addresses": ["2001:db8::100", "2001:db8::200"]}
-        mock_client.reservation_get.return_value = existing
-        mock_client.reservation_update.return_value = None
-        response = self.client.post(
-            self._edit_url(),
-            {
-                "subnet_id": self._SUBNET_ID,
-                "ip_addresses": "2001:db8::dead,2001:db8::beef",  # different — should be ignored
-                "identifier_type": "duid",
-                "identifier": "00:01:02:03:04:05",
-                "hostname": "testhost6.example.com",
-            },
-        )
+        with stub_kea({"reservation-get": _res_get(existing), "reservation-update": {"result": 0}}) as kea:
+            # Posted ip_addresses differ from existing — the disabled field must be ignored.
+            response = self.client.post(self._edit_url(), self._post_data("2001:db8::dead,2001:db8::beef"))
         self.assertEqual(response.status_code, 302)
-        mock_client.reservation_update.assert_called_once()
-        call_args = mock_client.reservation_update.call_args
-        args, kwargs = call_args or ((), {})
-        reservation = kwargs.get("reservation") or (args[1] if len(args) > 1 else {})
+        self.assertEqual(kea.commands().count("reservation-update"), 1)
+        reservation = kea.bodies("reservation-update")[0]["arguments"]["reservation"]
         self.assertEqual(reservation["ip-addresses"], existing["ip-addresses"])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_aborts_when_reservation_get_fails(self, MockKeaClient):
-        """POST aborts with error redirect when reservation_get raises, preventing silent IP truncation."""
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_get.side_effect = KeaException({"result": 1, "text": "error"}, index=0)
-        response = self.client.post(
-            self._edit_url(),
-            {
-                "subnet_id": self._SUBNET_ID,
-                "ip_addresses": "2001:db8::100",
-                "identifier_type": "duid",
-                "identifier": "00:01:02:03:04:05",
-                "hostname": "testhost6.example.com",
-            },
-        )
+    def test_post_aborts_when_reservation_get_fails(self):
+        """POST aborts with error redirect when reservation-get fails, preventing silent IP truncation."""
+        # reservation-get result 1 → KeaException → the view aborts before issuing reservation-update.
+        with stub_kea({"reservation-get": {"result": 1, "text": "error"}}) as kea:
+            response = self.client.post(self._edit_url(), self._post_data())
         self.assertEqual(response.status_code, 302)
-        mock_client.reservation_update.assert_not_called()
+        self.assertNotIn("reservation-update", kea.commands())
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_aborts_when_reservation_get_returns_none(self, MockKeaClient):
-        """POST aborts when reservation_get returns None (reservation disappeared)."""
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_get.return_value = None
-        response = self.client.post(
-            self._edit_url(),
-            {
-                "subnet_id": self._SUBNET_ID,
-                "ip_addresses": "2001:db8::100",
-                "identifier_type": "duid",
-                "identifier": "00:01:02:03:04:05",
-                "hostname": "testhost6.example.com",
-            },
-        )
+    def test_post_aborts_when_reservation_get_returns_none(self):
+        """POST aborts when reservation-get returns not-found (reservation disappeared)."""
+        with stub_kea({"reservation-get": _RES_NOT_FOUND}) as kea:
+            response = self.client.post(self._edit_url(), self._post_data())
         self.assertEqual(response.status_code, 302)
-        mock_client.reservation_update.assert_not_called()
+        self.assertNotIn("reservation-update", kea.commands())
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -2460,78 +2402,47 @@ class TestV6EditPostPreservesFormIPs(_ReservationViewBase):
 class TestEnrichReservationsLeaseStatusErrors(_ReservationViewBase):
     """Error paths in _enrich_reservations_with_lease_status for malformed responses."""
 
-    def _prepare_mock_client(self, MockKeaClient, reservations=None):
-        mock_client = MockKeaClient.return_value
-        _wire_mock_clone(mock_client)
-        mock_client.reservation_get_page.return_value = (
-            reservations if reservations is not None else ([dict(_SAMPLE_RESERVATION4)], 0, 0)
-        )
-        return mock_client
+    def _stub(self, lease_all):
+        """Reservations4-list stub: one reservation + a given (malformed) lease4-get-all response."""
+        return stub_kea({"reservation-get-page": _res_page([dict(_SAMPLE_RESERVATION4)]), "lease4-get-all": lease_all})
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_malformed_args_not_dict_sets_indeterminate(self, MockKeaClient):
+    def _url(self):
+        return reverse("plugins:netbox_kea:server_reservations4", args=[self.server.pk])
+
+    def test_malformed_args_not_dict_sets_indeterminate(self):
         """When lease-get-all returns args that is not a dict, has_active_lease stays None."""
-        mock_client = self._prepare_mock_client(MockKeaClient)
-        # Response where arguments is a string instead of dict
-        mock_client.command.return_value = [{"result": 0, "arguments": "not-a-dict"}]
-        url = reverse("plugins:netbox_kea:server_reservations4", args=[self.server.pk])
-        response = self.client.get(url)
+        # arguments is a string instead of a dict → indeterminate.
+        with self._stub({"result": 0, "arguments": "not-a-dict"}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
-        table = response.context["table"]
-        for row in table.data:
+        for row in response.context["table"].data:
             # Indeterminate: has_active_lease should not be set to True or False
             self.assertIsNone(row.get("has_active_lease"))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_malformed_leases_not_list_sets_indeterminate(self, MockKeaClient):
+    def test_malformed_leases_not_list_sets_indeterminate(self):
         """When lease-get-all returns leases as a string instead of list, has_active_lease stays None."""
-        mock_client = self._prepare_mock_client(MockKeaClient)
-        mock_client.command.return_value = [{"result": 0, "arguments": {"leases": "not-a-list"}}]
-        url = reverse("plugins:netbox_kea:server_reservations4", args=[self.server.pk])
-        response = self.client.get(url)
+        with self._stub({"result": 0, "arguments": {"leases": "not-a-list"}}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
-        table = response.context["table"]
-        for row in table.data:
+        for row in response.context["table"].data:
             self.assertIsNone(row.get("has_active_lease"))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_non_dict_lease_entries_are_skipped(self, MockKeaClient):
+    def test_non_dict_lease_entries_are_skipped(self):
         """When lease entries contain non-dict items, they are skipped without crashing."""
-        mock_client = self._prepare_mock_client(MockKeaClient)
-        # Mix of valid dict and non-dict entries
-        mock_client.command.return_value = [
-            {
-                "result": 0,
-                "arguments": {
-                    "leases": [
-                        "not-a-dict",
-                        42,
-                        {"ip-address": "192.168.1.100"},
-                    ]
-                },
-            }
-        ]
-        url = reverse("plugins:netbox_kea:server_reservations4", args=[self.server.pk])
-        response = self.client.get(url)
+        # Mix of valid dict and non-dict entries; the valid one matches the reservation IP.
+        with self._stub({"result": 0, "arguments": {"leases": ["not-a-dict", 42, {"ip-address": "192.168.1.100"}]}}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
-        table = response.context["table"]
-        # The valid lease entry should match, so has_active_lease = True
-        for row in table.data:
+        for row in response.context["table"].data:
             self.assertTrue(row.get("has_active_lease"))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_kea_exception_result_not_2_sets_indeterminate(self, MockKeaClient):
+    def test_kea_exception_result_not_2_sets_indeterminate(self):
         """KeaException with result!=2 (not hook-unavailable) leaves has_active_lease=None."""
-        mock_client = self._prepare_mock_client(MockKeaClient)
-        mock_client.command.side_effect = KeaException(
-            {"result": 1, "text": "internal error"},
-            index=0,
-        )
-        url = reverse("plugins:netbox_kea:server_reservations4", args=[self.server.pk])
-        response = self.client.get(url)
+        # lease4-get-all result 1 → KeaException with result != 2 → indeterminate.
+        with self._stub({"result": 1, "text": "internal error"}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
-        table = response.context["table"]
-        for row in table.data:
+        for row in response.context["table"].data:
             self.assertIsNone(row.get("has_active_lease"))
 
 
@@ -2558,28 +2469,28 @@ class TestReservationSyncExceptionOnSuccess(_ReservationViewBase):
         }
 
     @patch("netbox_kea.views.reservations.sync_reservation_to_netbox")
-    @patch("netbox_kea.models.KeaClient")
-    def test_sync_failure_shows_warning_but_reservation_saved(self, MockKeaClient, mock_sync):
-        """If sync_reservation_to_netbox raises, reservation add still redirects with warning."""
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_add.return_value = None
+    def test_sync_failure_shows_warning_but_reservation_saved(self, mock_sync):
+        """If sync_reservation_to_netbox raises, reservation add still redirects with warning.
+
+        The KeaClient is real; only the NetBox sync boundary is patched to raise.
+        """
         mock_sync.side_effect = ValueError("DB sync failed")
-        response = self.client.post(self._add_url(), self._valid_post_data())
+        with stub_kea({"subnet4-get": _subnet_get(4), "reservation-add": {"result": 0}}) as kea:
+            response = self.client.post(self._add_url(), self._valid_post_data())
         self.assertEqual(response.status_code, 302)
-        mock_client.reservation_add.assert_called_once()
+        self.assertEqual(kea.commands().count("reservation-add"), 1)
         msgs = [str(m) for m in get_messages(response.wsgi_request)]
         self.assertTrue(any("sync failed" in m.lower() for m in msgs))
+        # The raw exception text must not leak into a user-facing message.
         self.assertFalse(any("DB sync failed" in m for m in msgs))
 
-    @patch("netbox_kea.views.reservations.sync_reservation_to_netbox")
-    @patch("netbox_kea.models.KeaClient")
-    def test_sync_success_shows_info_message(self, MockKeaClient, mock_sync):
-        """If sync succeeds, info message shown with created/updated status."""
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_add.return_value = None
-        mock_sync.return_value = (MagicMock(spec=NbIP), True, True)
-        response = self.client.post(self._add_url(), self._valid_post_data())
+    def test_sync_success_shows_info_message(self):
+        """If the real sync succeeds, an info message is shown with created status."""
+        # The real sync creates a NetBox IPAddress for 192.168.1.50 → "created".
+        with stub_kea({"subnet4-get": _subnet_get(4), "reservation-add": {"result": 0}}):
+            response = self.client.post(self._add_url(), self._valid_post_data())
         self.assertEqual(response.status_code, 302)
+        self.assertTrue(NbIP.objects.filter(address__startswith="192.168.1.50/").exists())
         msgs = [str(m) for m in get_messages(response.wsgi_request)]
         self.assertTrue(any("created" in m.lower() for m in msgs))
 
@@ -2596,10 +2507,8 @@ class TestReservation4AddInvalidOptionsFormset(_ReservationViewBase):
     def _add_url(self):
         return reverse("plugins:netbox_kea:server_reservation4_add", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_invalid_options_formset_rerenders_form(self, MockKeaClient):
-        """When option formset is invalid, form is re-rendered (not submitted to Kea)."""
-        mock_client = MockKeaClient.return_value
+    def test_invalid_options_formset_rerenders_form(self):
+        """When option formset is invalid, form is re-rendered (never submitted to Kea)."""
         data = {
             "subnet_id": 1,
             "ip_address": "192.168.1.100",
@@ -2615,14 +2524,13 @@ class TestReservation4AddInvalidOptionsFormset(_ReservationViewBase):
             "options-0-name": "routers",
             "options-0-data": "",  # required field — empty triggers validation error
         }
-        response = self.client.post(self._add_url(), data)
+        # Empty stub: any Kea command would raise AssertionError, proving no traffic occurred.
+        with stub_kea({}):
+            response = self.client.post(self._add_url(), data)
         self.assertEqual(response.status_code, 200)
-        mock_client.reservation_add.assert_not_called()
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_partial_options_submission_without_management_form(self, MockKeaClient):
+    def test_partial_options_submission_without_management_form(self):
         """Partial options submission (options-* keys but no TOTAL_FORMS) re-renders form."""
-        mock_client = MockKeaClient.return_value
         data = {
             "subnet_id": 1,
             "ip_address": "192.168.1.100",
@@ -2633,9 +2541,9 @@ class TestReservation4AddInvalidOptionsFormset(_ReservationViewBase):
             "options-0-name": "routers",
             "options-0-data": "10.0.0.1",
         }
-        response = self.client.post(self._add_url(), data)
+        with stub_kea({}):
+            response = self.client.post(self._add_url(), data)
         self.assertEqual(response.status_code, 200)
-        mock_client.reservation_add.assert_not_called()
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -2723,23 +2631,21 @@ class TestReservation4EditOptionDataNotList(_ReservationViewBase):
             args=[self.server.pk, self._SUBNET_ID, self._IP],
         )
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_option_data_as_string_handled_gracefully(self, MockKeaClient):
+    def test_option_data_as_string_handled_gracefully(self):
         """When option-data is a string instead of list, view must not crash."""
         reservation = dict(_SAMPLE_RESERVATION4, **{"option-data": "not-a-list"})
-        MockKeaClient.return_value.reservation_get.return_value = reservation
-        response = self.client.get(self._edit_url())
+        with stub_kea({"reservation-get": _res_get(reservation), "lease4-get": _LEASE_NOT_FOUND}):
+            response = self.client.get(self._edit_url())
         self.assertEqual(response.status_code, 200)
         # options_formset should have no initial data since string was rejected
         formset = response.context["options_formset"]
         self.assertEqual(len(formset.initial_forms), 0)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_option_data_as_dict_handled_gracefully(self, MockKeaClient):
+    def test_option_data_as_dict_handled_gracefully(self):
         """When option-data is a dict instead of list, view must not crash."""
         reservation = dict(_SAMPLE_RESERVATION4, **{"option-data": {"name": "routers", "data": "10.0.0.1"}})
-        MockKeaClient.return_value.reservation_get.return_value = reservation
-        response = self.client.get(self._edit_url())
+        with stub_kea({"reservation-get": _res_get(reservation), "lease4-get": _LEASE_NOT_FOUND}):
+            response = self.client.get(self._edit_url())
         self.assertEqual(response.status_code, 200)
         formset = response.context["options_formset"]
         self.assertEqual(len(formset.initial_forms), 0)
@@ -2758,12 +2664,11 @@ class TestReservation6EditOptionDataNotList(_ReservationViewBase):
             args=[self.server.pk, self._SUBNET_ID, self._IP],
         )
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_option_data_as_int_handled_gracefully(self, MockKeaClient):
+    def test_option_data_as_int_handled_gracefully(self):
         """When option-data is an int instead of list, view must not crash."""
         reservation = dict(_SAMPLE_RESERVATION6, **{"option-data": 42})
-        MockKeaClient.return_value.reservation_get.return_value = reservation
-        response = self.client.get(self._edit_url())
+        with stub_kea({"reservation-get": _res_get(reservation), "lease6-get": _LEASE_NOT_FOUND}):
+            response = self.client.get(self._edit_url())
         self.assertEqual(response.status_code, 200)
         formset = response.context["options_formset"]
         self.assertEqual(len(formset.initial_forms), 0)
@@ -2775,127 +2680,93 @@ class TestReservation6EditOptionDataNotList(_ReservationViewBase):
 
 
 class TestEnrichReservationsWithLeaseStatus(SimpleTestCase):
-    """_enrich_reservations_with_lease_status gracefully handles error paths."""
+    """_enrich_reservations_with_lease_status gracefully handles error paths.
 
-    def _make_mock_client(self, command_side_effect=None, command_return=None):
-        """Create a mock KeaClient with clone() context-manager wired up."""
-        mock_client = MagicMock(spec=KeaClient)
-        _wire_mock_clone(mock_client)
-        if command_side_effect is not None:
-            mock_client.command.side_effect = command_side_effect
-        elif command_return is not None:
-            mock_client.command.return_value = command_return
-        return mock_client
+    Drives the real ``_enrich_reservations_with_lease_status`` against a real
+    ``KeaClient`` with only the HTTP boundary stubbed — the helper ``clone()``s the
+    client and issues ``lease{v}-get-all`` from worker threads, which the class-level
+    ``requests.Session.post`` patch also covers. No database is required.
+    """
+
+    def _enrich(self, reservations, version, responses):
+        """Run the enrichment against a real KeaClient + HTTP stub; return the stub."""
+        from netbox_kea.views.reservations import _enrich_reservations_with_lease_status
+
+        client = KeaClient(url="http://kea.test/")
+        with stub_kea(responses) as kea:
+            _enrich_reservations_with_lease_status(client, reservations, version=version)
+        return kea
 
     def test_malformed_arguments_not_dict_sets_indeterminate(self):
         """When Kea returns arguments as a string (not dict), has_active_lease stays unset."""
-        from netbox_kea.views.reservations import _enrich_reservations_with_lease_status
-
-        mock_client = self._make_mock_client(
-            command_return=[{"result": 0, "arguments": "bad-string"}],
-        )
         reservations = [{"subnet-id": 1, "ip-address": "10.0.0.1"}]
-        _enrich_reservations_with_lease_status(mock_client, reservations, version=4)
+        kea = self._enrich(reservations, 4, {"lease4-get-all": {"result": 0, "arguments": "bad-string"}})
         # indeterminate — has_active_lease should not be set
         self.assertNotIn("has_active_lease", reservations[0])
-        mock_client.clone.assert_called()
+        # the worker cloned the client and issued the lease query
+        self.assertIn("lease4-get-all", kea.commands())
 
     def test_malformed_leases_not_list_sets_indeterminate(self):
         """When arguments.leases is not a list, has_active_lease stays unset."""
-        from netbox_kea.views.reservations import _enrich_reservations_with_lease_status
-
-        mock_client = self._make_mock_client(
-            command_return=[{"result": 0, "arguments": {"leases": "not-a-list"}}],
-        )
         reservations = [{"subnet-id": 1, "ip-address": "10.0.0.1"}]
-        _enrich_reservations_with_lease_status(mock_client, reservations, version=4)
+        kea = self._enrich(reservations, 4, {"lease4-get-all": {"result": 0, "arguments": {"leases": "not-a-list"}}})
         self.assertNotIn("has_active_lease", reservations[0])
-        mock_client.clone.assert_called()
+        self.assertIn("lease4-get-all", kea.commands())
 
     def test_kea_exception_non_result_2_sets_indeterminate(self):
         """KeaException with result!=2 (not hook-missing) marks subnet as indeterminate."""
-        from netbox_kea.views.reservations import _enrich_reservations_with_lease_status
-
-        mock_client = self._make_mock_client(
-            command_side_effect=KeaException({"result": 1, "text": "internal error"}, index=0),
-        )
+        # lease4-get-all result 1 → real KeaException with result != 2.
         reservations = [{"subnet-id": 1, "ip-address": "10.0.0.1"}]
-        _enrich_reservations_with_lease_status(mock_client, reservations, version=4)
+        kea = self._enrich(reservations, 4, {"lease4-get-all": {"result": 1, "text": "internal error"}})
         self.assertNotIn("has_active_lease", reservations[0])
-        mock_client.clone.assert_called()
+        self.assertIn("lease4-get-all", kea.commands())
 
     def test_requests_exception_sets_indeterminate(self):
         """requests.RequestException in worker thread marks subnet as indeterminate."""
         import requests as req_lib
 
-        from netbox_kea.views.reservations import _enrich_reservations_with_lease_status
-
-        mock_client = self._make_mock_client(
-            command_side_effect=req_lib.ConnectionError("timeout"),
-        )
+        # The stub raises a ConnectionError at the HTTP boundary.
         reservations = [{"subnet-id": 1, "ip-address": "10.0.0.1"}]
-        _enrich_reservations_with_lease_status(mock_client, reservations, version=4)
+        kea = self._enrich(reservations, 4, {"lease4-get-all": req_lib.ConnectionError("timeout")})
         self.assertNotIn("has_active_lease", reservations[0])
-        mock_client.clone.assert_called()
+        self.assertIn("lease4-get-all", kea.commands())
 
     def test_empty_reservations_returns_early(self):
         """Empty reservations list returns immediately without any API calls."""
-        from netbox_kea.views.reservations import _enrich_reservations_with_lease_status
-
-        mock_client = self._make_mock_client()
-        _enrich_reservations_with_lease_status(mock_client, [], version=4)
-        mock_client.clone.assert_not_called()
+        kea = self._enrich([], 4, {})
+        self.assertEqual(kea.commands(), [])
 
     def test_no_subnet_ids_returns_early(self):
         """Reservations without valid subnet-id return early without API calls."""
-        from netbox_kea.views.reservations import _enrich_reservations_with_lease_status
-
-        mock_client = self._make_mock_client()
         reservations = [{"ip-address": "10.0.0.1"}]  # no subnet-id
-        _enrich_reservations_with_lease_status(mock_client, reservations, version=4)
-        mock_client.clone.assert_not_called()
+        kea = self._enrich(reservations, 4, {})
+        self.assertEqual(kea.commands(), [])
 
     def test_result_3_empty_subnet_sets_false(self):
         """When Kea returns result=3 (empty), has_active_lease should be False."""
-        from netbox_kea.views.reservations import _enrich_reservations_with_lease_status
-
-        mock_client = self._make_mock_client(
-            command_return=[{"result": 3, "text": "no leases found", "arguments": {}}],
-        )
         reservations = [{"subnet-id": 1, "ip-address": "10.0.0.1"}]
-        _enrich_reservations_with_lease_status(mock_client, reservations, version=4)
+        kea = self._enrich(
+            reservations, 4, {"lease4-get-all": {"result": 3, "text": "no leases found", "arguments": {}}}
+        )
         self.assertFalse(reservations[0]["has_active_lease"])
-        mock_client.clone.assert_called()
+        self.assertIn("lease4-get-all", kea.commands())
 
     def test_arguments_none_sets_no_active_lease(self):
         """When Kea returns arguments=null, has_active_lease should be left unset (indeterminate state)."""
-        from netbox_kea.views.reservations import _enrich_reservations_with_lease_status
-
-        mock_client = self._make_mock_client(
-            command_return=[{"result": 0, "arguments": None}],
-        )
         reservations = [{"subnet-id": 1, "ip-address": "10.0.0.1"}]
-        _enrich_reservations_with_lease_status(mock_client, reservations, version=4)
+        self._enrich(reservations, 4, {"lease4-get-all": {"result": 0, "arguments": None}})
         self.assertNotIn("has_active_lease", reservations[0])
 
     def test_v6_enrichment_checks_ip_addresses_list(self):
         """DHCPv6 enrichment checks ip-addresses list for active lease match."""
-        from netbox_kea.views.reservations import _enrich_reservations_with_lease_status
-
-        mock_client = self._make_mock_client(
-            command_return=[
-                {
-                    "result": 0,
-                    "arguments": {
-                        "leases": [{"ip-address": "2001:db8::100"}],
-                    },
-                }
-            ],
-        )
         reservations = [{"subnet-id": 1, "ip-addresses": ["2001:db8::100"]}]
-        _enrich_reservations_with_lease_status(mock_client, reservations, version=6)
+        kea = self._enrich(
+            reservations,
+            6,
+            {"lease6-get-all": {"result": 0, "arguments": {"leases": [{"ip-address": "2001:db8::100"}]}}},
+        )
         self.assertTrue(reservations[0]["has_active_lease"])
-        mock_client.clone.assert_called()
+        self.assertIn("lease6-get-all", kea.commands())
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -2921,34 +2792,33 @@ class TestRunReservationSuccessSideEffectsSyncFail(_ReservationViewBase):
         }
 
     @patch("netbox_kea.views.reservations.sync_reservation_to_netbox")
-    @patch("netbox_kea.models.KeaClient")
-    def test_sync_db_error_shows_warning_reservation_still_created(self, MockKeaClient, mock_sync):
-        """Reservation created in Kea; sync raises DatabaseError → warning shown, no 500."""
+    def test_sync_db_error_shows_warning_reservation_still_created(self, mock_sync):
+        """Reservation created in Kea; sync raises DatabaseError → warning shown, no 500.
+
+        The KeaClient is real; only the NetBox sync boundary is patched to raise.
+        """
         from django.db import DatabaseError
 
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_add.return_value = None
         mock_sync.side_effect = DatabaseError("db constraint violation")
-        response = self.client.post(self._add_url(), self._valid_post_data())
+        with stub_kea({"subnet4-get": _subnet_get(4), "reservation-add": {"result": 0}}) as kea:
+            response = self.client.post(self._add_url(), self._valid_post_data())
         # Kea reservation created → redirect
         self.assertEqual(response.status_code, 302)
-        mock_client.reservation_add.assert_called_once()
+        self.assertEqual(kea.commands().count("reservation-add"), 1)
         msgs = [str(m) for m in get_messages(response.wsgi_request)]
         self.assertTrue(any("sync failed" in m.lower() for m in msgs))
         self.assertFalse(any("db constraint violation" in m for m in msgs))
 
     @patch("netbox_kea.views.reservations.sync_reservation_to_netbox")
-    @patch("netbox_kea.models.KeaClient")
-    def test_sync_validation_error_shows_warning(self, MockKeaClient, mock_sync):
+    def test_sync_validation_error_shows_warning(self, mock_sync):
         """sync raises ValidationError → warning shown, reservation still created."""
         from django.core.exceptions import ValidationError
 
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_add.return_value = None
         mock_sync.side_effect = ValidationError("bad data")
-        response = self.client.post(self._add_url(), self._valid_post_data())
+        with stub_kea({"subnet4-get": _subnet_get(4), "reservation-add": {"result": 0}}) as kea:
+            response = self.client.post(self._add_url(), self._valid_post_data())
         self.assertEqual(response.status_code, 302)
-        mock_client.reservation_add.assert_called_once()
+        self.assertEqual(kea.commands().count("reservation-add"), 1)
         msgs = [str(m) for m in get_messages(response.wsgi_request)]
         self.assertTrue(any("sync" in m.lower() or "warning" in m.lower() or "failed" in m.lower() for m in msgs))
         self.assertFalse(any("bad data" in m for m in msgs))

--- a/netbox_kea/tests/test_reservation_views.py
+++ b/netbox_kea/tests/test_reservation_views.py
@@ -22,7 +22,7 @@ from django.test import SimpleTestCase, TestCase, override_settings
 from django.urls import reverse
 from ipam.models import IPAddress as NbIP
 
-from netbox_kea.kea import KeaClient, KeaException, PartialPersistError
+from netbox_kea.kea import KeaClient, KeaException
 from netbox_kea.models import Server
 from netbox_kea.views import _filter_reservations
 
@@ -1945,66 +1945,54 @@ class TestReservationSyncToNetBox(_ReservationViewBase):
             data["sync_to_netbox"] = "on"
         return data
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_add_form_has_sync_to_netbox_field(self, MockKeaClient):
-        """GET reservation add renders a sync_to_netbox checkbox."""
-        MockKeaClient.return_value.get_available_commands.return_value = _RESERVATION_COMMANDS
+    def _synced_ip_exists(self):
+        return NbIP.objects.filter(address__startswith="192.168.1.100/").exists()
+
+    def test_add_form_has_sync_to_netbox_field(self):
+        """GET reservation add renders a sync_to_netbox checkbox — no Kea traffic."""
         response = self.client.get(self._add4_url())
         self.assertEqual(response.status_code, 200)
         self.assertIn("sync_to_netbox", response.content.decode())
 
-    @patch("netbox_kea.views.reservations.sync_reservation_to_netbox")
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_add_with_sync_checked_calls_sync(self, MockKeaClient, mock_sync):
-        """POSTing with sync_to_netbox=on calls sync_reservation_to_netbox()."""
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_add.return_value = None
-        mock_sync.return_value = (MagicMock(spec=NbIP), True, True)
-        response = self.client.post(self._add4_url(), self._valid_post_data(sync=True))
+    def test_post_add_with_sync_checked_calls_sync(self):
+        """POSTing with sync_to_netbox=on runs the real sync → a NetBox IPAddress is created."""
+        with stub_kea({"subnet4-get": _subnet_get(4), "reservation-add": {"result": 0}}):
+            response = self.client.post(self._add4_url(), self._valid_post_data(sync=True))
         self.assertEqual(response.status_code, 302)
-        mock_sync.assert_called_once()
-        called_reservation = mock_sync.call_args[0][0]
-        self.assertEqual(called_reservation["ip-address"], "192.168.1.100")
+        self.assertTrue(self._synced_ip_exists())
+
+    def test_post_add_without_sync_does_not_call_sync(self):
+        """POSTing without sync_to_netbox must not create a NetBox IPAddress."""
+        with stub_kea({"subnet4-get": _subnet_get(4), "reservation-add": {"result": 0}}):
+            response = self.client.post(self._add4_url(), self._valid_post_data(sync=False))
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(self._synced_ip_exists())
 
     @patch("netbox_kea.views.reservations.sync_reservation_to_netbox")
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_add_without_sync_does_not_call_sync(self, MockKeaClient, mock_sync):
-        """POSTing without sync_to_netbox does NOT call sync_reservation_to_netbox()."""
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_add.return_value = None
-        response = self.client.post(self._add4_url(), self._valid_post_data(sync=False))
-        self.assertEqual(response.status_code, 302)
-        mock_sync.assert_not_called()
+    def test_post_add_sync_failure_still_redirects(self, mock_sync):
+        """Sync failure is a warning; the Kea reservation creation still succeeds.
 
-    @patch("netbox_kea.views.reservations.sync_reservation_to_netbox")
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_add_sync_failure_still_redirects(self, MockKeaClient, mock_sync):
-        """Sync failure is a warning; Kea reservation creation still succeeds."""
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_add.return_value = None
+        The sync boundary (a NetBox-side function tested in test_sync.py) is patched
+        to raise so the view's error handling is exercised; the KeaClient is real.
+        """
         mock_sync.side_effect = ValueError("Reservation has no ip-address or ip-addresses field.")
-        response = self.client.post(self._add4_url(), self._valid_post_data(sync=True))
+        with stub_kea({"subnet4-get": _subnet_get(4), "reservation-add": {"result": 0}}) as kea:
+            response = self.client.post(self._add4_url(), self._valid_post_data(sync=True))
         self.assertEqual(response.status_code, 302)
-        mock_client.reservation_add.assert_called_once()
+        self.assertEqual(kea.commands().count("reservation-add"), 1)
 
-    @patch("netbox_kea.views.reservations.sync_reservation_to_netbox")
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_edit_with_sync_checked_calls_sync(self, MockKeaClient, mock_sync):
-        """POSTing reservation edit with sync_to_netbox=on calls sync_reservation_to_netbox()."""
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_update.return_value = None
-        mock_sync.return_value = (MagicMock(spec=NbIP), False, True)
-        mock_client.reservation_get.return_value = {
+    def test_post_edit_with_sync_checked_calls_sync(self):
+        """POSTing reservation edit with sync_to_netbox=on runs the real sync → IPAddress created."""
+        existing = {
             "ip-address": "192.168.1.100",
             "hw-address": "aa:bb:cc:dd:ee:ff",
             "subnet-id": 1,
             "hostname": "testhost.example.com",
         }
-        response = self.client.post(self._edit4_url(), self._valid_post_data(sync=True))
+        with stub_kea({"reservation-get": _res_get(existing), "reservation-update": {"result": 0}}):
+            response = self.client.post(self._edit4_url(), self._valid_post_data(sync=True))
         self.assertEqual(response.status_code, 302)
-        mock_sync.assert_called_once()
-        called_reservation = mock_sync.call_args[0][0]
-        self.assertEqual(called_reservation["ip-address"], "192.168.1.100")
+        self.assertTrue(self._synced_ip_exists())
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -2012,29 +2000,13 @@ class TestReservationSyncToNetBox(_ReservationViewBase):
 # ─────────────────────────────────────────────────────────────────────────────
 
 
-@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
-class TestPartialPersistErrorOnReservationAdd(_ReservationViewBase):
-    """PartialPersistError on reservation4 add shows warning and redirects (not 500)."""
-
-    def _url(self):
-        return reverse("plugins:netbox_kea:server_reservation4_add", args=[self.server.pk])
-
-    @patch("netbox_kea.models.KeaClient")
-    def test_partial_persist_error_shows_warning_and_redirects(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_add.side_effect = PartialPersistError("dhcp4", Exception("config-write failed"))
-        response = self.client.post(
-            self._url(),
-            {
-                "subnet_id": 1,
-                "ip_address": "192.168.1.100",
-                "identifier_type": "hw-address",
-                "identifier": "aa:bb:cc:dd:ee:ff",
-                "hostname": "testhost.example.com",
-            },
-        )
-        # PartialPersistError should redirect (302) with a warning message, not crash (500)
-        self.assertEqual(response.status_code, 302)
+# NOTE: there is no ``TestPartialPersistErrorOnReservationAdd`` here. Reservation
+# writes (reservation-add/-update/-del) issue a single Kea command and never call
+# config-write, so ``KeaClient.reservation_add`` cannot raise ``PartialPersistError``.
+# The view's ``except PartialPersistError`` branch after reservation_add is therefore
+# unreachable through the real client and cannot be exercised without mocking the
+# client to raise. The equivalent guarantee for config-persisting writes is covered by
+# the pool_add / subnet_add / subnet_del cases below (real config-write result 1).
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
@@ -2046,11 +2018,10 @@ class TestPartialPersistErrorOnPoolAdd(_ReservationViewBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_subnet4_pool_add", args=[self.server.pk, self._SUBNET_ID])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_partial_persist_error_shows_warning_and_redirects(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.pool_add.side_effect = PartialPersistError("dhcp4", Exception("config-write failed"))
-        response = self.client.post(self._url(), {"pool": "10.0.0.50-10.0.0.99"})
+    def test_partial_persist_error_shows_warning_and_redirects(self):
+        # A real config-write failure (result 1) after the pool is applied → PartialPersistError.
+        with _pool_add_stub(4, **{"config-write": {"result": 1, "text": "config-write failed"}}):
+            response = self.client.post(self._url(), {"pool": "10.0.0.50-10.0.0.99"})
         self.assertEqual(response.status_code, 302)
 
 
@@ -2061,18 +2032,10 @@ class TestPartialPersistErrorOnSubnetAdd(_ReservationViewBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_subnet4_add", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_partial_persist_error_shows_warning_and_redirects(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.subnet_add.side_effect = PartialPersistError("dhcp4", Exception("config-write failed"))
-        mock_client.command.return_value = [{"result": 0, "arguments": {"Dhcp4": {"shared-networks": []}}}]
-        response = self.client.post(
-            self._url(),
-            {
-                "subnet": "10.10.0.0/24",
-            },
-        )
-        mock_client.subnet_add.assert_called_once()
+    def test_partial_persist_error_shows_warning_and_redirects(self):
+        with _subnet_add_stub(4, **{"config-write": {"result": 1, "text": "config-write failed"}}) as kea:
+            response = self.client.post(self._url(), {"subnet": "10.10.0.0/24"})
+        self.assertEqual(kea.commands().count("subnet4-add"), 1)
         self.assertEqual(response.status_code, 302)
 
 
@@ -2085,11 +2048,9 @@ class TestPartialPersistErrorOnSubnetDelete(_ReservationViewBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_subnet4_delete", args=[self.server.pk, self._SUBNET_ID])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_partial_persist_error_shows_warning_and_redirects(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.subnet_del.side_effect = PartialPersistError("dhcp4", Exception("config-write failed"))
-        response = self.client.post(self._url(), {"confirm": True})
+    def test_partial_persist_error_shows_warning_and_redirects(self):
+        with _subnet_del_stub(4, subnet_id=self._SUBNET_ID, **{"config-write": {"result": 1, "text": "failed"}}):
+            response = self.client.post(self._url(), {"confirm": True})
         self.assertEqual(response.status_code, 302)
 
 

--- a/netbox_kea/tests/test_reservation_views.py
+++ b/netbox_kea/tests/test_reservation_views.py
@@ -119,6 +119,28 @@ def _list_stub6(hosts=None):
     return stub_kea({"reservation-get-page": _res_page(hosts), "lease6-get-all": _LEASE_NONE6})
 
 
+def _subnet_get(version, pools=None, subnet_id=1):
+    """A ``subnet{v}-get`` result for the reservation-add pool-overlap probe.
+
+    *pools* is a list of pool range strings (e.g. ``["192.168.1.50-192.168.1.200"]``);
+    the probe warns only when the reservation IP falls inside one of them.
+    """
+    return {
+        "result": 0,
+        "arguments": {f"subnet{version}": [{"id": subnet_id, "pools": [{"pool": p} for p in (pools or [])]}]},
+    }
+
+
+def _res_get(reservation):
+    """A ``reservation-get`` result: the host fields Kea returns directly inside ``arguments``."""
+    return {"result": 0, "arguments": dict(reservation)}
+
+
+#: ``reservation-get`` / ``lease{v}-get`` with result 3 = no such record.
+_RES_NOT_FOUND = {"result": 3}
+_LEASE_NOT_FOUND = {"result": 3}
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Shared base
 # ─────────────────────────────────────────────────────────────────────────────
@@ -315,81 +337,70 @@ class TestServerReservation4AddView(_ReservationViewBase):
             "hostname": "testhost.example.com",
         }
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_renders_form(self, MockKeaClient):
+    def test_get_renders_form(self):
+        # GET renders the add form only — no Kea traffic.
         response = self.client.get(self._add_url())
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_valid_creates_reservation_and_redirects(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_add.return_value = None
-        response = self.client.post(self._add_url(), self._valid_post_data())
+    def test_post_valid_creates_reservation_and_redirects(self):
+        with stub_kea({"subnet4-get": _subnet_get(4), "reservation-add": {"result": 0}}) as kea:
+            response = self.client.post(self._add_url(), self._valid_post_data())
         self.assertEqual(response.status_code, 302)
         # Must redirect to the server's reservations page (not to /None/)
         self.assertNotIn("None", response.url)
-        mock_client.reservation_add.assert_called_once()
+        self.assertEqual(kea.commands().count("reservation-add"), 1)
+        # The real payload carries the identifier the form submitted.
+        added = kea.bodies("reservation-add")[0]["arguments"]["reservation"]
+        self.assertEqual(added["ip-address"], "192.168.1.100")
+        self.assertEqual(added["hw-address"], "aa:bb:cc:dd:ee:ff")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_invalid_rerenders_form(self, MockKeaClient):
-        # Empty POST — all required fields missing
+    def test_post_invalid_rerenders_form(self):
+        # Empty POST — all required fields missing; form invalid before any Kea call.
         response = self.client.post(self._add_url(), {})
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_missing_ip_address_rerenders_form(self, MockKeaClient):
+    def test_post_missing_ip_address_rerenders_form(self):
         data = self._valid_post_data()
         del data["ip_address"]
         response = self.client.post(self._add_url(), data)
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_kea_error_shows_error_message(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_add.side_effect = KeaException(
-            {"result": 1, "text": "failed to add host: conflicts with existing reservation"},
-            index=0,
-        )
-        response = self.client.post(self._add_url(), self._valid_post_data())
+    def test_post_kea_error_shows_error_message(self):
+        # reservation-add result 1 → real KeaClient raises KeaException → view re-renders.
+        with stub_kea(
+            {
+                "subnet4-get": _subnet_get(4),
+                "reservation-add": {"result": 1, "text": "failed to add host: conflicts with existing reservation"},
+            }
+        ):
+            response = self.client.post(self._add_url(), self._valid_post_data())
         # Must not crash with 500; either re-render (200) or redirect with error
         self.assertIn(response.status_code, (200, 302))
 
     # ── F4: reservation-in-pool overlap warning ───────────────────────────────
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_warns_when_reservation_ip_inside_pool(self, MockKeaClient):
+    def test_post_warns_when_reservation_ip_inside_pool(self):
         """F4: POST adding a reservation whose IP is inside an existing pool shows a non-blocking warning."""
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_add.return_value = None
-        # subnet4-get returns subnet with a pool that covers the reservation IP (192.168.1.100)
-        mock_client.command.return_value = [
-            {
-                "result": 0,
-                "arguments": {"subnet4": [{"id": 1, "pools": [{"pool": "192.168.1.50-192.168.1.200"}]}]},
-            }
-        ]
-        response = self.client.post(self._add_url(), self._valid_post_data())
+        # subnet4-get returns a pool that covers the reservation IP (192.168.1.100).
+        with stub_kea(
+            {"subnet4-get": _subnet_get(4, pools=["192.168.1.50-192.168.1.200"]), "reservation-add": {"result": 0}}
+        ) as kea:
+            response = self.client.post(self._add_url(), self._valid_post_data())
         # Non-blocking: still redirects
         self.assertEqual(response.status_code, 302)
-        mock_client.reservation_add.assert_called_once()
+        self.assertEqual(kea.commands().count("reservation-add"), 1)
         storage = list(get_messages(response.wsgi_request))
         self.assertTrue(any(m.level == WARNING for m in storage))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_no_warning_when_reservation_ip_outside_pool(self, MockKeaClient):
+    def test_post_no_warning_when_reservation_ip_outside_pool(self):
         """F4: No warning when the reservation IP is not in any existing pool."""
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_add.return_value = None
-        # Pool does NOT cover the reservation IP
-        mock_client.command.return_value = [
-            {
-                "result": 0,
-                "arguments": {"subnet4": [{"id": 1, "pools": [{"pool": "192.168.1.10-192.168.1.50"}]}]},
-            }
-        ]
-        response = self.client.post(self._add_url(), self._valid_post_data())
+        # Pool does NOT cover the reservation IP.
+        with stub_kea(
+            {"subnet4-get": _subnet_get(4, pools=["192.168.1.10-192.168.1.50"]), "reservation-add": {"result": 0}}
+        ) as kea:
+            response = self.client.post(self._add_url(), self._valid_post_data())
         self.assertEqual(response.status_code, 302)
-        mock_client.reservation_add.assert_called_once()
+        self.assertEqual(kea.commands().count("reservation-add"), 1)
         storage = list(get_messages(response.wsgi_request))
         self.assertFalse(any(m.level == WARNING for m in storage))
 
@@ -415,33 +426,27 @@ class TestServerReservation6AddView(_ReservationViewBase):
             "hostname": "testhost6.example.com",
         }
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_renders_form(self, MockKeaClient):
+    def test_get_renders_form(self):
         response = self.client.get(self._add_url())
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_valid_creates_reservation_and_redirects(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_add.return_value = None
-        response = self.client.post(self._add_url(), self._valid_post_data())
+    def test_post_valid_creates_reservation_and_redirects(self):
+        with stub_kea({"subnet6-get": _subnet_get(6), "reservation-add": {"result": 0}}) as kea:
+            response = self.client.post(self._add_url(), self._valid_post_data())
         self.assertEqual(response.status_code, 302)
         self.assertNotIn("None", response.url)
-        mock_client.reservation_add.assert_called_once()
+        self.assertEqual(kea.commands().count("reservation-add"), 1)
+        added = kea.bodies("reservation-add")[0]["arguments"]["reservation"]
+        self.assertEqual(added["ip-addresses"], ["2001:db8::100"])
+        self.assertEqual(added["duid"], "00:01:02:03:04:05:06:07")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_invalid_rerenders_form(self, MockKeaClient):
+    def test_post_invalid_rerenders_form(self):
         response = self.client.post(self._add_url(), {})
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_kea_error_shows_error_message(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_add.side_effect = KeaException(
-            {"result": 1, "text": "failed to add host"},
-            index=0,
-        )
-        response = self.client.post(self._add_url(), self._valid_post_data())
+    def test_post_kea_error_shows_error_message(self):
+        with stub_kea({"subnet6-get": _subnet_get(6), "reservation-add": {"result": 1, "text": "failed to add host"}}):
+            response = self.client.post(self._add_url(), self._valid_post_data())
         self.assertIn(response.status_code, (200, 302))
 
 
@@ -472,38 +477,28 @@ class TestServerReservation4EditView(_ReservationViewBase):
             "hostname": "updated-host.example.com",
         }
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_prepopulates_form_with_reservation_data(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_get.return_value = _SAMPLE_RESERVATION4
-        response = self.client.get(self._edit_url())
+    def test_get_prepopulates_form_with_reservation_data(self):
+        with stub_kea({"reservation-get": _res_get(_SAMPLE_RESERVATION4), "lease4-get": _LEASE_NOT_FOUND}):
+            response = self.client.get(self._edit_url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, self._IP)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_404_when_reservation_not_found(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_get.return_value = None  # not found
-        response = self.client.get(self._edit_url())
+    def test_get_404_when_reservation_not_found(self):
+        with stub_kea({"reservation-get": _RES_NOT_FOUND}):
+            response = self.client.get(self._edit_url())
         self.assertEqual(response.status_code, 404)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_valid_updates_reservation_and_redirects(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_get.return_value = _SAMPLE_RESERVATION4
-        mock_client.reservation_update.return_value = None
-        response = self.client.post(self._edit_url(), self._valid_post_data())
+    def test_post_valid_updates_reservation_and_redirects(self):
+        with stub_kea({"reservation-get": _res_get(_SAMPLE_RESERVATION4), "reservation-update": {"result": 0}}) as kea:
+            response = self.client.post(self._edit_url(), self._valid_post_data())
         self.assertEqual(response.status_code, 302)
         self.assertNotIn("None", response.url)
-        mock_client.reservation_update.assert_called_once()
+        self.assertEqual(kea.commands().count("reservation-update"), 1)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_invalid_rerenders_form(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_get.return_value = _SAMPLE_RESERVATION4
-        # All form fields (subnet_id, ip_address, identifier_type, identifier) are disabled in the
+    def test_post_invalid_rerenders_form(self):
+        # All key fields (subnet_id, ip_address, identifier_type, identifier) are disabled in the
         # edit POST handler and take their values from existing.  Trigger invalidity via the options
-        # formset: submit a row with data but no name (name is required).
+        # formset: submit a row with data but no name (name is required).  The update never fires.
         data = self._valid_post_data()
         data.update(
             {
@@ -515,54 +510,57 @@ class TestServerReservation4EditView(_ReservationViewBase):
                 "options-0-data": "192.168.1.1",
             }
         )
-        response = self.client.post(self._edit_url(), data)
+        with stub_kea({"reservation-get": _res_get(_SAMPLE_RESERVATION4)}) as kea:
+            response = self.client.post(self._edit_url(), data)
         self.assertEqual(response.status_code, 200)
+        self.assertNotIn("reservation-update", kea.commands())
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_kea_error_shows_error_message(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_get.return_value = _SAMPLE_RESERVATION4
-        mock_client.reservation_update.side_effect = KeaException(
-            {"result": 1, "text": "failed to update host"},
-            index=0,
-        )
-        response = self.client.post(self._edit_url(), self._valid_post_data())
+    def test_post_kea_error_shows_error_message(self):
+        with stub_kea(
+            {
+                "reservation-get": _res_get(_SAMPLE_RESERVATION4),
+                "reservation-update": {"result": 1, "text": "failed to update host"},
+            }
+        ):
+            response = self.client.post(self._edit_url(), self._valid_post_data())
         self.assertIn(response.status_code, (200, 302))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_shows_lease_diff_when_hostname_differs(self, MockKeaClient):
+    def test_get_shows_lease_diff_when_hostname_differs(self):
         """GET must add lease_diff to context when active lease hostname differs."""
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_get.return_value = _SAMPLE_RESERVATION4  # hostname: "testhost.example.com"
-        mock_client.lease_get_by_ip.return_value = {
-            "ip-address": self._IP,
-            "hostname": "lease-host.example.com",
-        }
-        response = self.client.get(self._edit_url())
+        # _SAMPLE_RESERVATION4 hostname is "testhost.example.com"; the active lease differs.
+        with stub_kea(
+            {
+                "reservation-get": _res_get(_SAMPLE_RESERVATION4),
+                "lease4-get": {
+                    "result": 0,
+                    "arguments": {"ip-address": self._IP, "hostname": "lease-host.example.com"},
+                },
+            }
+        ):
+            response = self.client.get(self._edit_url())
         self.assertEqual(response.status_code, 200)
         self.assertIn("lease_diff", response.context)
         self.assertEqual(response.context["lease_diff"]["hostname"], "lease-host.example.com")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_no_lease_diff_when_hostname_matches(self, MockKeaClient):
+    def test_get_no_lease_diff_when_hostname_matches(self):
         """GET must not include lease_diff when lease hostname matches reservation."""
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_get.return_value = _SAMPLE_RESERVATION4  # hostname: "testhost.example.com"
-        mock_client.lease_get_by_ip.return_value = {
-            "ip-address": self._IP,
-            "hostname": "testhost.example.com",
-        }
-        response = self.client.get(self._edit_url())
+        with stub_kea(
+            {
+                "reservation-get": _res_get(_SAMPLE_RESERVATION4),
+                "lease4-get": {"result": 0, "arguments": {"ip-address": self._IP, "hostname": "testhost.example.com"}},
+            }
+        ):
+            response = self.client.get(self._edit_url())
         self.assertEqual(response.status_code, 200)
         self.assertNotIn("lease_diff", response.context)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_no_lease_diff_when_lease_fetch_raises(self, MockKeaClient):
+    def test_get_no_lease_diff_when_lease_fetch_raises(self):
         """GET must not crash or add lease_diff when the lease fetch raises KeaException."""
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_get.return_value = _SAMPLE_RESERVATION4
-        mock_client.lease_get_by_ip.side_effect = KeaException({"result": 3, "text": "not found"}, index=0)
-        response = self.client.get(self._edit_url())
+        # lease4-get result 1 → real KeaClient raises KeaException → the diff branch is skipped.
+        with stub_kea(
+            {"reservation-get": _res_get(_SAMPLE_RESERVATION4), "lease4-get": {"result": 1, "text": "error"}}
+        ):
+            response = self.client.get(self._edit_url())
         self.assertEqual(response.status_code, 200)
         self.assertNotIn("lease_diff", response.context)
 
@@ -585,38 +583,31 @@ class TestServerReservation6EditView(_ReservationViewBase):
             args=[self.server.pk, self._SUBNET_ID, self._IP],
         )
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_prepopulates_form_with_reservation_data(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_get.return_value = _SAMPLE_RESERVATION6
-        response = self.client.get(self._edit_url())
+    def test_get_prepopulates_form_with_reservation_data(self):
+        with stub_kea({"reservation-get": _res_get(_SAMPLE_RESERVATION6), "lease6-get": _LEASE_NOT_FOUND}):
+            response = self.client.get(self._edit_url())
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_404_when_reservation_not_found(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_get.return_value = None
-        response = self.client.get(self._edit_url())
+    def test_get_404_when_reservation_not_found(self):
+        with stub_kea({"reservation-get": _RES_NOT_FOUND}):
+            response = self.client.get(self._edit_url())
         self.assertEqual(response.status_code, 404)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_valid_updates_reservation_and_redirects(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_get.return_value = _SAMPLE_RESERVATION6
-        mock_client.reservation_update.return_value = None
-        response = self.client.post(
-            self._edit_url(),
-            {
-                "subnet_id": self._SUBNET_ID,
-                "ip_addresses": "2001:db8::100",
-                "identifier_type": "duid",
-                "identifier": "00:01:02:03:04:05",
-                "hostname": "testhost6.example.com",
-            },
-        )
+    def test_post_valid_updates_reservation_and_redirects(self):
+        with stub_kea({"reservation-get": _res_get(_SAMPLE_RESERVATION6), "reservation-update": {"result": 0}}) as kea:
+            response = self.client.post(
+                self._edit_url(),
+                {
+                    "subnet_id": self._SUBNET_ID,
+                    "ip_addresses": "2001:db8::100",
+                    "identifier_type": "duid",
+                    "identifier": "00:01:02:03:04:05",
+                    "hostname": "testhost6.example.com",
+                },
+            )
         self.assertEqual(response.status_code, 302)
         self.assertNotIn("None", response.url)
-        mock_client.reservation_update.assert_called_once()
+        self.assertEqual(kea.commands().count("reservation-update"), 1)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -637,30 +628,24 @@ class TestServerReservation4DeleteView(_ReservationViewBase):
             args=[self.server.pk, self._SUBNET_ID, self._IP],
         )
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_shows_confirmation_page(self, MockKeaClient):
+    def test_get_shows_confirmation_page(self):
+        # GET renders the confirmation page only — no Kea traffic.
         response = self.client.get(self._delete_url())
         self.assertEqual(response.status_code, 200)
         # The confirmation page should mention the IP being deleted
         self.assertContains(response, self._IP)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_deletes_reservation_and_redirects(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_del.return_value = None
-        response = self.client.post(self._delete_url(), {"confirm": "true"})
+    def test_post_deletes_reservation_and_redirects(self):
+        with stub_kea({"reservation-del": {"result": 0}}) as kea:
+            response = self.client.post(self._delete_url(), {"confirm": "true"})
         self.assertEqual(response.status_code, 302)
         self.assertNotIn("None", response.url)
-        mock_client.reservation_del.assert_called_once()
+        self.assertEqual(kea.commands().count("reservation-del"), 1)
+        self.assertEqual(kea.bodies("reservation-del")[0]["arguments"]["ip-address"], self._IP)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_kea_error_shows_message(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_del.side_effect = KeaException(
-            {"result": 1, "text": "Host not found."},
-            index=0,
-        )
-        response = self.client.post(self._delete_url(), {"confirm": "true"})
+    def test_post_kea_error_shows_message(self):
+        with stub_kea({"reservation-del": {"result": 1, "text": "Host not found."}}):
+            response = self.client.post(self._delete_url(), {"confirm": "true"})
         # Must not crash with 500
         self.assertIn(response.status_code, (200, 302))
 
@@ -691,29 +676,22 @@ class TestServerReservation6DeleteView(_ReservationViewBase):
             args=[self.server.pk, self._SUBNET_ID, self._IP],
         )
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_shows_confirmation_page(self, MockKeaClient):
+    def test_get_shows_confirmation_page(self):
         response = self.client.get(self._delete_url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, self._IP)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_deletes_reservation_and_redirects(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_del.return_value = None
-        response = self.client.post(self._delete_url(), {"confirm": "true"})
+    def test_post_deletes_reservation_and_redirects(self):
+        with stub_kea({"reservation-del": {"result": 0}}) as kea:
+            response = self.client.post(self._delete_url(), {"confirm": "true"})
         self.assertEqual(response.status_code, 302)
         self.assertNotIn("None", response.url)
-        mock_client.reservation_del.assert_called_once()
+        self.assertEqual(kea.commands().count("reservation-del"), 1)
+        self.assertEqual(kea.bodies("reservation-del")[0]["arguments"]["ip-address"], self._IP)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_kea_error_shows_message(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_del.side_effect = KeaException(
-            {"result": 1, "text": "Host not found."},
-            index=0,
-        )
-        response = self.client.post(self._delete_url(), {"confirm": "true"})
+    def test_post_kea_error_shows_message(self):
+        with stub_kea({"reservation-del": {"result": 1, "text": "Host not found."}}):
+            response = self.client.post(self._delete_url(), {"confirm": "true"})
         self.assertIn(response.status_code, (200, 302))
 
 

--- a/netbox_kea/tests/test_reservation_views.py
+++ b/netbox_kea/tests/test_reservation_views.py
@@ -2072,40 +2072,42 @@ class TestServerReservation6EditLeaseDiff(_ReservationViewBase):
             args=[self.server.pk, self._SUBNET_ID, self._IP],
         )
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_shows_lease_diff_when_hostname_differs(self, MockKeaClient):
+    def _reservation(self):
+        return {**_SAMPLE_RESERVATION6, "ip-addresses": [self._IP]}
+
+    def test_get_shows_lease_diff_when_hostname_differs(self):
         """GET must add lease_diff to context when DHCPv6 active lease hostname differs."""
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_get.return_value = {**_SAMPLE_RESERVATION6, "ip-addresses": [self._IP]}
-        mock_client.lease_get_by_ip.return_value = {
-            "ip-address": self._IP,
-            "hostname": "lease-host6.example.com",
-        }
-        response = self.client.get(self._edit_url())
+        with stub_kea(
+            {
+                "reservation-get": _res_get(self._reservation()),
+                "lease6-get": {
+                    "result": 0,
+                    "arguments": {"ip-address": self._IP, "hostname": "lease-host6.example.com"},
+                },
+            }
+        ):
+            response = self.client.get(self._edit_url())
         self.assertEqual(response.status_code, 200)
         self.assertIn("lease_diff", response.context)
         self.assertEqual(response.context["lease_diff"]["hostname"], "lease-host6.example.com")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_no_lease_diff_when_lease_fetch_raises(self, MockKeaClient):
+    def test_get_no_lease_diff_when_lease_fetch_raises(self):
         """GET must not crash when DHCPv6 lease fetch raises KeaException."""
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_get.return_value = {**_SAMPLE_RESERVATION6, "ip-addresses": [self._IP]}
-        mock_client.lease_get_by_ip.side_effect = KeaException({"result": 3, "text": "not found"}, index=0)
-        response = self.client.get(self._edit_url())
+        # lease6-get result 1 → real KeaClient raises KeaException → the diff branch is skipped.
+        with stub_kea({"reservation-get": _res_get(self._reservation()), "lease6-get": {"result": 1, "text": "err"}}):
+            response = self.client.get(self._edit_url())
         self.assertEqual(response.status_code, 200)
         self.assertNotIn("lease_diff", response.context)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_no_lease_diff_when_hostname_matches(self, MockKeaClient):
+    def test_get_no_lease_diff_when_hostname_matches(self):
         """GET must not add lease_diff when lease hostname matches the reservation hostname."""
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_get.return_value = {**_SAMPLE_RESERVATION6, "ip-addresses": [self._IP]}
-        mock_client.lease_get_by_ip.return_value = {
-            "ip-address": self._IP,
-            "hostname": "testhost6.example.com",  # matches reservation
-        }
-        response = self.client.get(self._edit_url())
+        with stub_kea(
+            {
+                "reservation-get": _res_get(self._reservation()),
+                "lease6-get": {"result": 0, "arguments": {"ip-address": self._IP, "hostname": "testhost6.example.com"}},
+            }
+        ):
+            response = self.client.get(self._edit_url())
         self.assertEqual(response.status_code, 200)
         self.assertNotIn("lease_diff", response.context)
 
@@ -2147,70 +2149,43 @@ class TestReservationJournalEntries(_ReservationViewBase):
             assigned_object_id=self.server.pk,
         ).count()
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_add_creates_journal_entry(self, MockKeaClient):
+    def _add_post_data(self, hostname="testhost.example.com"):
+        return {
+            "subnet_id": self._SUBNET_ID,
+            "ip_address": self._IP,
+            "identifier_type": "hw-address",
+            "identifier": "aa:bb:cc:dd:ee:ff",
+            "hostname": hostname,
+        }
+
+    def test_add_creates_journal_entry(self):
         """Successful reservation-add must create a JournalEntry on the Server."""
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_add.return_value = None
         before = self._journal_count()
-        self.client.post(
-            self._add_url(),
-            {
-                "subnet_id": self._SUBNET_ID,
-                "ip_address": self._IP,
-                "identifier_type": "hw-address",
-                "identifier": "aa:bb:cc:dd:ee:ff",
-                "hostname": "testhost.example.com",
-            },
-        )
+        with stub_kea({"subnet4-get": _subnet_get(4), "reservation-add": {"result": 0}}):
+            self.client.post(self._add_url(), self._add_post_data())
         self.assertEqual(self._journal_count(), before + 1)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_edit_creates_journal_entry(self, MockKeaClient):
+    def test_edit_creates_journal_entry(self):
         """Successful reservation-update must create a JournalEntry on the Server."""
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_get.return_value = _SAMPLE_RESERVATION4
-        mock_client.reservation_update.return_value = None
         before = self._journal_count()
-        self.client.post(
-            self._edit_url(),
-            {
-                "subnet_id": self._SUBNET_ID,
-                "ip_address": self._IP,
-                "identifier_type": "hw-address",
-                "identifier": "aa:bb:cc:dd:ee:ff",
-                "hostname": "updated-host.example.com",
-            },
-        )
+        with stub_kea({"reservation-get": _res_get(_SAMPLE_RESERVATION4), "reservation-update": {"result": 0}}):
+            self.client.post(self._edit_url(), self._add_post_data(hostname="updated-host.example.com"))
         self.assertEqual(self._journal_count(), before + 1)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_delete_creates_journal_entry(self, MockKeaClient):
+    def test_delete_creates_journal_entry(self):
         """Successful reservation-del must create a JournalEntry on the Server."""
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_del.return_value = None
         before = self._journal_count()
-        self.client.post(self._delete_url(), {"confirm": "true"})
+        with stub_kea({"reservation-del": {"result": 0}}):
+            self.client.post(self._delete_url(), {"confirm": "true"})
         self.assertEqual(self._journal_count(), before + 1)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_add_kea_error_does_not_create_journal_entry(self, MockKeaClient):
+    def test_add_kea_error_does_not_create_journal_entry(self):
         """Failed reservation-add must NOT create a JournalEntry."""
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_add.side_effect = KeaException({"result": 1, "text": "error"}, index=0)
         before = self._journal_count()
-        response = self.client.post(
-            self._add_url(),
-            {
-                "subnet_id": self._SUBNET_ID,
-                "ip_address": self._IP,
-                "identifier_type": "hw-address",
-                "identifier": "aa:bb:cc:dd:ee:ff",
-                "hostname": "testhost.example.com",
-            },
-        )
+        with stub_kea({"subnet4-get": _subnet_get(4), "reservation-add": {"result": 1, "text": "error"}}) as kea:
+            response = self.client.post(self._add_url(), self._add_post_data())
         self.assertIn(response.status_code, (200, 302))
-        mock_client.reservation_add.assert_called_once()
+        self.assertEqual(kea.commands().count("reservation-add"), 1)
         self.assertEqual(self._journal_count(), before)
 
 
@@ -2264,59 +2239,37 @@ class TestReservation4OptionData(_ReservationViewBase):
             data.update(extra)
         return data
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_add_with_options_includes_option_data(self, MockKeaClient):
-        """POST add with options formset must include option-data in the reservation_add call."""
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_add.return_value = None
-
+    def test_post_add_with_options_includes_option_data(self):
+        """POST add with options formset must include option-data in the reservation-add payload."""
         post_data = self._base_post()
-        post_data.update(
-            _options_formset_data(
-                [
-                    {"name": "boot-file-name", "data": "http://10.0.0.1/ztp.py"},
-                ]
-            )
-        )
-        response = self.client.post(self._add_url(), post_data)
+        post_data.update(_options_formset_data([{"name": "boot-file-name", "data": "http://10.0.0.1/ztp.py"}]))
+        with stub_kea({"subnet4-get": _subnet_get(4), "reservation-add": {"result": 0}}) as kea:
+            response = self.client.post(self._add_url(), post_data)
         self.assertEqual(response.status_code, 302)
-
-        mock_client.reservation_add.assert_called_once()
-        call_args = mock_client.reservation_add.call_args
-        args, kwargs = call_args or ((), {})
-        reservation = kwargs.get("reservation") or (args[1] if len(args) > 1 else (args[0] if len(args) > 0 else {}))
+        reservation = kea.bodies("reservation-add")[0]["arguments"]["reservation"]
         self.assertIn("option-data", reservation)
         self.assertEqual(len(reservation["option-data"]), 1)
         self.assertEqual(reservation["option-data"][0]["name"], "boot-file-name")
         self.assertEqual(reservation["option-data"][0]["data"], "http://10.0.0.1/ztp.py")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_add_without_options_omits_option_data(self, MockKeaClient):
-        """POST add with empty formset must NOT include option-data in the reservation dict."""
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_add.return_value = None
-
+    def test_post_add_without_options_omits_option_data(self):
+        """POST add with empty formset must NOT include option-data in the reservation payload."""
         post_data = self._base_post()
         post_data.update(_options_formset_data([]))
-        response = self.client.post(self._add_url(), post_data)
+        with stub_kea({"subnet4-get": _subnet_get(4), "reservation-add": {"result": 0}}) as kea:
+            response = self.client.post(self._add_url(), post_data)
         self.assertEqual(response.status_code, 302)
-
-        mock_client.reservation_add.assert_called_once()
-        call_args = mock_client.reservation_add.call_args
-        args, kwargs = call_args or ((), {})
-        reservation = kwargs.get("reservation") or (args[1] if len(args) > 1 else (args[0] if len(args) > 0 else {}))
+        reservation = kea.bodies("reservation-add")[0]["arguments"]["reservation"]
         self.assertNotIn("option-data", reservation)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_edit_prepopulates_options_formset(self, MockKeaClient):
+    def test_get_edit_prepopulates_options_formset(self):
         """GET edit must pre-populate the options formset from existing reservation option-data."""
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_get.return_value = {
+        existing = {
             **_SAMPLE_RESERVATION4,
             "option-data": [{"name": "boot-file-name", "data": "http://10.0.0.1/ztp.py"}],
         }
-        mock_client.lease_get_by_ip.return_value = None
-        response = self.client.get(self._edit_url())
+        with stub_kea({"reservation-get": _res_get(existing), "lease4-get": _LEASE_NOT_FOUND}):
+            response = self.client.get(self._edit_url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "boot-file-name")
         self.assertContains(response, "http://10.0.0.1/ztp.py")
@@ -2324,35 +2277,20 @@ class TestReservation4OptionData(_ReservationViewBase):
         self.assertEqual(formset.initial[0]["name"], "boot-file-name")
         self.assertEqual(formset.initial[0]["data"], "http://10.0.0.1/ztp.py")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_edit_with_options_includes_option_data(self, MockKeaClient):
-        """POST edit with options formset must include option-data in the reservation_update call."""
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_get.return_value = _SAMPLE_RESERVATION4
-        mock_client.reservation_update.return_value = None
-
+    def test_post_edit_with_options_includes_option_data(self):
+        """POST edit with options formset must include option-data in the reservation-update payload."""
         post_data = self._base_post()
-        post_data.update(
-            _options_formset_data(
-                [
-                    {"name": "tftp-server-name", "data": "10.0.0.1"},
-                ]
-            )
-        )
-        response = self.client.post(self._edit_url(), post_data)
+        post_data.update(_options_formset_data([{"name": "tftp-server-name", "data": "10.0.0.1"}]))
+        with stub_kea({"reservation-get": _res_get(_SAMPLE_RESERVATION4), "reservation-update": {"result": 0}}) as kea:
+            response = self.client.post(self._edit_url(), post_data)
         self.assertEqual(response.status_code, 302)
-
-        mock_client.reservation_update.assert_called_once()
-        call_args = mock_client.reservation_update.call_args
-        args, kwargs = call_args or ((), {})
-        reservation = kwargs.get("reservation") or (args[1] if len(args) > 1 else (args[0] if len(args) > 0 else {}))
+        reservation = kea.bodies("reservation-update")[0]["arguments"]["reservation"]
         self.assertIn("option-data", reservation)
         self.assertEqual(reservation["option-data"][0]["name"], "tftp-server-name")
         self.assertEqual(reservation["option-data"][0]["data"], "10.0.0.1")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_add_shows_ztp_help_text(self, MockKeaClient):
-        """GET add form must contain ZTP reference text in the response."""
+    def test_get_add_shows_ztp_help_text(self):
+        """GET add form must contain ZTP reference text in the response — no Kea traffic."""
         response = self.client.get(self._add_url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "boot-file-name")
@@ -2371,11 +2309,12 @@ class TestSyncReservationCleanupFalse(_ReservationViewBase):
         return reverse("plugins:netbox_kea:server_reservation4_add", args=[self.server.pk])
 
     @patch("netbox_kea.views.reservations.sync_reservation_to_netbox")
-    @patch("netbox_kea.models.KeaClient")
-    def test_add_post_sync_calls_with_cleanup_false(self, MockKeaClient, mock_sync):
-        """POSTing reservation add with sync_to_netbox=on passes cleanup=False."""
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_add.return_value = None
+    def test_add_post_sync_calls_with_cleanup_false(self, mock_sync):
+        """POSTing reservation add with sync_to_netbox=on passes cleanup=False.
+
+        The KeaClient is real (HTTP-stubbed); the sync boundary is patched only to
+        inspect the cleanup kwarg the view passes.
+        """
         mock_sync.return_value = (MagicMock(spec=NbIP), True, True)
         data = {
             "subnet_id": 1,
@@ -2385,7 +2324,8 @@ class TestSyncReservationCleanupFalse(_ReservationViewBase):
             "hostname": "testhost.example.com",
             "sync_to_netbox": "on",
         }
-        response = self.client.post(self._add4_url(), data)
+        with stub_kea({"subnet4-get": _subnet_get(4), "reservation-add": {"result": 0}}):
+            response = self.client.post(self._add4_url(), data)
         self.assertEqual(response.status_code, 302)
         mock_sync.assert_called_once()
         _, kwargs = mock_sync.call_args

--- a/netbox_kea/tests/test_reservation_views.py
+++ b/netbox_kea/tests/test_reservation_views.py
@@ -26,6 +26,7 @@ from netbox_kea.kea import KeaClient, KeaException, PartialPersistError
 from netbox_kea.models import Server
 from netbox_kea.views import _filter_reservations
 
+from .kea_stub import queued, stub_kea
 from .utils import _PLUGINS_CONFIG, User, _make_db_server
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -60,11 +61,62 @@ _RESERVATION_COMMANDS = {
 
 
 def _wire_mock_clone(mock_client):
-    """Wire clone/context-manager on a mock KeaClient so worker threads see the same instance."""
+    """Wire clone/context-manager on a mock KeaClient so worker threads see the same instance.
+
+    Temporary: retained only until the last mock-based class below is de-mocked.
+    """
     mock_client.clone.return_value = mock_client
     mock_client.__enter__ = lambda s: s
     mock_client.__exit__ = lambda s, *a: None
     return mock_client
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Shared stub responses (real KeaClient + HTTP-boundary stub)
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# The reservation list/edit/delete views drive a real ``KeaClient``; only the HTTP
+# boundary is stubbed via ``kea_stub.stub_kea`` so the actual request payloads are
+# exercised. Command chains issued by the views:
+#   list GET:  ``reservation-get-page`` (drained via ``iter_reservations``) then, if
+#              any reservations are found, ``lease{v}-get-all`` per unique subnet
+#              (lease-status enrichment; NetBox IPAM badges hit the DB, not Kea).
+#   add POST:  ``reservation-get-page`` + ``list-commands`` (pool-overlap probe, both
+#              non-fatal) then ``reservation-add``. No config-write — reservation
+#              writes do not persist, so they never raise PartialPersistError.
+#   edit GET:  ``reservation-get`` (prefill) + ``lease{v}-get`` (hostname diff).
+#   edit POST: ``reservation-get`` (reload existing) + ``reservation-update``.
+#   delete POST: ``reservation-del``.
+
+
+def _res_page(hosts, *, next_from=0, next_source=0):
+    """A ``reservation-get-page`` result: *hosts* plus Kea's pagination cursor.
+
+    ``next_from``/``next_source`` both 0 marks the source exhausted, so
+    ``iter_reservations`` stops after this page.
+    """
+    return {"result": 0, "arguments": {"hosts": hosts, "next": {"from": next_from, "source-index": next_source}}}
+
+
+#: ``reservation-get-page`` with no hosts (source exhausted → empty reservation list).
+_RES_EMPTY_PAGE = {"result": 3}
+#: ``lease{v}-get-all`` with no active leases in the subnet (result 3 = empty).
+_LEASE_NONE4 = {"result": 3}
+_LEASE_NONE6 = {"result": 3}
+
+
+def _list_stub4(hosts=None):
+    """``stub_kea`` for the DHCPv4 reservations list view: get-page drain + lease enrichment."""
+    if hosts is None:
+        hosts = [dict(_SAMPLE_RESERVATION4)]
+    return stub_kea({"reservation-get-page": _res_page(hosts), "lease4-get-all": _LEASE_NONE4})
+
+
+def _list_stub6(hosts=None):
+    """``stub_kea`` for the DHCPv6 reservations list view: get-page drain + lease enrichment."""
+    if hosts is None:
+        hosts = [dict(_SAMPLE_RESERVATION6)]
+    return stub_kea({"reservation-get-page": _res_page(hosts), "lease6-get-all": _LEASE_NONE6})
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -85,20 +137,6 @@ class _ReservationViewBase(TestCase):
         self.client.force_login(self.user)
         self.server = _make_db_server()
 
-    def _mock_client_with_reservations4(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.get_available_commands.return_value = _RESERVATION_COMMANDS
-        mock_client.reservation_get_page.return_value = ([dict(_SAMPLE_RESERVATION4)], 0, 0)
-        mock_client.command.return_value = [{"result": 0, "arguments": {"leases": [], "count": 0}}]
-        return mock_client
-
-    def _mock_client_with_reservations6(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.get_available_commands.return_value = _RESERVATION_COMMANDS
-        mock_client.reservation_get_page.return_value = ([dict(_SAMPLE_RESERVATION6)], 0, 0)
-        mock_client.command.return_value = [{"result": 0, "arguments": {"leases": [], "count": 0}}]
-        return mock_client
-
 
 # ─────────────────────────────────────────────────────────────────────────────
 # TestServerReservations4View
@@ -109,59 +147,46 @@ class _ReservationViewBase(TestCase):
 class TestServerReservations4View(_ReservationViewBase):
     """GET /plugins/kea/servers/<pk>/reservations4/"""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_list_returns_200(self, MockKeaClient):
-        self._mock_client_with_reservations4(MockKeaClient)
+    def test_list_returns_200(self):
         url = reverse("plugins:netbox_kea:server_reservations4", args=[self.server.pk])
-        response = self.client.get(url)
+        with _list_stub4():
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_list_shows_reservations_in_table(self, MockKeaClient):
-        self._mock_client_with_reservations4(MockKeaClient)
+    def test_list_shows_reservations_in_table(self):
         url = reverse("plugins:netbox_kea:server_reservations4", args=[self.server.pk])
-        response = self.client.get(url)
+        with _list_stub4():
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "192.168.1.100")
         self.assertContains(response, "aa:bb:cc:dd:ee:ff")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_list_when_hook_not_loaded_shows_warning(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_get_page.side_effect = KeaException(
-            {"result": 2, "text": "unknown command 'reservation-get-page'"},
-            index=0,
-        )
+    def test_list_when_hook_not_loaded_shows_warning(self):
+        # result==2 (unknown command) → reservation_get_page raises KeaException,
+        # the view marks the host_cmds hook unavailable instead of crashing.
         url = reverse("plugins:netbox_kea:server_reservations4", args=[self.server.pk])
-        response = self.client.get(url)
+        with stub_kea({"reservation-get-page": {"result": 2, "text": "unknown command 'reservation-get-page'"}}):
+            response = self.client.get(url)
         # Must not crash with 500; show the page with a warning indicator
         self.assertEqual(response.status_code, 200)
         self.assertFalse(response.context["hook_available"])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_general_kea_error_keeps_hook_available(self, MockKeaClient):
+    def test_general_kea_error_keeps_hook_available(self):
         """Result code 1 (general Kea error) keeps hook_available=True.
 
         Only result==2 (unknown command = hook not loaded) should set
         hook_available=False.  Other errors are transient/backend failures.
         """
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_get_page.side_effect = KeaException(
-            {"result": 1, "text": "missing parameter 'limit'"},
-            index=0,
-        )
         url = reverse("plugins:netbox_kea:server_reservations4", args=[self.server.pk])
-        response = self.client.get(url)
+        with stub_kea({"reservation-get-page": {"result": 1, "text": "missing parameter 'limit'"}}):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.context["hook_available"])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_list_handles_empty_reservations(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.get_available_commands.return_value = _RESERVATION_COMMANDS
-        mock_client.reservation_get_page.return_value = ([], 0, 0)
+    def test_list_handles_empty_reservations(self):
         url = reverse("plugins:netbox_kea:server_reservations4", args=[self.server.pk])
-        response = self.client.get(url)
+        with stub_kea({"reservation-get-page": _RES_EMPTY_PAGE}):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
     def test_get_nonexistent_server_returns_404(self):
@@ -176,37 +201,29 @@ class TestServerReservations4View(_ReservationViewBase):
         self.assertEqual(response.status_code, 302)
         self.assertIn("login", response.url)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_drains_multiple_pages_from_kea(self, MockKeaClient):
-        """View must call reservation_get_page in a loop until all pages are fetched."""
-        mock_client = MockKeaClient.return_value
-        mock_client.get_available_commands.return_value = _RESERVATION_COMMANDS
+    def test_drains_multiple_pages_from_kea(self):
+        """View must page reservation-get-page in a loop until all pages are fetched."""
+        # page1 is a full page (100 == the view's limit) with the cursor advanced, so
+        # iter_reservations continues; page2 resets the cursor, ending the drain.
+        page1 = [dict(_SAMPLE_RESERVATION4, **{"ip-address": f"10.0.0.{i}", "subnet-id": 1}) for i in range(1, 101)]
         page2 = [dict(_SAMPLE_RESERVATION4, **{"ip-address": "10.0.1.1", "subnet-id": 1})]
-        # Simulate drain: side_effect returns full page then partial page.
-        # The view uses limit=100 internally, so page1 has < 100 items and will
-        # be detected as the last page after 1 call — use side_effect to control
-        # the 2-call sequence explicitly via a larger page1.
-        page1_full = [
-            dict(_SAMPLE_RESERVATION4, **{"ip-address": f"10.0.0.{i}", "subnet-id": 1})
-            for i in range(1, 101)  # exactly 100 items == limit → loop continues
-        ]
-        mock_client.reservation_get_page.side_effect = [
-            (page1_full, 100, 0),
-            (page2, 0, 0),
-        ]
-        mock_client.command.return_value = [{"result": 0, "arguments": {"leases": [], "count": 0}}]
         url = reverse("plugins:netbox_kea:server_reservations4", args=[self.server.pk])
-        response = self.client.get(url)
+        with stub_kea(
+            {
+                "reservation-get-page": queued(_res_page(page1, next_from=100), _res_page(page2)),
+                "lease4-get-all": _LEASE_NONE4,
+            }
+        ) as kea:
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        # The crucial assertion: view made exactly 2 calls (drain loop worked)
-        self.assertEqual(mock_client.reservation_get_page.call_count, 2)
+        # The crucial assertion: view issued exactly 2 get-page calls (drain loop worked).
+        self.assertEqual(kea.commands().count("reservation-get-page"), 2)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_reservation_table_data_has_ip_sort_key(self, MockKeaClient):
+    def test_reservation_table_data_has_ip_sort_key(self):
         """F1: each reservation dict in the table must have an integer _ip_sort_key."""
-        self._mock_client_with_reservations4(MockKeaClient)
         url = reverse("plugins:netbox_kea:server_reservations4", args=[self.server.pk])
-        response = self.client.get(url)
+        with _list_stub4():
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         table = response.context["table"]
         for row in table.data:
@@ -223,28 +240,23 @@ class TestServerReservations4View(_ReservationViewBase):
 class TestServerReservations6View(_ReservationViewBase):
     """GET /plugins/kea/servers/<pk>/reservations6/"""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_list_returns_200(self, MockKeaClient):
-        self._mock_client_with_reservations6(MockKeaClient)
+    def test_list_returns_200(self):
         url = reverse("plugins:netbox_kea:server_reservations6", args=[self.server.pk])
-        response = self.client.get(url)
+        with _list_stub6():
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_list_shows_reservations_in_table(self, MockKeaClient):
-        self._mock_client_with_reservations6(MockKeaClient)
+    def test_list_shows_reservations_in_table(self):
         url = reverse("plugins:netbox_kea:server_reservations6", args=[self.server.pk])
-        response = self.client.get(url)
+        with _list_stub6():
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "2001:db8::100")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_list_handles_empty_reservations(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.get_available_commands.return_value = _RESERVATION_COMMANDS
-        mock_client.reservation_get_page.return_value = ([], 0, 0)
+    def test_list_handles_empty_reservations(self):
         url = reverse("plugins:netbox_kea:server_reservations6", args=[self.server.pk])
-        response = self.client.get(url)
+        with stub_kea({"reservation-get-page": _RES_EMPTY_PAGE}):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
     def test_get_nonexistent_server_returns_404(self):
@@ -252,35 +264,28 @@ class TestServerReservations6View(_ReservationViewBase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_drains_multiple_pages_from_kea(self, MockKeaClient):
-        """View must call reservation_get_page in a loop until all pages are fetched."""
-        mock_client = MockKeaClient.return_value
-        mock_client.get_available_commands.return_value = _RESERVATION_COMMANDS
-        page2 = [dict(_SAMPLE_RESERVATION6, **{"ip-addresses": ["2001:db8::ff01"], "subnet-id": 1})]
-        mock_client.reservation_get_page.side_effect = [
-            (
-                [
-                    dict(_SAMPLE_RESERVATION6, **{"ip-addresses": [f"2001:db8::{i:x}"], "subnet-id": 1})
-                    for i in range(100)
-                ],
-                100,
-                0,
-            ),
-            (page2, 0, 0),
+    def test_drains_multiple_pages_from_kea(self):
+        """View must page reservation-get-page in a loop until all pages are fetched."""
+        page1 = [
+            dict(_SAMPLE_RESERVATION6, **{"ip-addresses": [f"2001:db8::{i:x}"], "subnet-id": 1}) for i in range(100)
         ]
-        mock_client.command.return_value = [{"result": 0, "arguments": {"leases": [], "count": 0}}]
+        page2 = [dict(_SAMPLE_RESERVATION6, **{"ip-addresses": ["2001:db8::ff01"], "subnet-id": 1})]
         url = reverse("plugins:netbox_kea:server_reservations6", args=[self.server.pk])
-        response = self.client.get(url)
+        with stub_kea(
+            {
+                "reservation-get-page": queued(_res_page(page1, next_from=100), _res_page(page2)),
+                "lease6-get-all": _LEASE_NONE6,
+            }
+        ) as kea:
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(mock_client.reservation_get_page.call_count, 2)
+        self.assertEqual(kea.commands().count("reservation-get-page"), 2)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_action_hrefs_contain_ipv6_address(self, MockKeaClient):
+    def test_action_hrefs_contain_ipv6_address(self):
         """Edit/delete action links must embed the IPv6 address in the URL path (issue #12)."""
-        self._mock_client_with_reservations6(MockKeaClient)
         url = reverse("plugins:netbox_kea:server_reservations6", args=[self.server.pk])
-        response = self.client.get(url)
+        with _list_stub6():
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         ip = _SAMPLE_RESERVATION6["ip-addresses"][0]
         subnet_id = _SAMPLE_RESERVATION6["subnet-id"]

--- a/netbox_kea/tests/test_reservation_views.py
+++ b/netbox_kea/tests/test_reservation_views.py
@@ -26,7 +26,7 @@ from netbox_kea.kea import KeaClient
 from netbox_kea.models import Server
 from netbox_kea.views import _filter_reservations
 
-from .kea_stub import queued, stub_kea
+from .kea_stub import _res_get, _res_page, _subnet_get, queued, stub_kea
 from .utils import _PLUGINS_CONFIG, User, _make_db_server
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -65,15 +65,6 @@ _SAMPLE_RESERVATION6 = {
 #   delete POST: ``reservation-del``.
 
 
-def _res_page(hosts, *, next_from=0, next_source=0):
-    """A ``reservation-get-page`` result: *hosts* plus Kea's pagination cursor.
-
-    ``next_from``/``next_source`` both 0 marks the source exhausted, so
-    ``iter_reservations`` stops after this page.
-    """
-    return {"result": 0, "arguments": {"hosts": hosts, "next": {"from": next_from, "source-index": next_source}}}
-
-
 #: ``reservation-get-page`` with no hosts (source exhausted → empty reservation list).
 _RES_EMPTY_PAGE = {"result": 3}
 #: ``lease{v}-get-all`` with no active leases in the subnet (result 3 = empty).
@@ -93,23 +84,6 @@ def _list_stub6(hosts=None):
     if hosts is None:
         hosts = [dict(_SAMPLE_RESERVATION6)]
     return stub_kea({"reservation-get-page": _res_page(hosts), "lease6-get-all": _LEASE_NONE6})
-
-
-def _subnet_get(version, pools=None, subnet_id=1):
-    """A ``subnet{v}-get`` result for the reservation-add pool-overlap probe.
-
-    *pools* is a list of pool range strings (e.g. ``["192.168.1.50-192.168.1.200"]``);
-    the probe warns only when the reservation IP falls inside one of them.
-    """
-    return {
-        "result": 0,
-        "arguments": {f"subnet{version}": [{"id": subnet_id, "pools": [{"pool": p} for p in (pools or [])]}]},
-    }
-
-
-def _res_get(reservation):
-    """A ``reservation-get`` result: the host fields Kea returns directly inside ``arguments``."""
-    return {"result": 0, "arguments": dict(reservation)}
 
 
 #: ``reservation-get`` / ``lease{v}-get`` with result 3 = no such record.

--- a/netbox_kea/tests/test_sync_views.py
+++ b/netbox_kea/tests/test_sync_views.py
@@ -35,7 +35,7 @@ from ipam.models import IPAddress as NbIP
 
 from netbox_kea.models import Server
 
-from .kea_stub import _res_page, stub_kea
+from .kea_stub import _res_page, _subnet_list, stub_kea
 
 User = get_user_model()
 
@@ -65,11 +65,6 @@ def _reservation_get(hostname, **extra):
         return {"result": 0, "arguments": {"ip-address": ip, "hostname": hostname, "subnet-id": 1, **extra}}
 
     return _resp
-
-
-def _subnet_list(version, cidr):
-    """A ``subnet{v}-list`` payload with one subnet (so reservation_get_by_ip finds it)."""
-    return {"result": 0, "arguments": {"subnets": [{"id": 1, "subnet": cidr}]}}
 
 
 def _make_server(**kwargs) -> Server:
@@ -233,7 +228,7 @@ class TestReservation4SyncView(_SyncViewBase):
         super().setUp()
         self._start_stub(
             {
-                "subnet4-list": _subnet_list(4, "10.0.0.0/24"),
+                "subnet4-list": _subnet_list(4, [{"id": 1, "subnet": "10.0.0.0/24"}]),
                 "reservation-get": _reservation_get("mock-res.local", **{"hw-address": "aa:bb:cc:00:00:02"}),
             }
         )
@@ -281,7 +276,7 @@ class TestReservation6SyncView(_SyncViewBase):
         super().setUp()
         self._start_stub(
             {
-                "subnet6-list": _subnet_list(6, "2001:db8:1::/64"),
+                "subnet6-list": _subnet_list(6, [{"id": 1, "subnet": "2001:db8:1::/64"}]),
                 "reservation-get": _reservation_get("mock-v6res.local", duid="01:02:03:04"),
             }
         )

--- a/netbox_kea/tests/test_sync_views.py
+++ b/netbox_kea/tests/test_sync_views.py
@@ -15,19 +15,27 @@ Each endpoint accepts POST with:
 
 Returns an HTMX HTML fragment (<td> content) with a link to the new/updated
 NetBox IPAddress, or an error message if something went wrong.
+
+These tests drive the **real** ``KeaClient`` and the **real** sync functions
+(``sync_lease_to_netbox`` / ``sync_reservation_to_netbox``) — they assert the
+NetBox ``IPAddress`` rows those create. Only the HTTP boundary to Kea is stubbed
+via ``kea_stub.stub_kea``:
+
+* single lease sync       → ``lease{v}-get`` (echoes the posted IP back)
+* single reservation sync → ``subnet{v}-list`` + ``reservation-get``
+* bulk reservation sync   → ``reservation-get-page``
 """
 
 from __future__ import annotations
-
-from unittest.mock import MagicMock, patch
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from ipam.models import IPAddress as NbIP
 
-from netbox_kea.kea import KeaClient
 from netbox_kea.models import Server
+
+from .kea_stub import stub_kea
 
 User = get_user_model()
 
@@ -35,8 +43,38 @@ _PLUGINS_CONFIG = {"netbox_kea": {"kea_timeout": 30}}
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Helpers
+# Helpers — echo the queried IP back so the real sync creates the matching NbIP
 # ─────────────────────────────────────────────────────────────────────────────
+
+
+def _lease_get(hostname, **extra):
+    """Build a ``lease{v}-get`` callable that echoes the queried ip-address."""
+
+    def _resp(body):
+        ip = body["arguments"]["ip-address"]
+        return {"result": 0, "arguments": {"ip-address": ip, "hostname": hostname, "subnet-id": 1, **extra}}
+
+    return _resp
+
+
+def _reservation_get(hostname, **extra):
+    """Build a ``reservation-get`` callable that echoes the queried ip-address."""
+
+    def _resp(body):
+        ip = body["arguments"]["ip-address"]
+        return {"result": 0, "arguments": {"ip-address": ip, "hostname": hostname, "subnet-id": 1, **extra}}
+
+    return _resp
+
+
+def _subnet_list(version, cidr):
+    """A ``subnet{v}-list`` payload with one subnet (so reservation_get_by_ip finds it)."""
+    return {"result": 0, "arguments": {"subnets": [{"id": 1, "subnet": cidr}]}}
+
+
+def _res_page(hosts):
+    """A single exhausted ``reservation-get-page`` payload."""
+    return {"result": 0, "arguments": {"hosts": hosts, "next": {"from": 0, "source-index": 0}}}
 
 
 def _make_server(**kwargs) -> Server:
@@ -62,6 +100,13 @@ class _SyncViewBase(TestCase):
         self.client.force_login(self.user)
         self.server = _make_server()
 
+    def _start_stub(self, responses):
+        """Enter a ``stub_kea`` context for the whole test and return the stub."""
+        cm = stub_kea(responses)
+        stub = cm.__enter__()
+        self.addCleanup(cm.__exit__, None, None, None)
+        return stub
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # TestLease4SyncView
@@ -74,20 +119,13 @@ class TestLease4SyncView(_SyncViewBase):
 
     def setUp(self):
         super().setUp()
-        self._kea_patcher = patch("netbox_kea.models.KeaClient")
-        self._mock_kea = self._kea_patcher.start()
-        self._mock_kea.return_value.lease_get_by_ip.side_effect = lambda ver, ip: {
-            "ip-address": ip,
-            "hostname": "mock-host.local",
-            "hw-address": "aa:bb:cc:00:00:01",
-            "valid-lft": 86400,
-            "cltt": 1700000000,
-            "subnet-id": 1,
-        }
-
-    def tearDown(self):
-        self._kea_patcher.stop()
-        super().tearDown()
+        self._start_stub(
+            {
+                "lease4-get": _lease_get(
+                    "mock-host.local", **{"hw-address": "aa:bb:cc:00:00:01", "valid-lft": 86400, "cltt": 1700000000}
+                )
+            }
+        )
 
     def _url(self):
         return reverse("plugins:netbox_kea:server_lease4_sync", args=[self.server.pk])
@@ -153,20 +191,9 @@ class TestLease6SyncView(_SyncViewBase):
 
     def setUp(self):
         super().setUp()
-        self._kea_patcher = patch("netbox_kea.models.KeaClient")
-        self._mock_kea = self._kea_patcher.start()
-        self._mock_kea.return_value.lease_get_by_ip.side_effect = lambda ver, ip: {
-            "ip-address": ip,
-            "hostname": "mock-v6.local",
-            "duid": "01:02:03:04",
-            "valid-lft": 86400,
-            "cltt": 1700000000,
-            "subnet-id": 1,
-        }
-
-    def tearDown(self):
-        self._kea_patcher.stop()
-        super().tearDown()
+        self._start_stub(
+            {"lease6-get": _lease_get("mock-v6.local", duid="01:02:03:04", **{"valid-lft": 86400, "cltt": 1700000000})}
+        )
 
     def _url(self):
         return reverse("plugins:netbox_kea:server_lease6_sync", args=[self.server.pk])
@@ -209,18 +236,12 @@ class TestReservation4SyncView(_SyncViewBase):
 
     def setUp(self):
         super().setUp()
-        self._kea_patcher = patch("netbox_kea.models.KeaClient")
-        self._mock_kea = self._kea_patcher.start()
-        self._mock_kea.return_value.reservation_get_by_ip.side_effect = lambda ver, ip: {
-            "ip-address": ip,
-            "hostname": "mock-res.local",
-            "hw-address": "aa:bb:cc:00:00:02",
-            "subnet-id": 1,
-        }
-
-    def tearDown(self):
-        self._kea_patcher.stop()
-        super().tearDown()
+        self._start_stub(
+            {
+                "subnet4-list": _subnet_list(4, "10.0.0.0/24"),
+                "reservation-get": _reservation_get("mock-res.local", **{"hw-address": "aa:bb:cc:00:00:02"}),
+            }
+        )
 
     def _url(self):
         return reverse("plugins:netbox_kea:server_reservation4_sync", args=[self.server.pk])
@@ -263,18 +284,12 @@ class TestReservation6SyncView(_SyncViewBase):
 
     def setUp(self):
         super().setUp()
-        self._kea_patcher = patch("netbox_kea.models.KeaClient")
-        self._mock_kea = self._kea_patcher.start()
-        self._mock_kea.return_value.reservation_get_by_ip.side_effect = lambda ver, ip: {
-            "ip-address": ip,
-            "hostname": "mock-v6res.local",
-            "duid": "01:02:03:04",
-            "subnet-id": 1,
-        }
-
-    def tearDown(self):
-        self._kea_patcher.stop()
-        super().tearDown()
+        self._start_stub(
+            {
+                "subnet6-list": _subnet_list(6, "2001:db8:1::/64"),
+                "reservation-get": _reservation_get("mock-v6res.local", duid="01:02:03:04"),
+            }
+        )
 
     def _url(self):
         return reverse("plugins:netbox_kea:server_reservation6_sync", args=[self.server.pk])
@@ -310,42 +325,25 @@ class TestReservation4BulkSyncView(_SyncViewBase):
         return reverse("plugins:netbox_kea:server_reservation4_bulk_sync", args=[self.server.pk])
 
     def test_redirects_after_success(self):
-        mock_client = MagicMock(spec=KeaClient)
-        mock_client.reservation_get_page.return_value = (
-            [{"ip-address": "10.0.10.1", "hostname": "bulk-host", "subnet-id": 1}],
-            0,
-            0,
-        )
-        with patch("netbox_kea.models.KeaClient", return_value=mock_client):
+        hosts = [{"ip-address": "10.0.10.1", "hostname": "bulk-host", "subnet-id": 1}]
+        with stub_kea({"reservation-get-page": _res_page(hosts)}):
             response = self.client.post(self._url(), follow=False)
         # Must redirect back to reservations page
         self.assertIn(response.status_code, [302, 303])
 
     def test_creates_netbox_ips_for_all_reservations(self):
-
-        mock_client = MagicMock(spec=KeaClient)
-        mock_client.reservation_get_page.return_value = (
-            [
-                {"ip-address": "10.0.11.1", "hostname": "bulk-1", "subnet-id": 1},
-                {"ip-address": "10.0.11.2", "hostname": "bulk-2", "subnet-id": 1},
-            ],
-            0,
-            0,
-        )
-        with patch("netbox_kea.models.KeaClient", return_value=mock_client):
+        hosts = [
+            {"ip-address": "10.0.11.1", "hostname": "bulk-1", "subnet-id": 1},
+            {"ip-address": "10.0.11.2", "hostname": "bulk-2", "subnet-id": 1},
+        ]
+        with stub_kea({"reservation-get-page": _res_page(hosts)}):
             self.client.post(self._url())
         self.assertTrue(NbIP.objects.filter(address__startswith="10.0.11.1/").exists())
         self.assertTrue(NbIP.objects.filter(address__startswith="10.0.11.2/").exists())
 
     def test_created_ips_have_reserved_status(self):
-
-        mock_client = MagicMock(spec=KeaClient)
-        mock_client.reservation_get_page.return_value = (
-            [{"ip-address": "10.0.12.1", "hostname": "bulk-rsv", "subnet-id": 1}],
-            0,
-            0,
-        )
-        with patch("netbox_kea.models.KeaClient", return_value=mock_client):
+        hosts = [{"ip-address": "10.0.12.1", "hostname": "bulk-rsv", "subnet-id": 1}]
+        with stub_kea({"reservation-get-page": _res_page(hosts)}):
             self.client.post(self._url())
         ip = NbIP.objects.filter(address__startswith="10.0.12.1/").first()
         self.assertIsNotNone(ip)
@@ -396,19 +394,16 @@ class TestSyncViewPermissionChecks(_SyncViewBase):
         response = self.client.post(url, {"ip_address": "192.168.99.2"})
         self.assertEqual(response.status_code, 403)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_superuser_can_still_sync(self, MockKeaClient):
+    def test_superuser_can_still_sync(self):
         # self.user is superuser — should succeed as before
-        MockKeaClient.return_value.lease_get_by_ip.side_effect = lambda ver, ip: {
-            "ip-address": ip,
-            "hostname": "mock-host.local",
-            "hw-address": "aa:bb:cc:00:00:01",
-            "valid-lft": 86400,
-            "cltt": 1700000000,
-            "subnet-id": 1,
-        }
         url = reverse("plugins:netbox_kea:server_lease4_sync", args=[self.server.pk])
-        response = self.client.post(url, {"ip_address": "192.168.99.3"})
+        stub = {
+            "lease4-get": _lease_get(
+                "mock-host.local", **{"hw-address": "aa:bb:cc:00:00:01", "valid-lft": 86400, "cltt": 1700000000}
+            )
+        }
+        with stub_kea(stub):
+            response = self.client.post(url, {"ip_address": "192.168.99.3"})
         self.assertEqual(response.status_code, 200)
 
 
@@ -424,23 +419,11 @@ class TestReservation6BulkSyncView(_SyncViewBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_reservation6_bulk_sync", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_bulk_syncs_v6_reservations(self, MockKeaClient):
+    def test_post_bulk_syncs_v6_reservations(self):
         """Bulk sync v6 reservation creates an IPAddress with /128 prefix and reserved status."""
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_get_page.return_value = (
-            [
-                {
-                    "subnet-id": 1,
-                    "duid": "00:01:aa:bb",
-                    "ip-addresses": ["2001:db8::1"],
-                    "hostname": "host-v6",
-                }
-            ],
-            0,
-            0,
-        )
-        self.client.post(self._url())
+        hosts = [{"subnet-id": 1, "duid": "00:01:aa:bb", "ip-addresses": ["2001:db8::1"], "hostname": "host-v6"}]
+        with stub_kea({"reservation-get-page": _res_page(hosts)}):
+            self.client.post(self._url())
         ip = NbIP.objects.filter(address__startswith="2001:db8::1").first()
         self.assertIsNotNone(ip)
         self.assertEqual(ip.status, "reserved")
@@ -473,13 +456,11 @@ class TestReservationBulkSyncConflictProtection(_SyncViewBase):
         from django.contrib import messages as django_messages
 
         NbIP.objects.create(address="10.0.20.5/32", status="active", description="Router loopback")
-        mock_client = MagicMock(spec=KeaClient)
-        mock_client.reservation_get_page.return_value = (
-            [{"ip-address": "10.0.20.5", "hostname": "foreign", "subnet-id": 1}],
-            0,
-            0,
-        )
-        with patch("netbox_kea.models.KeaClient", return_value=mock_client):
+        hosts = [{"ip-address": "10.0.20.5", "hostname": "foreign", "subnet-id": 1}]
+        # follow=True lands on the reservations list, which re-drains reservation-get-page
+        # and enriches with lease4-get-all per subnet.
+        stub = {"reservation-get-page": _res_page(hosts), "lease4-get-all": {"result": 0, "arguments": {"leases": []}}}
+        with stub_kea(stub):
             response = self.client.post(self._url(), follow=True)
 
         # Foreign IP left untouched.
@@ -492,16 +473,12 @@ class TestReservationBulkSyncConflictProtection(_SyncViewBase):
 
     def test_managed_ip_still_synced_alongside_conflict(self):
         NbIP.objects.create(address="10.0.20.6/32", status="active", description="Router loopback")
-        mock_client = MagicMock(spec=KeaClient)
-        mock_client.reservation_get_page.return_value = (
-            [
-                {"ip-address": "10.0.20.6", "hostname": "foreign", "subnet-id": 1},
-                {"ip-address": "10.0.20.7", "hostname": "managed", "subnet-id": 1},
-            ],
-            0,
-            0,
-        )
-        with patch("netbox_kea.models.KeaClient", return_value=mock_client):
+        hosts = [
+            {"ip-address": "10.0.20.6", "hostname": "foreign", "subnet-id": 1},
+            {"ip-address": "10.0.20.7", "hostname": "managed", "subnet-id": 1},
+        ]
+        stub = {"reservation-get-page": _res_page(hosts), "lease4-get-all": {"result": 0, "arguments": {"leases": []}}}
+        with stub_kea(stub):
             self.client.post(self._url(), follow=True)
 
         # Foreign untouched, the other reservation claimed normally.

--- a/netbox_kea/tests/test_sync_views.py
+++ b/netbox_kea/tests/test_sync_views.py
@@ -35,7 +35,7 @@ from ipam.models import IPAddress as NbIP
 
 from netbox_kea.models import Server
 
-from .kea_stub import stub_kea
+from .kea_stub import _res_page, stub_kea
 
 User = get_user_model()
 
@@ -70,11 +70,6 @@ def _reservation_get(hostname, **extra):
 def _subnet_list(version, cidr):
     """A ``subnet{v}-list`` payload with one subnet (so reservation_get_by_ip finds it)."""
     return {"result": 0, "arguments": {"subnets": [{"id": 1, "subnet": cidr}]}}
-
-
-def _res_page(hosts):
-    """A single exhausted ``reservation-get-page`` payload."""
-    return {"result": 0, "arguments": {"hosts": hosts, "next": {"from": 0, "source-index": 0}}}
 
 
 def _make_server(**kwargs) -> Server:
@@ -424,7 +419,7 @@ class TestReservation6BulkSyncView(_SyncViewBase):
         hosts = [{"subnet-id": 1, "duid": "00:01:aa:bb", "ip-addresses": ["2001:db8::1"], "hostname": "host-v6"}]
         with stub_kea({"reservation-get-page": _res_page(hosts)}):
             self.client.post(self._url())
-        ip = NbIP.objects.filter(address__startswith="2001:db8::1").first()
+        ip = NbIP.objects.filter(address__startswith="2001:db8::1/").first()
         self.assertIsNotNone(ip)
         self.assertEqual(ip.status, "reserved")
         self.assertIn("/128", str(ip.address))

--- a/netbox_kea/tests/test_views_combined.py
+++ b/netbox_kea/tests/test_views_combined.py
@@ -6,115 +6,113 @@ Also contains pure-Python unit tests for helper functions defined in views.py
 (e.g. ``_extract_identifier``), which do not require a database but live here
 because they are tightly coupled to view logic.
 
-These tests verify correct HTTP responses and redirect behaviour for every view.
-All Kea HTTP calls are mocked so no running Kea instance is required.
-
-Test organisation strategy
---------------------------
-Each view class gets its own ``TestCase`` subclass so failures are isolated and
-clearly named.  Every test that triggers a redirect asserts that the redirect URL
-contains an *integer* pk (never the string "None"), which is the pattern that
-revealed the original ``POST /plugins/kea/servers/None`` 404 bug.
-
-View tests use ``django.test.TestCase`` because they write to the test database
-(user + server fixtures).  Server objects are created via ``Server.objects.create()``
-which does **not** call ``Model.clean()`` and therefore does not trigger live Kea
-connectivity checks.
+These tests drive the **real** ``KeaClient``; only the HTTP boundary is stubbed
+via ``kea_stub.stub_kea``, so the combined multi-server fetch helpers exercise the
+real request/response path.
 """
-
-from unittest.mock import patch
 
 from django.test import override_settings
 from django.urls import reverse
 
+from .kea_stub import queued, stub_kea
 from .utils import _PLUGINS_CONFIG, _ViewTestBase
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestFetchSharedNetworksFromServer(_ViewTestBase):
-    """Line 3939: _fetch_shared_networks_from_server with null config raises RuntimeError."""
+    """_fetch_shared_networks_from_server with null config-get arguments raises RuntimeError."""
 
     def test_null_config_raises_runtime_error(self):
         from netbox_kea.views import _fetch_shared_networks_from_server
 
-        with patch("netbox_kea.models.KeaClient") as MockKea:
-            MockKea.return_value.command.return_value = [{"result": 0, "arguments": None}]
+        with stub_kea({"config-get": [{"result": 0, "arguments": None}]}):
             with self.assertRaises(RuntimeError):
                 _fetch_shared_networks_from_server(self.server, version=4)
 
 
 # ---------------------------------------------------------------------------
-# Combined reservations — multi-page pagination
+# Combined fetch helpers — response-shape guards
 # ---------------------------------------------------------------------------
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestCombinedResponseShapeGuards(_ViewTestBase):
-    """Malformed Kea responses (empty list / non-dict entry) must raise RuntimeError.
+    """An empty Kea response list must raise RuntimeError before indexing ``resp[0]``.
 
     ``KeaClient.command`` only guarantees a *list*; ``check_response`` iterating an
-    empty list raises nothing, so indexing ``resp[0]["result"]`` / ``config[0][...]``
-    blows up with ``IndexError``/``TypeError``. The sibling subnet/option/server
-    views guard this with ``isinstance(resp, list) and resp and isinstance(resp[0],
-    dict)`` and raise ``RuntimeError``; these combined helpers must do the same
-    (CLAUDE.md: "Validate Kea response shape before indexing … raise RuntimeError").
-    """
+    empty list raises nothing, so a helper that indexes ``resp[0]["result"]`` would
+    blow up with ``IndexError``. These combined helpers guard with
+    ``_require_first_entry`` and raise ``RuntimeError`` instead (CLAUDE.md: "Validate
+    Kea response shape before indexing … raise RuntimeError").
 
-    def _patched(self, command_return):
-        p = patch("netbox_kea.models.KeaClient")
-        mock = p.start()
-        self.addCleanup(p.stop)
-        mock.return_value.command.return_value = command_return
-        return mock
+    A *non-dict* first entry (e.g. ``["not-a-dict"]``) is not exercised here: with the
+    real client it never reaches the helper's guard because ``check_response`` (which
+    every one of these commands runs with ``check=(0, 3)``) indexes ``entry["result"]``
+    first and raises on the non-subscriptable entry. The empty-list case below covers
+    the ``_require_first_entry`` guard through a response the real client can produce.
+    """
 
     def test_leases_empty_response_raises_runtime_error(self):
         from netbox_kea import constants
         from netbox_kea.views import _fetch_leases_from_server
 
-        self._patched([])
-        with self.assertRaises(RuntimeError):
-            _fetch_leases_from_server(self.server, "10.0.0.1", constants.BY_IP, 4)
+        with stub_kea({"lease4-get": []}):
+            with self.assertRaises(RuntimeError):
+                _fetch_leases_from_server(self.server, "10.0.0.1", constants.BY_IP, 4)
 
-    def test_all_leases_non_dict_entry_raises_runtime_error(self):
+    def test_all_leases_empty_response_raises_runtime_error(self):
         from netbox_kea.views import _fetch_all_leases_from_server
 
-        self._patched(["not-a-dict"])
-        with self.assertRaises(RuntimeError):
-            _fetch_all_leases_from_server(self.server, 4)
+        with stub_kea({"lease4-get-page": []}):
+            with self.assertRaises(RuntimeError):
+                _fetch_all_leases_from_server(self.server, 4)
 
     def test_subnets_empty_response_raises_runtime_error(self):
         from netbox_kea.views import _fetch_subnets_from_server
 
-        self._patched([])
-        with self.assertRaises(RuntimeError):
-            _fetch_subnets_from_server(self.server, 4)
+        with stub_kea({"config-get": []}):
+            with self.assertRaises(RuntimeError):
+                _fetch_subnets_from_server(self.server, 4)
 
     def test_shared_networks_empty_response_raises_runtime_error(self):
         from netbox_kea.views import _fetch_shared_networks_from_server
 
-        self._patched([])
-        with self.assertRaises(RuntimeError):
-            _fetch_shared_networks_from_server(self.server, 4)
+        with stub_kea({"config-get": []}):
+            with self.assertRaises(RuntimeError):
+                _fetch_shared_networks_from_server(self.server, 4)
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestCombinedReservationsMultiPage(_ViewTestBase):
-    """Lines 4065-4066: combined reservations multi-page pagination."""
+    """Combined reservations must follow reservation-get-page across multiple pages."""
 
     def _url(self):
         return reverse("plugins:netbox_kea:combined_reservations4") + f"?server={self.server.pk}"
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_multi_page_pagination_followed(self, MockKeaClient):
-        """Lines 4065-4066: from_index/source_index advance across pages."""
-        page1 = [{"subnet-id": 1, "ip-address": "10.0.0.1", "hw-address": "aa:bb:cc:dd:ee:01"}]
-        page2 = [{"subnet-id": 1, "ip-address": "10.0.0.2", "hw-address": "aa:bb:cc:dd:ee:02"}]
-        MockKeaClient.return_value.reservation_get_page.side_effect = [
-            (page1, 1, 1),
-            (page2, 0, 0),
-        ]
-        response = self.client.get(self._url())
+    def test_multi_page_pagination_followed(self):
+        """from/source-index advance across pages until the cursor is exhausted."""
+        page1 = {
+            "result": 0,
+            "arguments": {
+                "hosts": [{"subnet-id": 1, "ip-address": "10.0.0.1", "hw-address": "aa:bb:cc:dd:ee:01"}],
+                "next": {"from": 1, "source-index": 1},  # not exhausted
+            },
+        }
+        page2 = {
+            "result": 0,
+            "arguments": {
+                "hosts": [{"subnet-id": 1, "ip-address": "10.0.0.2", "hw-address": "aa:bb:cc:dd:ee:02"}],
+                "next": {"from": 0, "source-index": 0},  # exhausted
+            },
+        }
+        stub = {
+            "reservation-get-page": queued(page1, page2),
+            # active-lease badge enrichment queries lease4-get-all per unique subnet
+            "lease4-get-all": {"result": 0, "arguments": {"leases": []}},
+        }
+        with stub_kea(stub) as kea:
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(MockKeaClient.return_value.reservation_get_page.call_count, 2)
+        self.assertEqual(len(kea.bodies("reservation-get-page")), 2)
         self.assertIn(b"10.0.0.1", response.content)
         self.assertIn(b"10.0.0.2", response.content)

--- a/netbox_kea/tests/test_views_dhcp_control.py
+++ b/netbox_kea/tests/test_views_dhcp_control.py
@@ -1,34 +1,52 @@
 # SPDX-FileCopyrightText: 2025 Marcin Zieba <marcinpsk@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
-"""View tests for netbox_kea plugin.
+"""DHCP enable/disable control-view tests for the netbox_kea plugin.
 
-Also contains pure-Python unit tests for helper functions defined in views.py
-(e.g. ``_extract_identifier``), which do not require a database but live here
-because they are tightly coupled to view logic.
+Covers ``ServerDHCP{4,6}EnableView`` and ``ServerDHCP{4,6}DisableView``.
 
-These tests verify correct HTTP responses and redirect behaviour for every view.
-All Kea HTTP calls are mocked so no running Kea instance is required.
+These tests drive the **real** ``KeaClient``; only the HTTP boundary is stubbed
+via ``kea_stub.stub_kea``, so the request payloads the views actually send to Kea
+are asserted:
 
-Test organisation strategy
---------------------------
-Each view class gets its own ``TestCase`` subclass so failures are isolated and
-clearly named.  Every test that triggers a redirect asserts that the redirect URL
-contains an *integer* pk (never the string "None"), which is the pattern that
-revealed the original ``POST /plugins/kea/servers/None`` 404 bug.
+* enable  → ``dhcp-enable``  (``service=["dhcp{v}"]``)
+* disable → ``dhcp-disable`` (``service=["dhcp{v}"]``; ``{"max-period": N}`` only
+  when a period is supplied — omitted otherwise)
 
-View tests use ``django.test.TestCase`` because they write to the test database
-(user + server fixtures).  Server objects are created via ``Server.objects.create()``
-which does **not** call ``Model.clean()`` and therefore does not trigger live Kea
-connectivity checks.
+Error paths run through the real client: a ``{"result": 1}`` response becomes a
+real ``KeaException`` and a boundary ``requests.RequestException`` a transport
+error; the view flashes a generic message and must not leak the raw Kea text. The
+error tests follow the redirect onto the status tab, which itself issues
+``status-get``/``version-get``/``config-get`` — registered benign so the landing
+page renders.
 """
-
-from unittest.mock import patch
 
 import requests
 from django.test import override_settings
 from django.urls import reverse
 
-from .utils import _PLUGINS_CONFIG, _kea_command_side_effect, _ViewTestBase
+from .kea_stub import stub_kea
+from .utils import _PLUGINS_CONFIG, _ViewTestBase
+
+
+def _config_get_empty(body):
+    """A benign ``config-get`` payload for the status-tab landing (global options)."""
+    svc = (body.get("service") or [""])[0]
+    version = 6 if svc == "dhcp6" else 4
+    key = f"Dhcp{version}"
+    return {"result": 0, "arguments": {key: {"option-data": [], f"subnet{version}": [], "shared-networks": []}}}
+
+
+def _control_stub(**overrides):
+    """Register dhcp-enable/-disable plus the status-tab landing commands (all benign)."""
+    base = {
+        "dhcp-enable": {"result": 0},
+        "dhcp-disable": {"result": 0},
+        "status-get": {"result": 0, "arguments": {"pid": 1, "uptime": 1, "reload": 0}},
+        "version-get": {"result": 0, "arguments": {"extended": "2.5"}},
+        "config-get": _config_get_empty,
+    }
+    base.update(overrides)
+    return stub_kea(base)
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
@@ -38,48 +56,36 @@ class TestServerDHCP4EnableView(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_dhcp4_enable", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_returns_confirmation_page(self, MockKeaClient):
-        """GET must render the enable confirmation page with dhcp_version=4."""
-        response = self.client.get(self._url())
+    def test_get_returns_confirmation_page(self):
+        """GET must render the enable confirmation page with dhcp_version=4 (no Kea)."""
+        with stub_kea({}) as kea:
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "4")
+        self.assertEqual(kea.commands(), [])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_calls_dhcp_enable_and_redirects(self, MockKeaClient):
-        """POST must call dhcp_enable('dhcp4') and redirect to status tab."""
-        mock_client = MockKeaClient.return_value
-        mock_client.dhcp_enable.return_value = None
-        response = self.client.post(self._url())
+    def test_post_calls_dhcp_enable_and_redirects(self):
+        """POST must issue dhcp-enable to the dhcp4 service and redirect to the status tab."""
+        with _control_stub() as kea:
+            response = self.client.post(self._url())
         self.assertEqual(response.status_code, 302)
         self._assert_no_none_pk_redirect(response)
-        mock_client.dhcp_enable.assert_called_once_with("dhcp4")
+        self.assertEqual(kea.bodies("dhcp-enable")[0]["service"], ["dhcp4"])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_on_kea_exception_shows_error_and_redirects(self, MockKeaClient):
+    def test_post_on_kea_exception_shows_error_and_redirects(self):
         """POST with KeaException must flash a generic error; raw Kea text must not be leaked."""
-        from netbox_kea.kea import KeaException
-
-        mock_client = MockKeaClient.return_value
-        mock_client.command.side_effect = _kea_command_side_effect
-        mock_client.dhcp_enable.side_effect = KeaException(
-            {"result": 1, "text": "kea_secret_internal_url=https://kea.internal:8080/api/"},
-            index=0,
-        )
-        response = self.client.post(self._url(), follow=True)
+        secret = "kea_secret_internal_url=https://kea.internal:8080/api/"
+        with _control_stub(**{"dhcp-enable": {"result": 1, "text": secret}}):
+            response = self.client.post(self._url(), follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertNotIn("kea_secret_internal_url", response.content.decode())
         self.assertIn("Failed to enable DHCPv4:", response.content.decode())
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_on_unexpected_exception_shows_error_and_redirects(self, MockKeaClient):
+    def test_post_on_unexpected_exception_shows_error_and_redirects(self):
         """POST with transport exception must not leak the raw exception text."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.side_effect = _kea_command_side_effect
-        mock_client.dhcp_enable.side_effect = requests.RequestException(
-            "kea_secret_transport_marker=https://kea.internal/"
-        )
-        response = self.client.post(self._url(), follow=True)
+        marker = "kea_secret_transport_marker=https://kea.internal/"
+        with _control_stub(**{"dhcp-enable": requests.RequestException(marker)}):
+            response = self.client.post(self._url(), follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertNotIn("kea_secret_transport_marker", response.content.decode())
         self.assertIn("An internal error occurred.", response.content.decode())
@@ -99,19 +105,17 @@ class TestServerDHCP4EnableView(_ViewTestBase):
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestServerDHCP6EnableView(_ViewTestBase):
-    """Tests for ServerDHCP6EnableView — verifies v6 variant uses dhcp6 service."""
+    """Tests for ServerDHCP6EnableView — verifies v6 variant uses the dhcp6 service."""
 
     def _url(self):
         return reverse("plugins:netbox_kea:server_dhcp6_enable", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_calls_dhcp_enable_v6(self, MockKeaClient):
-        """POST must call dhcp_enable('dhcp6')."""
-        mock_client = MockKeaClient.return_value
-        mock_client.dhcp_enable.return_value = None
-        response = self.client.post(self._url())
+    def test_post_calls_dhcp_enable_v6(self):
+        """POST must issue dhcp-enable to the dhcp6 service."""
+        with _control_stub() as kea:
+            response = self.client.post(self._url())
         self.assertEqual(response.status_code, 302)
-        mock_client.dhcp_enable.assert_called_once_with("dhcp6")
+        self.assertEqual(kea.bodies("dhcp-enable")[0]["service"], ["dhcp6"])
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
@@ -121,65 +125,55 @@ class TestServerDHCP4DisableView(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_dhcp4_disable", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_returns_form_page(self, MockKeaClient):
-        """GET must render the disable form with max_period field."""
-        response = self.client.get(self._url())
+    def test_get_returns_form_page(self):
+        """GET must render the disable form with max_period field (no Kea)."""
+        with stub_kea({}) as kea:
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "max_period")
+        self.assertEqual(kea.commands(), [])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_without_max_period_calls_disable_no_period(self, MockKeaClient):
-        """POST without max_period must call dhcp_disable(service) with max_period=None."""
-        mock_client = MockKeaClient.return_value
-        mock_client.dhcp_disable.return_value = None
-        response = self.client.post(self._url(), {"confirm": "1"})
+    def test_post_without_max_period_calls_disable_no_period(self):
+        """POST without max_period must issue dhcp-disable with no max-period argument."""
+        with _control_stub() as kea:
+            response = self.client.post(self._url(), {"confirm": "1"})
         self.assertEqual(response.status_code, 302)
         self._assert_no_none_pk_redirect(response)
-        mock_client.dhcp_disable.assert_called_once_with("dhcp4", max_period=None)
+        body = kea.bodies("dhcp-disable")[0]
+        self.assertEqual(body["service"], ["dhcp4"])
+        self.assertNotIn("arguments", body)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_with_max_period_passes_value(self, MockKeaClient):
-        """POST with max_period=300 must pass max_period=300 to dhcp_disable."""
-        mock_client = MockKeaClient.return_value
-        mock_client.dhcp_disable.return_value = None
-        response = self.client.post(self._url(), {"confirm": "1", "max_period": "300"})
+    def test_post_with_max_period_passes_value(self):
+        """POST with max_period=300 must send {"max-period": 300} to dhcp-disable."""
+        with _control_stub() as kea:
+            response = self.client.post(self._url(), {"confirm": "1", "max_period": "300"})
         self.assertEqual(response.status_code, 302)
         self._assert_no_none_pk_redirect(response)
-        mock_client.dhcp_disable.assert_called_once_with("dhcp4", max_period=300)
+        body = kea.bodies("dhcp-disable")[0]
+        self.assertEqual(body["service"], ["dhcp4"])
+        self.assertEqual(body["arguments"], {"max-period": 300})
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_with_invalid_max_period_rerenders_form(self, MockKeaClient):
-        """POST with non-integer max_period must re-render the form (not redirect)."""
-        response = self.client.post(self._url(), {"confirm": "1", "max_period": "not-a-number"})
+    def test_post_with_invalid_max_period_rerenders_form(self):
+        """POST with non-integer max_period must re-render the form (no Kea call)."""
+        with stub_kea({}) as kea:
+            response = self.client.post(self._url(), {"confirm": "1", "max_period": "not-a-number"})
         self.assertEqual(response.status_code, 200)
-        MockKeaClient.return_value.dhcp_disable.assert_not_called()
+        self.assertNotIn("dhcp-disable", kea.commands())
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_on_kea_exception_shows_error_and_redirects(self, MockKeaClient):
+    def test_post_on_kea_exception_shows_error_and_redirects(self):
         """POST with KeaException must flash a generic error; raw Kea text must not be leaked."""
-        from netbox_kea.kea import KeaException
-
-        mock_client = MockKeaClient.return_value
-        mock_client.command.side_effect = _kea_command_side_effect
-        mock_client.dhcp_disable.side_effect = KeaException(
-            {"result": 1, "text": "kea_secret_internal_url=https://kea.internal:8080/api/"},
-            index=0,
-        )
-        response = self.client.post(self._url(), {"confirm": "1"}, follow=True)
+        secret = "kea_secret_internal_url=https://kea.internal:8080/api/"
+        with _control_stub(**{"dhcp-disable": {"result": 1, "text": secret}}):
+            response = self.client.post(self._url(), {"confirm": "1"}, follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertNotIn("kea_secret_internal_url", response.content.decode())
         self.assertIn("Failed to disable DHCPv4:", response.content.decode())
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_on_unexpected_exception_shows_error_and_redirects(self, MockKeaClient):
+    def test_post_on_unexpected_exception_shows_error_and_redirects(self):
         """POST with transport exception must not leak the raw exception text."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.side_effect = _kea_command_side_effect
-        mock_client.dhcp_disable.side_effect = requests.RequestException(
-            "kea_secret_transport_marker=https://kea.internal/"
-        )
-        response = self.client.post(self._url(), {"confirm": "1"}, follow=True)
+        marker = "kea_secret_transport_marker=https://kea.internal/"
+        with _control_stub(**{"dhcp-disable": requests.RequestException(marker)}):
+            response = self.client.post(self._url(), {"confirm": "1"}, follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertNotIn("kea_secret_transport_marker", response.content.decode())
         self.assertIn("An internal error occurred.", response.content.decode())
@@ -199,16 +193,16 @@ class TestServerDHCP4DisableView(_ViewTestBase):
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestServerDHCP6DisableView(_ViewTestBase):
-    """Tests for ServerDHCP6DisableView — verifies v6 variant uses dhcp6 service."""
+    """Tests for ServerDHCP6DisableView — verifies v6 variant uses the dhcp6 service."""
 
     def _url(self):
         return reverse("plugins:netbox_kea:server_dhcp6_disable", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_calls_dhcp_disable_v6(self, MockKeaClient):
-        """POST must call dhcp_disable('dhcp6')."""
-        mock_client = MockKeaClient.return_value
-        mock_client.dhcp_disable.return_value = None
-        response = self.client.post(self._url(), {"confirm": "1"})
+    def test_post_calls_dhcp_disable_v6(self):
+        """POST must issue dhcp-disable to the dhcp6 service with no max-period argument."""
+        with _control_stub() as kea:
+            response = self.client.post(self._url(), {"confirm": "1"})
         self.assertEqual(response.status_code, 302)
-        mock_client.dhcp_disable.assert_called_once_with("dhcp6", max_period=None)
+        body = kea.bodies("dhcp-disable")[0]
+        self.assertEqual(body["service"], ["dhcp6"])
+        self.assertNotIn("arguments", body)

--- a/netbox_kea/tests/test_views_dual_url.py
+++ b/netbox_kea/tests/test_views_dual_url.py
@@ -8,20 +8,21 @@ that calls ``server.get_client(version=self.dhcp_version)`` must construct
 ``ca_url``.
 
 These tests create a server with all three URLs set to different values, then
-hit representative views for each protocol version and assert that
-``KeaClient.__init__`` received the expected URL.
+hit representative views for each protocol version and assert — via the real
+``KeaClient`` and the HTTP-boundary stub (``kea_stub.stub_kea``) — that the
+request was POSTed to the expected endpoint. ``KeaHttpStub.urls()`` records every
+endpoint hit, so a dual-URL regression (falling back to ``ca_url``) fails the test.
 
 Closes: https://github.com/marcinpsk/netbox-kea/issues/40
 """
-
-from unittest.mock import patch
 
 from django.test import TestCase, override_settings
 from django.urls import reverse
 
 from netbox_kea.models import Server
 
-from .utils import _PLUGINS_CONFIG, User, _kea_command_side_effect
+from .kea_stub import stub_kea
+from .utils import _PLUGINS_CONFIG, User
 
 # Distinct URLs so we can tell which one was selected.
 _SERVER_URL = "https://kea-default.example.com"
@@ -44,22 +45,33 @@ def _make_dual_url_server(**kwargs) -> Server:
     return Server.objects.create(**defaults)
 
 
-def _assert_keaclient_url(test_case, MockKeaClient, expected_url):
-    """Assert KeaClient was instantiated with the expected URL at least once."""
-    test_case.assertTrue(
-        MockKeaClient.called,
-        "KeaClient was never instantiated — the view may not have called get_client().",
-    )
-    actual_urls = []
-    for call in MockKeaClient.call_args_list:
-        url = call.kwargs.get("url") if call.kwargs else None
-        if url is None and call.args:
-            url = call.args[0]
-        actual_urls.append(url)
-    test_case.assertIn(
-        expected_url,
-        actual_urls,
-        f"KeaClient was never instantiated with {expected_url!r}. All calls: {MockKeaClient.call_args_list}",
+def _config_get(body):
+    """A benign ``config-get`` payload (empty subnets/networks/options) for the queried service."""
+    svc = (body.get("service") or [""])[0]
+    version = 6 if svc == "dhcp6" else 4
+    key = f"Dhcp{version}"
+    block = {f"subnet{version}": [], "shared-networks": [], "option-data": [], "option-def": []}
+    return {"result": 0, "arguments": {key: block}}
+
+
+def _dual_url_stub():
+    """Register the union of commands the representative views issue, all benign.
+
+    Enough for each view to build its per-version client and POST at least once, so
+    ``kea.urls()`` records the endpoint. Empty/absent results keep the views on their
+    happy path (200) or a graceful redirect (302).
+    """
+    return stub_kea(
+        {
+            "config-get": _config_get,
+            "stat-lease4-get": {"result": 2, "text": "unknown command"},
+            "stat-lease6-get": {"result": 2, "text": "unknown command"},
+            "lease4-get-page": {"result": 3},
+            "lease6-get-page": {"result": 3},
+            "reservation-get-page": {"result": 3},
+            "lease4-get-all": {"result": 0, "arguments": {"leases": []}},
+            "lease6-get-all": {"result": 0, "arguments": {"leases": []}},
+        }
     )
 
 
@@ -85,23 +97,21 @@ class _DualURLBase(TestCase):
 class TestDualURLSubnetViews(_DualURLBase):
     """Subnet views must use dhcp4_url for v4 and dhcp6_url for v6."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_subnets4_uses_dhcp4_url(self, MockKeaClient):
-        """GET subnets4 → KeaClient constructed with dhcp4_url."""
-        MockKeaClient.return_value.command.side_effect = _kea_command_side_effect
+    def test_subnets4_uses_dhcp4_url(self):
+        """GET subnets4 → request POSTed to dhcp4_url."""
         url = reverse("plugins:netbox_kea:server_subnets4", args=[self.server.pk])
-        response = self.client.get(url)
+        with _dual_url_stub() as kea:
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        _assert_keaclient_url(self, MockKeaClient, _DHCP4_URL)
+        self.assertIn(_DHCP4_URL, kea.urls())
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_subnets6_uses_dhcp6_url(self, MockKeaClient):
-        """GET subnets6 → KeaClient constructed with dhcp6_url."""
-        MockKeaClient.return_value.command.side_effect = _kea_command_side_effect
+    def test_subnets6_uses_dhcp6_url(self):
+        """GET subnets6 → request POSTed to dhcp6_url."""
         url = reverse("plugins:netbox_kea:server_subnets6", args=[self.server.pk])
-        response = self.client.get(url)
+        with _dual_url_stub() as kea:
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        _assert_keaclient_url(self, MockKeaClient, _DHCP6_URL)
+        self.assertIn(_DHCP6_URL, kea.urls())
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
@@ -113,111 +123,99 @@ class TestDualURLLeaseViews(_DualURLBase):
     ``get_client(version=...)``.
     """
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_leases4_uses_dhcp4_url(self, MockKeaClient):
-        """Export leases4 → KeaClient constructed with dhcp4_url."""
-        MockKeaClient.return_value.command.side_effect = _kea_command_side_effect
+    def test_leases4_uses_dhcp4_url(self):
+        """Export leases4 → request POSTed to dhcp4_url."""
         url = reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
-        response = self.client.get(url, {"export": "1", "by": "subnet", "q": "10.0.0.0/24"})
+        with _dual_url_stub() as kea:
+            response = self.client.get(url, {"export": "1", "by": "subnet", "q": "10.0.0.0/24"})
         self.assertIn(response.status_code, (200, 302))
-        _assert_keaclient_url(self, MockKeaClient, _DHCP4_URL)
+        self.assertIn(_DHCP4_URL, kea.urls())
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_leases6_uses_dhcp6_url(self, MockKeaClient):
-        """Export leases6 → KeaClient constructed with dhcp6_url."""
-        MockKeaClient.return_value.command.side_effect = _kea_command_side_effect
+    def test_leases6_uses_dhcp6_url(self):
+        """Export leases6 → request POSTed to dhcp6_url."""
         url = reverse("plugins:netbox_kea:server_leases6", args=[self.server.pk])
-        response = self.client.get(url, {"export": "1", "by": "subnet", "q": "2001:db8::/64"})
+        with _dual_url_stub() as kea:
+            response = self.client.get(url, {"export": "1", "by": "subnet", "q": "2001:db8::/64"})
         self.assertIn(response.status_code, (200, 302))
-        _assert_keaclient_url(self, MockKeaClient, _DHCP6_URL)
+        self.assertIn(_DHCP6_URL, kea.urls())
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestDualURLOptionViews(_DualURLBase):
     """Option views must use dhcp4_url for v4 and dhcp6_url for v6."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_option_defs4_uses_dhcp4_url(self, MockKeaClient):
-        """GET option-defs4 → KeaClient constructed with dhcp4_url."""
-        MockKeaClient.return_value.command.side_effect = _kea_command_side_effect
+    def test_option_defs4_uses_dhcp4_url(self):
+        """GET option-defs4 → request POSTed to dhcp4_url."""
         url = reverse("plugins:netbox_kea:server_option_def4", args=[self.server.pk])
-        response = self.client.get(url)
+        with _dual_url_stub() as kea:
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        _assert_keaclient_url(self, MockKeaClient, _DHCP4_URL)
+        self.assertIn(_DHCP4_URL, kea.urls())
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_option_defs6_uses_dhcp6_url(self, MockKeaClient):
-        """GET option-defs6 → KeaClient constructed with dhcp6_url."""
-        MockKeaClient.return_value.command.side_effect = _kea_command_side_effect
+    def test_option_defs6_uses_dhcp6_url(self):
+        """GET option-defs6 → request POSTed to dhcp6_url."""
         url = reverse("plugins:netbox_kea:server_option_def6", args=[self.server.pk])
-        response = self.client.get(url)
+        with _dual_url_stub() as kea:
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        _assert_keaclient_url(self, MockKeaClient, _DHCP6_URL)
+        self.assertIn(_DHCP6_URL, kea.urls())
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_server_options4_uses_dhcp4_url(self, MockKeaClient):
-        """GET server-options4 → KeaClient constructed with dhcp4_url."""
-        MockKeaClient.return_value.command.side_effect = _kea_command_side_effect
+    def test_server_options4_uses_dhcp4_url(self):
+        """GET server-options4 → request POSTed to dhcp4_url."""
         url = reverse("plugins:netbox_kea:server_dhcp4_options_edit", args=[self.server.pk])
-        response = self.client.get(url)
+        with _dual_url_stub() as kea:
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        _assert_keaclient_url(self, MockKeaClient, _DHCP4_URL)
+        self.assertIn(_DHCP4_URL, kea.urls())
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_server_options6_uses_dhcp6_url(self, MockKeaClient):
-        """GET server-options6 → KeaClient constructed with dhcp6_url."""
-        MockKeaClient.return_value.command.side_effect = _kea_command_side_effect
+    def test_server_options6_uses_dhcp6_url(self):
+        """GET server-options6 → request POSTed to dhcp6_url."""
         url = reverse("plugins:netbox_kea:server_dhcp6_options_edit", args=[self.server.pk])
-        response = self.client.get(url)
+        with _dual_url_stub() as kea:
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        _assert_keaclient_url(self, MockKeaClient, _DHCP6_URL)
+        self.assertIn(_DHCP6_URL, kea.urls())
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestDualURLReservationViews(_DualURLBase):
     """Reservation views must use dhcp4_url for v4 and dhcp6_url for v6."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_reservations4_uses_dhcp4_url(self, MockKeaClient):
-        """GET reservations4 → KeaClient constructed with dhcp4_url."""
-        MockKeaClient.return_value.command.side_effect = _kea_command_side_effect
-        MockKeaClient.return_value.reservation_get_page.return_value = ([], 0, 0)
+    def test_reservations4_uses_dhcp4_url(self):
+        """GET reservations4 → request POSTed to dhcp4_url."""
         url = reverse("plugins:netbox_kea:server_reservations4", args=[self.server.pk])
-        response = self.client.get(url)
+        with _dual_url_stub() as kea:
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        _assert_keaclient_url(self, MockKeaClient, _DHCP4_URL)
+        self.assertIn(_DHCP4_URL, kea.urls())
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_reservations6_uses_dhcp6_url(self, MockKeaClient):
-        """GET reservations6 → KeaClient constructed with dhcp6_url."""
-        MockKeaClient.return_value.command.side_effect = _kea_command_side_effect
-        MockKeaClient.return_value.reservation_get_page.return_value = ([], 0, 0)
+    def test_reservations6_uses_dhcp6_url(self):
+        """GET reservations6 → request POSTed to dhcp6_url."""
         url = reverse("plugins:netbox_kea:server_reservations6", args=[self.server.pk])
-        response = self.client.get(url)
+        with _dual_url_stub() as kea:
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        _assert_keaclient_url(self, MockKeaClient, _DHCP6_URL)
+        self.assertIn(_DHCP6_URL, kea.urls())
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestDualURLFallback(_DualURLBase):
     """When protocol-specific URL is not set, fall back to ca_url."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_v4_falls_back_to_server_url(self, MockKeaClient):
+    def test_v4_falls_back_to_server_url(self):
         """When dhcp4_url is empty, v4 views use ca_url."""
         server = _make_dual_url_server(name="v4-fallback", dhcp4_url="", dhcp6_url=_DHCP6_URL)
-        MockKeaClient.return_value.command.side_effect = _kea_command_side_effect
         url = reverse("plugins:netbox_kea:server_subnets4", args=[server.pk])
-        response = self.client.get(url)
+        with _dual_url_stub() as kea:
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        _assert_keaclient_url(self, MockKeaClient, _SERVER_URL)
+        self.assertIn(_SERVER_URL, kea.urls())
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_v6_falls_back_to_server_url(self, MockKeaClient):
+    def test_v6_falls_back_to_server_url(self):
         """When dhcp6_url is empty, v6 views use ca_url."""
         server = _make_dual_url_server(name="v6-fallback", dhcp4_url=_DHCP4_URL, dhcp6_url="")
-        MockKeaClient.return_value.command.side_effect = _kea_command_side_effect
         url = reverse("plugins:netbox_kea:server_subnets6", args=[server.pk])
-        response = self.client.get(url)
+        with _dual_url_stub() as kea:
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        _assert_keaclient_url(self, MockKeaClient, _SERVER_URL)
+        self.assertIn(_SERVER_URL, kea.urls())

--- a/netbox_kea/tests/test_views_leases.py
+++ b/netbox_kea/tests/test_views_leases.py
@@ -1967,8 +1967,18 @@ class TestFetchLeasesFromServer(_ViewTestBase):
 
         if resp is None:
             resp = [{"result": 0, "arguments": {"leases": [{"ip-address": "10.0.0.1", "valid-lft": 3600, "state": 0}]}}]
-        with patch("netbox_kea.models.KeaClient") as MockKea:
-            MockKea.return_value.command.return_value = resp
+        payload = resp[0] if isinstance(resp, list) else resp
+        # _fetch_leases_from_server picks the command from `by`; register every
+        # lease-get variant to the same payload so whichever it issues is covered.
+        variants = [
+            f"lease{version}-get",
+            f"lease{version}-get-by-hw-address",
+            f"lease{version}-get-by-hostname",
+            f"lease{version}-get-by-client-id",
+            f"lease{version}-get-all",
+            f"lease{version}-get-by-duid",
+        ]
+        with stub_kea(dict.fromkeys(variants, payload)):
             return _fetch_leases_from_server(self.server, q, by, version)
 
     def test_by_hw_address(self):
@@ -2009,8 +2019,7 @@ class TestFetchLeasesFromServer(_ViewTestBase):
         from netbox_kea import constants
         from netbox_kea.views import _fetch_leases_from_server
 
-        with patch("netbox_kea.models.KeaClient") as MockKea:
-            MockKea.return_value.command.return_value = [{"result": 0, "arguments": None}]
+        with stub_kea({"lease4-get-by-hostname": {"result": 0, "arguments": None}}):
             with self.assertRaises(RuntimeError):
                 _fetch_leases_from_server(self.server, "ghost", constants.BY_HOSTNAME, 4)
 
@@ -2035,8 +2044,10 @@ class TestFetchAllLeasesFromServer(_ViewTestBase):
     def _run(self, responses, max_leases=1000):
         from netbox_kea.views import _fetch_all_leases_from_server
 
-        with patch("netbox_kea.models.KeaClient") as MockKea:
-            MockKea.return_value.command.side_effect = iter(responses)
+        # Each element of *responses* is a one-service Kea reply list; unwrap to the
+        # single dict and feed them as a FIFO on lease4-get-page (the last repeats).
+        page_responses = [r[0] for r in responses]
+        with stub_kea({"lease4-get-page": page_responses}):
             return _fetch_all_leases_from_server(self.server, version=4, max_leases=max_leases)
 
     def test_result_3_stops_loop(self):
@@ -2105,11 +2116,15 @@ class TestFetchReservationByIP(_ViewTestBase):
     def _run(self, pages):
         from netbox_kea.views import _fetch_reservation_by_ip
 
-        with patch("netbox_kea.models.KeaClient") as MockKea:
-            side = iter(pages)
-            MockKea.return_value.reservation_get_page.side_effect = lambda *a, **kw: next(side)
-            result, available = _fetch_reservation_by_ip(MockKea.return_value, version=4)
-            return result, available
+        # Each *pages* entry is a (hosts, next_from, next_source) tuple as returned by
+        # reservation_get_page; rebuild the raw reservation-get-page replies it parses.
+        responses = [
+            {"result": 0, "arguments": {"hosts": hosts, "next": {"from": nf, "source-index": ns}}}
+            for (hosts, nf, ns) in pages
+        ]
+        client = self.server.get_client(version=4)
+        with stub_kea({"reservation-get-page": responses}):
+            return _fetch_reservation_by_ip(client, version=4)
 
     def test_single_ip_reservation(self):
         """Line 3530: reservation with ip-address key."""
@@ -2156,57 +2171,48 @@ class TestFetchReservationByIP(_ViewTestBase):
 class TestEnrichLeasesExceptionPaths2(_ViewTestBase):
     """Lines 3611-3619: enrich leases exception handling in combined leases view."""
 
+    # by=ip is a single-result search, so arguments is the lease dict itself.
+    _LEASE4 = {"result": 0, "arguments": {"ip-address": "10.0.0.1", "valid-lft": 3600, "state": 0, "subnet-id": 1}}
+
     def _url(self):
         return reverse("plugins:netbox_kea:combined_leases4") + f"?servers={self.server.pk}&q=10.0.0.1&by=ip"
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_kea_exception_result2_sets_hook_unavailable(self, MockKeaClient):
+    def test_kea_exception_result2_sets_hook_unavailable(self):
         """Lines 3612-3616: KeaException result=2 → host_cmds_available=False."""
         from netbox_kea.kea import KeaException
 
-        MockKeaClient.return_value.command.return_value = [
-            {
-                "result": 0,
-                "arguments": {"leases": [{"ip-address": "10.0.0.1", "valid-lft": 3600, "state": 0, "subnet-id": 1}]},
-            }
-        ]
-        with patch(
-            "netbox_kea.views.leases._fetch_reservation_by_ip_for_leases",
-            side_effect=KeaException({"result": 2, "text": "hook not loaded"}, index=0),
+        with (
+            stub_kea({"lease4-get": self._LEASE4}),
+            patch(
+                "netbox_kea.views.leases._fetch_reservation_by_ip_for_leases",
+                side_effect=KeaException({"result": 2, "text": "hook not loaded"}, index=0),
+            ),
         ):
             response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_kea_exception_non_result2_continues(self, MockKeaClient):
+    def test_kea_exception_non_result2_continues(self):
         """Lines 3612-3616: KeaException result≠2 → logged, host_cmds=False."""
         from netbox_kea.kea import KeaException
 
-        MockKeaClient.return_value.command.return_value = [
-            {
-                "result": 0,
-                "arguments": {"leases": [{"ip-address": "10.0.0.1", "valid-lft": 3600, "state": 0, "subnet-id": 1}]},
-            }
-        ]
-        with patch(
-            "netbox_kea.views.leases._fetch_reservation_by_ip_for_leases",
-            side_effect=KeaException({"result": 1, "text": "other error"}, index=0),
+        with (
+            stub_kea({"lease4-get": self._LEASE4}),
+            patch(
+                "netbox_kea.views.leases._fetch_reservation_by_ip_for_leases",
+                side_effect=KeaException({"result": 1, "text": "other error"}, index=0),
+            ),
         ):
             response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_generic_exception_continues(self, MockKeaClient):
+    def test_generic_exception_continues(self):
         """Lines 3617-3619: generic Exception from _fetch_reservation_by_ip_for_leases is handled."""
-        MockKeaClient.return_value.command.return_value = [
-            {
-                "result": 0,
-                "arguments": {"leases": [{"ip-address": "10.0.0.1", "valid-lft": 3600, "state": 0, "subnet-id": 1}]},
-            }
-        ]
-        with patch(
-            "netbox_kea.views.leases._fetch_reservation_by_ip_for_leases",
-            side_effect=RuntimeError("unexpected crash"),
+        with (
+            stub_kea({"lease4-get": self._LEASE4}),
+            patch(
+                "netbox_kea.views.leases._fetch_reservation_by_ip_for_leases",
+                side_effect=RuntimeError("unexpected crash"),
+            ),
         ):
             response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
@@ -2230,29 +2236,31 @@ class TestLeaseBulkImportEdgeCases(_ViewTestBase):
         self.assertEqual(response.status_code, 200)
 
     @patch("netbox_kea.views.sync_views.parse_lease_csv")
-    @patch("netbox_kea.models.KeaClient")
-    def test_parse_error_shows_form_error(self, MockKeaClient, mock_parse):
+    def test_parse_error_shows_form_error(self, mock_parse):
         """Lines 4617-4619: ValueError from parse_lease_csv adds generic form error (no raw exception text)."""
         import io
 
         mock_parse.side_effect = ValueError("bad column")
         csv_file = io.BytesIO(b"ip-address\n10.0.0.1")
         csv_file.name = "leases.csv"
-        response = self.client.post(self._url(), {"csv_file": csv_file})
+        # Parse fails before any client call — empty registry proves no Kea command runs.
+        with stub_kea({}) as kea:
+            response = self.client.post(self._url(), {"csv_file": csv_file})
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(kea.commands(), [])
         self.assertContains(response, "parsing failed")
         self.assertNotContains(response, "bad column")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_generic_exception_is_row_error(self, MockKeaClient):
+    def test_generic_exception_is_row_error(self):
         """Generic exceptions from lease_add are caught per-row (not propagated)."""
         import io
 
-        MockKeaClient.return_value.lease_add.side_effect = AttributeError("bug")
         csv_content = b"ip-address\n10.0.0.1"
         csv_file = io.BytesIO(csv_content)
         csv_file.name = "leases.csv"
-        response = self.client.post(self._url(), {"csv_file": csv_file})
+        # An unexpected error type from lease4-add is caught per-row by the import loop.
+        with stub_kea({"lease4-add": AttributeError("bug")}):
+            response = self.client.post(self._url(), {"csv_file": csv_file})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["result"]["errors"], 1)
         self.assertEqual(
@@ -2270,55 +2278,49 @@ class TestLeaseBulkImportEdgeCases(_ViewTestBase):
 class TestGetLeasesPageEdgeCases(_ViewTestBase):
     """Edge cases in BaseServerLeasesView.get_leases_page()."""
 
+    _CONFIG4 = {"result": 0, "arguments": {"Dhcp4": {"subnet4": [{"id": 1, "subnet": "10.0.0.0/24"}]}}}
+
     def _url(self):
         return reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_zero_network_uses_network_as_start(self, MockKeaClient):
+    def test_zero_network_uses_network_as_start(self):
         """Line 464: subnet.network == 0 → frm = str(subnet.network) = '0.0.0.0'."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = [{"result": 0, "arguments": {"count": 0, "leases": []}}]
         # 0.0.0.0/8: int(network) == 0 → line 464 fires
-        response = self.client.get(
-            self._url(),
-            {"by": "subnet", "q": "0.0.0.0/8"},
-            HTTP_HX_REQUEST="true",
-        )
+        with stub_kea(
+            {"config-get": self._CONFIG4, "lease4-get-page": {"result": 0, "arguments": {"count": 0, "leases": []}}}
+        ):
+            response = self.client.get(
+                self._url(),
+                {"by": "subnet", "q": "0.0.0.0/8"},
+                HTTP_HX_REQUEST="true",
+            )
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_null_args_raises_runtime_error(self, MockKeaClient):
+    def test_null_args_raises_runtime_error(self):
         """Line 480: lease-get-page returns arguments=None → RuntimeError (caught by HTMX handler)."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = [{"result": 0, "arguments": None}]
-        response = self.client.get(
-            self._url(),
-            {"by": "subnet", "q": "10.0.0.0/24"},
-            HTTP_HX_REQUEST="true",
-        )
+        with stub_kea({"config-get": self._CONFIG4, "lease4-get-page": {"result": 0, "arguments": None}}):
+            response = self.client.get(
+                self._url(),
+                {"by": "subnet", "q": "10.0.0.0/24"},
+                HTTP_HX_REQUEST="true",
+            )
         # RuntimeError is caught by outer except → HTMX error partial
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_lease_outside_subnet_truncates_list(self, MockKeaClient):
+    def test_lease_outside_subnet_truncates_list(self):
         """Lines 487-489: lease IP not in queried subnet → raw_leases truncated."""
-        mock_client = MockKeaClient.return_value
         per_page = 25
-        # Return per_page leases where the only one is OUTSIDE the queried subnet
-        mock_client.command.return_value = [
-            {
-                "result": 0,
-                "arguments": {
-                    "count": per_page,
-                    "leases": [{"ip-address": "10.0.1.1", "valid-lft": 3600, "state": 0}],
-                },
-            }
-        ]
-        response = self.client.get(
-            self._url(),
-            {"by": "subnet", "q": "10.0.0.0/24"},
-            HTTP_HX_REQUEST="true",
-        )
+        # Return per_page leases where the only one is OUTSIDE the queried subnet.
+        page = {
+            "result": 0,
+            "arguments": {"count": per_page, "leases": [{"ip-address": "10.0.1.1", "valid-lft": 3600, "state": 0}]},
+        }
+        with stub_kea({"config-get": self._CONFIG4, "lease4-get-page": page}):
+            response = self.client.get(
+                self._url(),
+                {"by": "subnet", "q": "10.0.0.0/24"},
+                HTTP_HX_REQUEST="true",
+            )
         self.assertEqual(response.status_code, 200)
 
 

--- a/netbox_kea/tests/test_views_leases.py
+++ b/netbox_kea/tests/test_views_leases.py
@@ -2334,35 +2334,29 @@ class TestGetLeasesPageAllLeasesMode(_ViewTestBase):
     ``subnet is None`` branch was otherwise unexercised.
     """
 
+    _CONFIG4 = {"result": 0, "arguments": {"Dhcp4": {"subnet4": []}}}
+    _CONFIG6 = {"result": 0, "arguments": {"Dhcp6": {"subnet6": []}}}
+    _EMPTY_PAGE = {"result": 0, "arguments": {"count": 0, "leases": []}}
+
     def _url4(self):
         return reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
 
     def _url6(self):
         return reverse("plugins:netbox_kea:server_leases6", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_all_leases_v4_starts_from_zero_address(self, MockKeaClient):
+    def test_all_leases_v4_starts_from_zero_address(self):
         """``by=""`` on the v4 view must call lease4-get-page with ``from="0.0.0.0"``."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = [{"result": 0, "arguments": {"count": 0, "leases": []}}]
-
-        response = self.client.get(self._url4(), {"by": ""}, HTTP_HX_REQUEST="true")
-
+        with stub_kea({"config-get": self._CONFIG4, "lease4-get-page": self._EMPTY_PAGE}) as kea:
+            response = self.client.get(self._url4(), {"by": ""}, HTTP_HX_REQUEST="true")
         self.assertEqual(response.status_code, 200)
-        page_call = next(c for c in mock_client.command.call_args_list if c.args[0] == "lease4-get-page")
-        self.assertEqual(page_call.kwargs["arguments"]["from"], "0.0.0.0")
+        self.assertEqual(kea.bodies("lease4-get-page")[0]["arguments"]["from"], "0.0.0.0")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_all_leases_v6_starts_from_unspecified_address(self, MockKeaClient):
+    def test_all_leases_v6_starts_from_unspecified_address(self):
         """``by=""`` on the v6 view must call lease6-get-page with ``from="::"``."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = [{"result": 0, "arguments": {"count": 0, "leases": []}}]
-
-        response = self.client.get(self._url6(), {"by": ""}, HTTP_HX_REQUEST="true")
-
+        with stub_kea({"config-get": self._CONFIG6, "lease6-get-page": self._EMPTY_PAGE}) as kea:
+            response = self.client.get(self._url6(), {"by": ""}, HTTP_HX_REQUEST="true")
         self.assertEqual(response.status_code, 200)
-        page_call = next(c for c in mock_client.command.call_args_list if c.args[0] == "lease6-get-page")
-        self.assertEqual(page_call.kwargs["arguments"]["from"], "::")
+        self.assertEqual(kea.bodies("lease6-get-page")[0]["arguments"]["from"], "::")
 
 
 # ---------------------------------------------------------------------------
@@ -2390,16 +2384,15 @@ class TestGetLeasesCoverage(_ViewTestBase):
         with self.assertRaises(AbortRequest):
             view.get_leases(mock_client, "test_query", "not_a_valid_by")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_null_args_from_lease_get_raises_runtime_error(self, MockKeaClient):
+    def test_null_args_from_lease_get_raises_runtime_error(self):
         """Line 535: lease-get returns arguments=None → RuntimeError (caught by HTMX handler)."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = [{"result": 0, "arguments": None}]
-        response = self.client.get(
-            self._url(),
-            {"by": "ip", "q": "10.0.0.1"},
-            HTTP_HX_REQUEST="true",
-        )
+        config = {"result": 0, "arguments": {"Dhcp4": {"subnet4": []}}}
+        with stub_kea({"config-get": config, "lease4-get": {"result": 0, "arguments": None}}):
+            response = self.client.get(
+                self._url(),
+                {"by": "ip", "q": "10.0.0.1"},
+                HTTP_HX_REQUEST="true",
+            )
         # RuntimeError is caught by outer except → HTMX error partial, still 200
         self.assertEqual(response.status_code, 200)
 
@@ -2422,12 +2415,10 @@ class TestGetExportCoverage(_ViewTestBase):
         response = self.client.get(self._url(), {"export": "1", "by": "INVALID_VALUE", "q": "test"})
         self.assertIn(response.status_code, [200, 302])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_export_all_null_args_returns_csv(self, MockKeaClient):
+    def test_export_all_null_args_returns_csv(self):
         """Line 618: export_all lease-get-page returns arguments=None → break → empty CSV."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = [{"result": 0, "arguments": None}]
-        response = self.client.get(self._url(), {"export_all": "1"})
+        with stub_kea({"lease4-get-page": {"result": 0, "arguments": None}}):
+            response = self.client.get(self._url(), {"export_all": "1"})
         # Should return CSV even when args is None (empty export)
         self.assertIn(response.status_code, [200, 302])
 
@@ -2441,16 +2432,17 @@ class TestGetExportCoverage(_ViewTestBase):
 class TestHTMXInvalidFormCoverage(_ViewTestBase):
     """Lines 649-650: HTMX GET with invalid form → renders HTMX partial."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_htmx_invalid_form_returns_partial(self, MockKeaClient):
+    def test_htmx_invalid_form_returns_partial(self):
         """form.is_valid()==False for HTMX → renders server_dhcp_leases_htmx.html."""
         url = reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
-        # 'by' has an invalid choice value → form.is_valid() returns False
-        response = self.client.get(
-            url,
-            {"by": "INVALID_CHOICE", "q": "test"},
-            HTTP_HX_REQUEST="true",
-        )
+        config = {"result": 0, "arguments": {"Dhcp4": {"subnet4": []}}}
+        # 'by' has an invalid choice value → form.is_valid() returns False (no lease fetch).
+        with stub_kea({"config-get": config}):
+            response = self.client.get(
+                url,
+                {"by": "INVALID_CHOICE", "q": "test"},
+                HTTP_HX_REQUEST="true",
+            )
         self.assertEqual(response.status_code, 200)
 
 
@@ -2463,28 +2455,27 @@ class TestHTMXInvalidFormCoverage(_ViewTestBase):
 class TestLease6EditDuid(_ViewTestBase):
     """Lines 952-953: POST lease6 edit with duid → duid added to kwargs."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_with_duid_calls_lease_update(self, MockKeaClient):
+    def test_post_with_duid_calls_lease_update(self):
         """duid field in POST → kwargs['duid'] is set and lease_update called."""
-        mock_client = MockKeaClient.return_value
-        mock_client.lease_update.return_value = None
         url = reverse(
             "plugins:netbox_kea:server_lease6_edit",
             args=[self.server.pk, "2001:db8::1"],
         )
-        response = self.client.post(
-            url,
-            {
-                "duid": "01:02:03:04",
-                "valid_lft": "",
-                "hostname": "",
-            },
-        )
+        # lease_update reads the current lease (lease6-get) then writes lease6-update.
+        current = {"result": 0, "arguments": {"ip-address": "2001:db8::1", "duid": "00:00", "valid-lft": 3600}}
+        with stub_kea({"lease6-get": current, "lease6-update": {"result": 0}}) as kea:
+            response = self.client.post(
+                url,
+                {
+                    "duid": "01:02:03:04",
+                    "valid_lft": "",
+                    "hostname": "",
+                },
+            )
         # Should redirect to leases6 URL
         self.assertIn(response.status_code, [302, 200])
-        mock_client.lease_update.assert_called_once()
-        _, call_kwargs = mock_client.lease_update.call_args
-        self.assertEqual(call_kwargs.get("duid"), "01:02:03:04")
+        self.assertIn("lease6-update", kea.commands())
+        self.assertEqual(kea.bodies("lease6-update")[0]["arguments"]["duid"], "01:02:03:04")
 
 
 # ---------------------------------------------------------------------------
@@ -2496,26 +2487,18 @@ class TestLease6EditDuid(_ViewTestBase):
 class TestFetchOneEmptyLease(_ViewTestBase):
     """Line 3561: _fetch_one returns early when lease has no subnet_id."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_lease_without_subnet_id_skips_reservation_lookup(self, MockKeaClient):
+    def test_lease_without_subnet_id_skips_reservation_lookup(self):
         """Lease without subnet-id → _fetch_one returns (ip, None, True) without API call."""
-        mock_client = MockKeaClient.return_value
-        # Return a lease with ip-address but NO subnet-id
-        mock_client.command.return_value = [
-            {
-                "result": 0,
-                "arguments": {
-                    "ip-address": "10.0.0.1",
-                    "valid-lft": 3600,
-                    "state": 0,
-                    "hostname": "testhost",
-                    # deliberately omit "subnet-id"
-                },
-            }
-        ]
-        mock_client.reservation_get.return_value = None
+        config = {"result": 0, "arguments": {"Dhcp4": {"subnet4": []}}}
+        # A lease with ip-address but NO subnet-id → enrichment issues no reservation-get
+        # (an empty registry for reservation-get would raise if it were called).
+        lease = {
+            "result": 0,
+            "arguments": {"ip-address": "10.0.0.1", "valid-lft": 3600, "state": 0, "hostname": "testhost"},
+        }
         url = reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
-        response = self.client.get(url, {"by": "ip", "q": "10.0.0.1"}, HTTP_HX_REQUEST="true")
+        with stub_kea({"config-get": config, "lease4-get": lease}):
+            response = self.client.get(url, {"by": "ip", "q": "10.0.0.1"}, HTTP_HX_REQUEST="true")
         self.assertEqual(response.status_code, 200)
 
 
@@ -2560,51 +2543,42 @@ class TestLeasePartialDelete(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_leases4_delete", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_continues_after_first_delete_error(self, MockKeaClient):
+    # A followed redirect lands on the leases page, which fetches the subnet quick-select.
+    _CONFIG4 = {"result": 0, "arguments": {"Dhcp4": {"subnet4": []}}}
+
+    def test_continues_after_first_delete_error(self):
         """When the first IP fails, the second IP is still deleted."""
-        from netbox_kea.kea import KeaException
-
-        mock_client = MockKeaClient.return_value
-        mock_client.command.side_effect = [
-            KeaException({"result": 1, "text": "not found", "arguments": None}, index=0),
-            None,
-        ]
-        response = self.client.post(
-            self._url(),
-            {"lease_ips": ["10.0.0.1", "10.0.0.2"], "_confirm": "1", "pk": ["10.0.0.1", "10.0.0.2"]},
-            follow=True,
-        )
+        # First lease4-del fails (result 1 → KeaException), second succeeds.
+        with stub_kea(
+            {"lease4-del": [{"result": 1, "text": "not found"}, {"result": 0}], "config-get": self._CONFIG4}
+        ) as kea:
+            response = self.client.post(
+                self._url(),
+                {"lease_ips": ["10.0.0.1", "10.0.0.2"], "_confirm": "1", "pk": ["10.0.0.1", "10.0.0.2"]},
+                follow=True,
+            )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(mock_client.command.call_count, 2)
+        self.assertEqual(kea.commands().count("lease4-del"), 2)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_success_message_shows_count_of_deleted(self, MockKeaClient):
+    def test_success_message_shows_count_of_deleted(self):
         """Success message reflects only the successfully deleted count."""
-        MockKeaClient.return_value.command.return_value = None
-        response = self.client.post(
-            self._url(),
-            {"lease_ips": ["10.0.0.1", "10.0.0.2"], "_confirm": "1", "pk": ["10.0.0.1", "10.0.0.2"]},
-            follow=True,
-        )
+        with stub_kea({"lease4-del": {"result": 0}, "config-get": self._CONFIG4}):
+            response = self.client.post(
+                self._url(),
+                {"lease_ips": ["10.0.0.1", "10.0.0.2"], "_confirm": "1", "pk": ["10.0.0.1", "10.0.0.2"]},
+                follow=True,
+            )
         msgs = [str(m) for m in response.context["messages"]]
         self.assertTrue(any("2" in m and "deleted" in m.lower() for m in msgs))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_partial_failure_shows_warning(self, MockKeaClient):
+    def test_partial_failure_shows_warning(self):
         """When some IPs fail, a warning message about partial failure is shown."""
-        from netbox_kea.kea import KeaException
-
-        mock_client = MockKeaClient.return_value
-        mock_client.command.side_effect = [
-            KeaException({"result": 1, "text": "not found", "arguments": None}, index=0),
-            None,
-        ]
-        response = self.client.post(
-            self._url(),
-            {"lease_ips": ["10.0.0.1", "10.0.0.2"], "_confirm": "1", "pk": ["10.0.0.1", "10.0.0.2"]},
-            follow=True,
-        )
+        with stub_kea({"lease4-del": [{"result": 1, "text": "not found"}, {"result": 0}], "config-get": self._CONFIG4}):
+            response = self.client.post(
+                self._url(),
+                {"lease_ips": ["10.0.0.1", "10.0.0.2"], "_confirm": "1", "pk": ["10.0.0.1", "10.0.0.2"]},
+                follow=True,
+            )
         msgs = [str(m) for m in response.context["messages"]]
         self.assertTrue(any("failed" in m.lower() or "error" in m.lower() for m in msgs))
 
@@ -2621,12 +2595,12 @@ class TestLeaseExportAllExceptNarrowing(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_attribute_error_propagates(self, MockKeaClient):
+    def test_attribute_error_propagates(self):
         """An AttributeError inside get_export_all must not be silently caught."""
-        MockKeaClient.return_value.command.side_effect = AttributeError("bad mock")
-        with self.assertRaises(AttributeError):
-            self.client.get(self._url(), {"export_all": "1"})
+        # get_export_all narrows its except clauses, so an AttributeError propagates.
+        with stub_kea({"lease4-get-page": AttributeError("bad stub")}):
+            with self.assertRaises(AttributeError):
+                self.client.get(self._url(), {"export_all": "1"})
 
 
 # ---------------------------------------------------------------------------
@@ -2639,12 +2613,10 @@ class TestEnrichLeasesFailedIpsSeeding(_ViewTestBase):
     """On enrichment error, all lease IPs are marked as indeterminate (failed_ips)."""
 
     @patch("netbox_kea.views.leases._fetch_reservation_by_ip_for_leases")
-    @patch("netbox_kea.models.KeaClient")
-    def test_reservation_enrichment_exception_does_not_show_not_reserved(self, MockKeaClient, mock_fetch_reservations):
+    def test_reservation_enrichment_exception_does_not_show_not_reserved(self, mock_fetch_reservations):
         """When reservation lookup raises an unexpected Exception, leases must not
         incorrectly appear as 'not reserved' (no create-reservation link shown)."""
-        mock_client = MockKeaClient.return_value
-
+        config = {"result": 0, "arguments": {"Dhcp4": {"subnet4": [{"id": 1, "subnet": "10.0.0.0/24"}]}}}
         raw_leases = [
             {
                 "ip-address": "10.0.0.1",
@@ -2655,14 +2627,13 @@ class TestEnrichLeasesFailedIpsSeeding(_ViewTestBase):
                 "hostname": "testhost",
             }
         ]
-        # subnet_id=1 search: client.command returns leases
-        mock_client.command.return_value = [{"result": 0, "arguments": {"leases": raw_leases}}]
         # Make reservation lookup raise an unexpected exception
         mock_fetch_reservations.side_effect = RuntimeError("unexpected enrichment failure")
 
         url = reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
-        # Use by=subnet_id so q="1" is a valid integer subnet ID (by=subnet requires CIDR)
-        response = self.client.get(url, HTTP_HX_REQUEST="true", data={"by": "subnet_id", "q": "1"})
+        # by=subnet_id → lease4-get-all with subnets=[1]; q="1" is a valid integer subnet ID.
+        with stub_kea({"config-get": config, "lease4-get-all": {"result": 0, "arguments": {"leases": raw_leases}}}):
+            response = self.client.get(url, HTTP_HX_REQUEST="true", data={"by": "subnet_id", "q": "1"})
 
         self.assertEqual(response.status_code, 200)
         # After fix: failed_ips is seeded with all lease IPs, so create-reservation link not shown
@@ -2677,8 +2648,7 @@ class TestLeaseExportStateFilter(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_state_filter_applied_to_export(self, MockKeaClient):
+    def test_state_filter_applied_to_export(self):
         """Exported CSV must contain only leases matching the requested state."""
         # Return two leases: one with state=0 (default/active), one with state=1 (declined)
         leases = [
@@ -2701,18 +2671,24 @@ class TestLeaseExportStateFilter(_ViewTestBase):
                 "state": 1,
             },
         ]
-        MockKeaClient.return_value.command.return_value = [{"result": 0, "arguments": {"leases": leases, "count": 2}}]
-
+        config = {"result": 0, "arguments": {"Dhcp4": {"subnet4": [{"id": 1, "subnet": "10.0.0.0/24"}]}}}
+        # Page 1 returns both leases; page 2 signals end-of-data (result 3) so the
+        # export pagination loop terminates regardless of the server's per-page size.
+        pages = [
+            {"result": 0, "arguments": {"leases": leases, "count": 2}},
+            {"result": 3, "arguments": None},
+        ]
         # Request export with state=1 (declined only)
-        response = self.client.get(
-            self._url(),
-            {
-                "export": "1",
-                "by": "subnet",
-                "q": "10.0.0.0/24",
-                "state": "1",
-            },
-        )
+        with stub_kea({"config-get": config, "lease4-get-page": pages}):
+            response = self.client.get(
+                self._url(),
+                {
+                    "export": "1",
+                    "by": "subnet",
+                    "q": "10.0.0.0/24",
+                    "state": "1",
+                },
+            )
         self.assertEqual(response.status_code, 200)
         content = response.content.decode()
         self.assertIn("10.0.0.2", content)

--- a/netbox_kea/tests/test_views_leases.py
+++ b/netbox_kea/tests/test_views_leases.py
@@ -1860,8 +1860,10 @@ class TestHTMXExceptionHandler(_ViewTestBase):
                 self._url() + "?q=10.0.0.1&by=ip",
                 HTTP_HX_REQUEST="true",
             )
-        # Must not crash — returns HTMX error partial
-        self.assertIn(response.status_code, (200, 500))
+        # Must not crash — the outer handler catches the RuntimeError and renders
+        # the HTMX error partial (never a 500; accepting 500 would let a regression
+        # where the handler stops catching the error pass unnoticed).
+        self.assertEqual(response.status_code, 200)
 
 
 # ---------------------------------------------------------------------------

--- a/netbox_kea/tests/test_views_leases.py
+++ b/netbox_kea/tests/test_views_leases.py
@@ -165,56 +165,56 @@ class TestReservedBadgeOnLeases(_ViewTestBase):
         "subnet-id": 1,
         "hostname": "testhost",
     }
+    # The lease-search page fetches the subnet quick-select via config-get first.
+    _CONFIG4 = {"result": 0, "arguments": {"Dhcp4": {"subnet4": [{"id": 1, "subnet": "192.168.1.0/24"}]}}}
 
     def _htmx_get(self, url, data):
         """Issue an HTMX GET request (adds HX-Request header)."""
         return self.client.get(url, data=data, HTTP_HX_REQUEST="true")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_reserved_badge_shown_when_reservation_exists(self, MockKeaClient):
+    def test_reserved_badge_shown_when_reservation_exists(self):
         """When a lease IP has a corresponding reservation, the table cell shows 'Reserved'."""
-        mock_client = MockKeaClient.return_value
-        # Lease search by IP
-        mock_client.command.return_value = [{"result": 0, "arguments": {"ip-address": "192.168.1.100", **self._LEASE4}}]
-        # Reservation lookup returns a matching reservation for this specific IP
-        mock_client.reservation_get.return_value = self._RESERVATION4
-
         url = reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
-        response = self._htmx_get(url, {"by": "ip", "q": "192.168.1.100"})
+        with stub_kea(
+            {
+                "config-get": self._CONFIG4,
+                "lease4-get": {"result": 0, "arguments": {"ip-address": "192.168.1.100", **self._LEASE4}},
+                "reservation-get": {"result": 0, "arguments": self._RESERVATION4},
+            }
+        ):
+            response = self._htmx_get(url, {"by": "ip", "q": "192.168.1.100"})
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Reserved")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_no_reserved_badge_when_no_reservation(self, MockKeaClient):
+    def test_no_reserved_badge_when_no_reservation(self):
         """When no reservation exists for the lease IP, no badge is rendered."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = [{"result": 0, "arguments": {"ip-address": "192.168.1.100", **self._LEASE4}}]
-        # No reservation found for this IP
-        mock_client.reservation_get.return_value = None
-
         url = reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
-        response = self._htmx_get(url, {"by": "ip", "q": "192.168.1.100"})
+        with stub_kea(
+            {
+                "config-get": self._CONFIG4,
+                "lease4-get": {"result": 0, "arguments": {"ip-address": "192.168.1.100", **self._LEASE4}},
+                "reservation-get": {"result": 3},  # not found
+            }
+        ):
+            response = self._htmx_get(url, {"by": "ip", "q": "192.168.1.100"})
 
         self.assertEqual(response.status_code, 200)
         # The column header says "Reserved" — check no badge link is rendered
         self.assertNotContains(response, 'text-decoration-none">Reserved</a>')
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_no_crash_when_host_cmds_unavailable(self, MockKeaClient):
+    def test_no_crash_when_host_cmds_unavailable(self):
         """When host_cmds is not loaded, reservation lookup is skipped and no badge shown."""
-        from netbox_kea.kea import KeaException
-
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = [{"result": 0, "arguments": {"ip-address": "192.168.1.100", **self._LEASE4}}]
-        # host_cmds not loaded — result=2 means unknown command
-        mock_client.reservation_get.side_effect = KeaException(
-            {"result": 2, "text": "unknown command 'reservation-get'"},
-            index=0,
-        )
-
         url = reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
-        response = self._htmx_get(url, {"by": "ip", "q": "192.168.1.100"})
+        with stub_kea(
+            {
+                "config-get": self._CONFIG4,
+                "lease4-get": {"result": 0, "arguments": {"ip-address": "192.168.1.100", **self._LEASE4}},
+                # host_cmds not loaded — result=2 (unknown command) makes reservation_get raise KeaException.
+                "reservation-get": {"result": 2, "text": "unknown command 'reservation-get'"},
+            }
+        ):
+            response = self._htmx_get(url, {"by": "ip", "q": "192.168.1.100"})
 
         # Must not 500; page renders normally without badge
         self.assertEqual(response.status_code, 200)

--- a/netbox_kea/tests/test_views_leases.py
+++ b/netbox_kea/tests/test_views_leases.py
@@ -399,27 +399,23 @@ class TestLeaseExport(_ViewTestBase):
         "valid-lft": 3600,
         "cltt": 1_700_000_000,
     }
+    # The export path builds the search form, which fetches the subnet quick-select.
+    _CONFIG4 = {"result": 0, "arguments": {"Dhcp4": {"subnet4": [{"id": 1, "subnet": "10.0.0.0/24"}]}}}
 
     def _url(self):
         return reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_export_all_returns_csv_content_type(self, MockKeaClient):
+    def test_export_all_returns_csv_content_type(self):
         """?export=all must respond with text/csv Content-Type."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = [{"result": 0, "arguments": {"ip-address": "10.0.0.5", **self._LEASE4}}]
-        mock_client.reservation_get_page.return_value = ([], 0, 0)
-        response = self.client.get(self._url(), {"export": "all", "by": "ip", "q": "10.0.0.5"})
+        with stub_kea({"config-get": self._CONFIG4, "lease4-get": {"result": 0, "arguments": dict(self._LEASE4)}}):
+            response = self.client.get(self._url(), {"export": "all", "by": "ip", "q": "10.0.0.5"})
         self.assertEqual(response.status_code, 200)
         self.assertIn("text/csv", response.get("Content-Type", ""))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_export_table_returns_csv(self, MockKeaClient):
+    def test_export_table_returns_csv(self):
         """?export=table must also return text/csv (selected columns)."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = [{"result": 0, "arguments": {"ip-address": "10.0.0.5", **self._LEASE4}}]
-        mock_client.reservation_get_page.return_value = ([], 0, 0)
-        response = self.client.get(self._url(), {"export": "table", "by": "ip", "q": "10.0.0.5"})
+        with stub_kea({"config-get": self._CONFIG4, "lease4-get": {"result": 0, "arguments": dict(self._LEASE4)}}):
+            response = self.client.get(self._url(), {"export": "table", "by": "ip", "q": "10.0.0.5"})
         self.assertEqual(response.status_code, 200)
         self.assertIn("text/csv", response.get("Content-Type", ""))
 
@@ -430,8 +426,7 @@ class TestLeaseExport(_ViewTestBase):
         self.assertEqual(response.status_code, 302)
         self._assert_no_none_pk_redirect(response)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_export_by_subnet_paginates_all_leases(self, MockKeaClient):
+    def test_export_by_subnet_paginates_all_leases(self):
         """?export=all&by=subnet must paginate until next_cursor is None."""
         page1_leases = [
             {
@@ -444,25 +439,25 @@ class TestLeaseExport(_ViewTestBase):
             }
             for i in range(1, 4)
         ]
-        call_count = {"n": 0}
-
-        def command_side_effect(cmd, **kwargs):
-            call_count["n"] += 1
-            if call_count["n"] == 1:
-                # First page: 3 leases; count == per_page (3) signals more data
-                return [{"result": 0, "arguments": {"leases": page1_leases, "count": 3}}]
-            # Second call returns empty — end of pagination
-            return [{"result": 3, "arguments": None}]
-
-        MockKeaClient.return_value.command.side_effect = command_side_effect
-        # Pass per_page=3 so that count(3) == per_page(3) triggers next-page fetch
-        response = self.client.get(
-            self._url(),
-            {"export": "all", "by": "subnet", "q": "10.0.0.0/24", "per_page": "3"},
-        )
+        # Page 1 returns 3 leases (count == per_page 3 → more data); page 2 returns
+        # result=3 (end). FIFO queue on lease4-get-page drives the pagination loop.
+        with stub_kea(
+            {
+                "config-get": self._CONFIG4,
+                "lease4-get-page": [
+                    {"result": 0, "arguments": {"leases": page1_leases, "count": 3}},
+                    {"result": 3, "arguments": None},
+                ],
+            }
+        ) as kea:
+            # Pass per_page=3 so that count(3) == per_page(3) triggers the next-page fetch.
+            response = self.client.get(
+                self._url(),
+                {"export": "all", "by": "subnet", "q": "10.0.0.0/24", "per_page": "3"},
+            )
         self.assertEqual(response.status_code, 200)
         self.assertIn("text/csv", response.get("Content-Type", ""))
-        self.assertGreaterEqual(call_count["n"], 2)
+        self.assertGreaterEqual(kea.commands().count("lease4-get-page"), 2)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -485,32 +480,27 @@ class TestLeaseDeleteFullFlow(_ViewTestBase):
         self.assertContains(response, "10.0.0.1")
         self.assertContains(response, "10.0.0.2")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_confirmed_calls_kea_and_redirects(self, MockKeaClient):
+    def test_post_confirmed_calls_kea_and_redirects(self):
         """POST with _confirm=1 must call Kea lease4-del and redirect."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = [{"result": 0}]
-        response = self.client.post(
-            self._url(),
-            {"pk": ["10.0.0.1"], "_confirm": "1"},
-        )
+        with stub_kea({"lease4-del": {"result": 0}}) as kea:
+            response = self.client.post(
+                self._url(),
+                {"pk": ["10.0.0.1"], "_confirm": "1"},
+            )
         self.assertEqual(response.status_code, 302)
         self._assert_no_none_pk_redirect(response)
-        # Verify Kea was called with the lease4-del command
-        cmd_names = [c.args[0] for c in mock_client.command.call_args_list]
-        self.assertIn("lease4-del", cmd_names)
+        # Verify Kea was called with the lease4-del command (real payload on the wire).
+        self.assertIn("lease4-del", kea.commands())
+        self.assertEqual(kea.bodies("lease4-del")[0]["arguments"], {"ip-address": "10.0.0.1"})
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_confirmed_kea_error_redirects_with_error_message(self, MockKeaClient):
+    def test_post_confirmed_kea_error_redirects_with_error_message(self):
         """When Kea returns an error during deletion, must redirect (not 500) and show error."""
-        from netbox_kea.kea import KeaException
-
-        mock_client = MockKeaClient.return_value
-        mock_client.command.side_effect = KeaException({"result": 1, "text": "lease not found"})
-        response = self.client.post(
-            self._url(),
-            {"pk": ["10.0.0.5"], "_confirm": "1"},
-        )
+        # result=1 makes the real KeaClient.command() raise KeaException (delete uses check=(0,3)).
+        with stub_kea({"lease4-del": {"result": 1, "text": "lease not found"}}):
+            response = self.client.post(
+                self._url(),
+                {"pk": ["10.0.0.5"], "_confirm": "1"},
+            )
         self.assertEqual(response.status_code, 302)
         self._assert_no_none_pk_redirect(response)
 
@@ -545,64 +535,67 @@ class TestEnrichLeasesErrorPaths(_ViewTestBase):
         "valid-lft": 3600,
         "cltt": 1_700_000_000,
     }
+    _CONFIG4 = {"result": 0, "arguments": {"Dhcp4": {"subnet4": [{"id": 1, "subnet": "10.0.0.0/24"}]}}}
 
     def _htmx_get(self, url, data):
         return self.client.get(url, data=data, HTTP_HX_REQUEST="true")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_non_result2_kea_exception_does_not_crash(self, MockKeaClient):
+    def test_non_result2_kea_exception_does_not_crash(self):
         """A KeaException with result=1 (server error) on reservation lookup must not 500."""
-        from netbox_kea.kea import KeaException
-
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = [{"result": 0, "arguments": {"ip-address": "10.0.0.5", **self._LEASE4}}]
-        mock_client.reservation_get.side_effect = KeaException({"result": 1, "text": "server error"}, index=0)
+        # result=1 on reservation-get makes the real client raise KeaException (non-result-2),
+        # which enrichment treats as indeterminate rather than crashing.
         url = reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
-        response = self._htmx_get(url, {"by": "ip", "q": "10.0.0.5"})
+        with stub_kea(
+            {
+                "config-get": self._CONFIG4,
+                "lease4-get": {"result": 0, "arguments": dict(self._LEASE4)},
+                "reservation-get": {"result": 1, "text": "server error"},
+            }
+        ):
+            response = self._htmx_get(url, {"by": "ip", "q": "10.0.0.5"})
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_unexpected_exception_on_reservation_lookup_does_not_crash(self, MockKeaClient):
+    def test_unexpected_exception_on_reservation_lookup_does_not_crash(self):
         """An unexpected exception (e.g. network error) during reservation lookup must not 500."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = [{"result": 0, "arguments": {"ip-address": "10.0.0.5", **self._LEASE4}}]
-        mock_client.reservation_get.side_effect = RuntimeError("socket closed")
         url = reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
-        response = self._htmx_get(url, {"by": "ip", "q": "10.0.0.5"})
+        with stub_kea(
+            {
+                "config-get": self._CONFIG4,
+                "lease4-get": {"result": 0, "arguments": dict(self._LEASE4)},
+                "reservation-get": RuntimeError("socket closed"),
+            }
+        ):
+            response = self._htmx_get(url, {"by": "ip", "q": "10.0.0.5"})
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.sync.bulk_fetch_netbox_ips")
-    @patch("netbox_kea.models.KeaClient")
-    def test_sync_url_set_when_no_netbox_ip(self, MockKeaClient, mock_bulk_fetch):
+    def test_sync_url_set_when_no_netbox_ip(self):
         """When the lease IP is absent from NetBox, sync_url must be set on the lease dict."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = [{"result": 0, "arguments": {"ip-address": "10.0.0.5", **self._LEASE4}}]
-        mock_client.clone.return_value = mock_client  # worker threads must see configured behaviors
-        mock_client.__enter__ = lambda s: s
-        mock_client.__exit__ = lambda s, *a: None
-        mock_client.reservation_get.return_value = None
-        mock_bulk_fetch.return_value = {}
+        # No NbIP created → bulk_fetch_netbox_ips returns {} from the real (empty) DB.
         url = reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
-        response = self._htmx_get(url, {"by": "ip", "q": "10.0.0.5"})
+        with stub_kea(
+            {
+                "config-get": self._CONFIG4,
+                "lease4-get": {"result": 0, "arguments": dict(self._LEASE4)},
+                "reservation-get": {"result": 3},  # no reservation
+            }
+        ):
+            response = self._htmx_get(url, {"by": "ip", "q": "10.0.0.5"})
         self.assertEqual(response.status_code, 200)
         # Sync button (hx-post) must appear since no NetBox IP
         self.assertContains(response, "hx-post")
 
-    @patch("netbox_kea.sync.bulk_fetch_netbox_ips")
-    @patch("netbox_kea.models.KeaClient")
-    def test_synced_badge_set_when_netbox_ip_exists(self, MockKeaClient, mock_bulk_fetch):
+    def test_synced_badge_set_when_netbox_ip_exists(self):
         """When the lease IP exists in NetBox IPAM, netbox_ip_url must be set (Synced badge)."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = [{"result": 0, "arguments": {"ip-address": "10.0.0.5", **self._LEASE4}}]
-        mock_client.clone.return_value = mock_client  # worker threads must see configured behaviors
-        mock_client.__enter__ = lambda s: s
-        mock_client.__exit__ = lambda s, *a: None
-        mock_client.reservation_get.return_value = None
-        nb_ip = MagicMock(spec=NbIP)
-        nb_ip.get_absolute_url.return_value = "/ipam/ip-addresses/99/"
-        mock_bulk_fetch.return_value = {"10.0.0.5": nb_ip}
+        NbIP.objects.create(address="10.0.0.5/24")  # real IPAM row → resolved by bulk_fetch_netbox_ips
         url = reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
-        response = self._htmx_get(url, {"by": "ip", "q": "10.0.0.5"})
+        with stub_kea(
+            {
+                "config-get": self._CONFIG4,
+                "lease4-get": {"result": 0, "arguments": dict(self._LEASE4)},
+                "reservation-get": {"result": 3},  # no reservation
+            }
+        ):
+            response = self._htmx_get(url, {"by": "ip", "q": "10.0.0.5"})
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Synced")
 
@@ -629,63 +622,51 @@ class TestStaleMacBadgeEnrichment(_ViewTestBase):
         "hw-address": "aa:bb:cc:dd:ee:99",  # different MAC → stale
         "subnet-id": 7,
     }
+    _CONFIG4 = {"result": 0, "arguments": {"Dhcp4": {"subnet4": [{"id": 7, "subnet": "10.0.0.0/24"}]}}}
 
     def _htmx_get(self, url, data):
         return self.client.get(url, data=data, HTTP_HX_REQUEST="true")
 
-    @patch("netbox_kea.sync.bulk_fetch_netbox_ips")
-    @patch("netbox_kea.models.KeaClient")
-    def test_stale_mac_badge_shows_specific_macs_in_title(self, MockKeaClient, mock_bulk_fetch):
+    def _stub(self, reservation):
+        """stub_kea responses for a single IP-matched lease with *reservation*."""
+        return stub_kea(
+            {
+                "config-get": self._CONFIG4,
+                "lease4-get": {"result": 0, "arguments": dict(self._LEASE4)},
+                "reservation-get": {"result": 0, "arguments": reservation},
+            }
+        )
+
+    def test_stale_mac_badge_shows_specific_macs_in_title(self):
         """The ⚠ MAC? badge title must contain both lease MAC and reservation MAC."""
-        mock_client = MockKeaClient.return_value
-        mock_client.clone.return_value = mock_client  # worker threads must see configured behaviors
-        mock_client.__enter__ = lambda s: s
-        mock_client.__exit__ = lambda s, *a: None
-        mock_client.command.return_value = [{"result": 0, "arguments": {"ip-address": "10.0.0.5", **self._LEASE4}}]
-        mock_client.reservation_get.return_value = self._RESERVATION
-        mock_bulk_fetch.return_value = {}
         url = reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
-        response = self._htmx_get(url, {"by": "ip", "q": "10.0.0.5"})
+        with self._stub(self._RESERVATION):
+            response = self._htmx_get(url, {"by": "ip", "q": "10.0.0.5"})
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "aa:bb:cc:dd:ee:01")  # lease MAC in tooltip
         self.assertContains(response, "aa:bb:cc:dd:ee:99")  # reservation MAC in tooltip
 
-    @patch("netbox_kea.sync.bulk_fetch_netbox_ips")
-    @patch("netbox_kea.models.KeaClient")
-    def test_stale_mac_badge_renders_htmx_delete_button(self, MockKeaClient, mock_bulk_fetch):
+    def test_stale_mac_badge_renders_htmx_delete_button(self):
         """The stale-MAC badge must include an HTMX delete button (hx-post) for one-click removal."""
-        mock_client = MockKeaClient.return_value
-        mock_client.clone.return_value = mock_client  # worker threads must see configured behaviors
-        mock_client.__enter__ = lambda s: s
-        mock_client.__exit__ = lambda s, *a: None
-        mock_client.command.return_value = [{"result": 0, "arguments": {"ip-address": "10.0.0.5", **self._LEASE4}}]
-        mock_client.reservation_get.return_value = self._RESERVATION
-        mock_bulk_fetch.return_value = {}
         url = reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
-        response = self._htmx_get(url, {"by": "ip", "q": "10.0.0.5"})
+        with self._stub(self._RESERVATION):
+            response = self._htmx_get(url, {"by": "ip", "q": "10.0.0.5"})
         self.assertEqual(response.status_code, 200)
         # hx-post must point to the delete endpoint (distinct from the bulk-delete form action)
         delete_url = reverse("plugins:netbox_kea:server_leases4_delete", args=[self.server.pk])
         self.assertContains(response, f'hx-post="{delete_url}"')
 
-    @patch("netbox_kea.sync.bulk_fetch_netbox_ips")
-    @patch("netbox_kea.models.KeaClient")
-    def test_matching_mac_badge_has_no_htmx_delete_button(self, MockKeaClient, mock_bulk_fetch):
+    def test_matching_mac_badge_has_no_htmx_delete_button(self):
         """When lease MAC matches reservation MAC, no HTMX delete button must appear."""
         matching_rsv = {**self._RESERVATION, "hw-address": self._LEASE4["hw-address"]}
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = [{"result": 0, "arguments": {"ip-address": "10.0.0.5", **self._LEASE4}}]
-        mock_client.reservation_get.return_value = matching_rsv
-        mock_bulk_fetch.return_value = {}
         url = reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
-        response = self._htmx_get(url, {"by": "ip", "q": "10.0.0.5"})
+        with self._stub(matching_rsv):
+            response = self._htmx_get(url, {"by": "ip", "q": "10.0.0.5"})
         self.assertEqual(response.status_code, 200)
         delete_url = reverse("plugins:netbox_kea:server_leases4_delete", args=[self.server.pk])
         self.assertNotContains(response, f'hx-post="{delete_url}"')
 
-    @patch("netbox_kea.sync.bulk_fetch_netbox_ips")
-    @patch("netbox_kea.models.KeaClient")
-    def test_stale_mac_badge_no_delete_when_no_permission(self, MockKeaClient, mock_bulk_fetch):
+    def test_stale_mac_badge_no_delete_when_no_permission(self):
         """When the user lacks delete permission, the stale-MAC badge must NOT include an HTMX delete button."""
         from django.contrib.auth import get_user_model
         from django.contrib.contenttypes.models import ContentType
@@ -700,12 +681,9 @@ class TestStaleMacBadgeEnrichment(_ViewTestBase):
         view_obj_perm.users.add(readonly_user)
         self.client.force_login(readonly_user)
 
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = [{"result": 0, "arguments": {"ip-address": "10.0.0.5", **self._LEASE4}}]
-        mock_client.reservation_get.return_value = self._RESERVATION
-        mock_bulk_fetch.return_value = {}
         url = reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
-        response = self._htmx_get(url, {"by": "ip", "q": "10.0.0.5"})
+        with self._stub(self._RESERVATION):
+            response = self._htmx_get(url, {"by": "ip", "q": "10.0.0.5"})
         self.assertEqual(response.status_code, 200)
         delete_url = reverse("plugins:netbox_kea:server_leases4_delete", args=[self.server.pk])
         self.assertNotContains(response, f'hx-post="{delete_url}"')

--- a/netbox_kea/tests/test_views_leases.py
+++ b/netbox_kea/tests/test_views_leases.py
@@ -1581,8 +1581,6 @@ class TestEnrichLeasesWithBadgesCanChange(_ViewTestBase):
 
     def test_edit_url_absent_when_can_change_false(self):
         """edit_url must NOT be set on leases when can_change=False."""
-        from unittest.mock import MagicMock
-
         from netbox_kea.views import _enrich_leases_with_badges
 
         server = self.server
@@ -1590,7 +1588,7 @@ class TestEnrichLeasesWithBadgesCanChange(_ViewTestBase):
         with (
             patch("netbox_kea.views.leases._fetch_reservation_by_ip_for_leases", return_value=({}, False, set())),
             patch("netbox_kea.sync.bulk_fetch_netbox_ips", return_value={}),
-            patch.object(server, "get_client", return_value=MagicMock(spec=KeaClient)),
+            stub_kea({"reservation-get": {"result": 3}}),
         ):
             _enrich_leases_with_badges([lease], server, 4, can_delete=False, can_change=False)
         self.assertNotIn("edit_url", lease)
@@ -1598,8 +1596,6 @@ class TestEnrichLeasesWithBadgesCanChange(_ViewTestBase):
 
     def test_edit_url_set_when_can_change_true(self):
         """edit_url must be set on leases when can_change=True."""
-        from unittest.mock import MagicMock
-
         from netbox_kea.views import _enrich_leases_with_badges
 
         server = self.server
@@ -1607,7 +1603,7 @@ class TestEnrichLeasesWithBadgesCanChange(_ViewTestBase):
         with (
             patch("netbox_kea.views.leases._fetch_reservation_by_ip_for_leases", return_value=({}, False, set())),
             patch("netbox_kea.sync.bulk_fetch_netbox_ips", return_value={}),
-            patch.object(server, "get_client", return_value=MagicMock(spec=KeaClient)),
+            stub_kea({"reservation-get": {"result": 3}}),
         ):
             _enrich_leases_with_badges([lease], server, 4, can_delete=False, can_change=True)
         self.assertIn("edit_url", lease)
@@ -1636,7 +1632,7 @@ class TestEnrichLeasesReservationFlags(_ViewTestBase):
                 return_value=({"10.0.0.5": rsv}, True, set()),
             ),
             patch("netbox_kea.sync.bulk_fetch_netbox_ips", return_value={}),
-            patch.object(server, "get_client", return_value=MagicMock(spec=KeaClient)),
+            stub_kea({"reservation-get": {"result": 3}}),
         ):
             _enrich_leases_with_badges([lease], server, 4, can_delete=False, can_change=False)
         self.assertTrue(lease["is_reserved"])
@@ -1650,7 +1646,7 @@ class TestEnrichLeasesReservationFlags(_ViewTestBase):
         with (
             patch("netbox_kea.views.leases._fetch_reservation_by_ip_for_leases", return_value=({}, True, set())),
             patch("netbox_kea.sync.bulk_fetch_netbox_ips", return_value={}),
-            patch.object(server, "get_client", return_value=MagicMock(spec=KeaClient)),
+            stub_kea({"reservation-get": {"result": 3}}),
         ):
             _enrich_leases_with_badges([lease], server, 4, can_delete=False, can_change=False)
         self.assertFalse(lease["is_reserved"])
@@ -1668,7 +1664,7 @@ class TestEnrichLeasesReservationFlags(_ViewTestBase):
                 return_value=({"10.0.0.5": rsv}, True, set()),
             ),
             patch("netbox_kea.sync.bulk_fetch_netbox_ips", return_value={}),
-            patch.object(server, "get_client", return_value=MagicMock(spec=KeaClient)),
+            stub_kea({"reservation-get": {"result": 3}}),
         ):
             _enrich_leases_with_badges([lease], server, 4, can_delete=False, can_change=False)
         self.assertIsNotNone(lease["reservation_url"])
@@ -1689,7 +1685,7 @@ class TestEnrichLeasesReservationFlags(_ViewTestBase):
                 return_value=({"10.0.0.5": rsv}, True, set()),
             ),
             patch("netbox_kea.sync.bulk_fetch_netbox_ips", return_value={}),
-            patch.object(server, "get_client", return_value=MagicMock(spec=KeaClient)),
+            stub_kea({"reservation-get": {"result": 3}}),
         ):
             _enrich_leases_with_badges([lease], server, 4, can_delete=False, can_change=True)
         self.assertIsNotNone(lease["reservation_url"])
@@ -1704,7 +1700,7 @@ class TestEnrichLeasesReservationFlags(_ViewTestBase):
         with (
             patch("netbox_kea.views.leases._fetch_reservation_by_ip_for_leases", return_value=({}, True, set())),
             patch("netbox_kea.sync.bulk_fetch_netbox_ips", return_value={}),
-            patch.object(server, "get_client", return_value=MagicMock(spec=KeaClient)),
+            stub_kea({"reservation-get": {"result": 3}}),
         ):
             _enrich_leases_with_badges([lease], server, 4, can_delete=False, can_change=False)
         self.assertIsNone(lease.get("create_reservation_url"))
@@ -1719,7 +1715,7 @@ class TestEnrichLeasesReservationFlags(_ViewTestBase):
             patch("netbox_kea.views.leases._fetch_reservation_by_ip_for_leases", return_value=({}, True, set())),
             patch("netbox_kea.views.leases._fetch_reservation_by_mac_for_leases", return_value=({}, set())),
             patch("netbox_kea.sync.bulk_fetch_netbox_ips", return_value={}),
-            patch.object(server, "get_client", return_value=MagicMock(spec=KeaClient)),
+            stub_kea({"reservation-get": {"result": 3}}),
         ):
             _enrich_leases_with_badges([lease], server, 4, can_delete=False, can_change=True)
         self.assertIsNotNone(lease.get("create_reservation_url"))
@@ -2379,17 +2375,15 @@ class TestGetLeasesCoverage(_ViewTestBase):
         return reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
 
     def test_invalid_by_raises_abort_request(self):
-        """Line 522: invalid 'by' value → AbortRequest raised."""
-        from unittest.mock import MagicMock
-
+        """Line 522: invalid 'by' value → AbortRequest raised (before the client is used)."""
         from utilities.exceptions import AbortRequest
 
         from netbox_kea.views import ServerLeases4View
 
         view = ServerLeases4View()
-        mock_client = MagicMock(spec=KeaClient)
+        client = KeaClient(url="https://kea.example.com")
         with self.assertRaises(AbortRequest):
-            view.get_leases(mock_client, "test_query", "not_a_valid_by")
+            view.get_leases(client, "test_query", "not_a_valid_by")
 
     def test_null_args_from_lease_get_raises_runtime_error(self):
         """Line 535: lease-get returns arguments=None → RuntimeError (caught by HTMX handler)."""
@@ -3124,7 +3118,7 @@ class TestPendingIpChangeDetection(_ViewTestBase):
                 return_value=({("aa:bb:cc:dd:ee:01", 1): mac_rsv}, set()),
             ),
             patch("netbox_kea.sync.bulk_fetch_netbox_ips", return_value={}),
-            patch.object(server, "get_client", return_value=MagicMock(spec=KeaClient)),
+            stub_kea({"reservation-get": {"result": 3}}),
         ):
             _enrich_leases_with_badges([lease], server, 4, can_delete=False, can_change=True)
         self.assertTrue(lease["pending_ip_change"])
@@ -3140,7 +3134,7 @@ class TestPendingIpChangeDetection(_ViewTestBase):
             patch("netbox_kea.views.leases._fetch_reservation_by_ip_for_leases", return_value=({}, True, set())),
             patch("netbox_kea.views.leases._fetch_reservation_by_mac_for_leases", return_value=({}, set())),
             patch("netbox_kea.sync.bulk_fetch_netbox_ips", return_value={}),
-            patch.object(server, "get_client", return_value=MagicMock(spec=KeaClient)),
+            stub_kea({"reservation-get": {"result": 3}}),
         ):
             _enrich_leases_with_badges([lease], server, 4, can_delete=False, can_change=True)
         self.assertFalse(lease["pending_ip_change"])
@@ -3160,7 +3154,7 @@ class TestPendingIpChangeDetection(_ViewTestBase):
                 return_value=({("aa:bb:cc:dd:ee:01", 1): mac_rsv}, set()),
             ),
             patch("netbox_kea.sync.bulk_fetch_netbox_ips", return_value={}),
-            patch.object(server, "get_client", return_value=MagicMock(spec=KeaClient)),
+            stub_kea({"reservation-get": {"result": 3}}),
         ):
             _enrich_leases_with_badges([lease], server, 4, can_delete=False, can_change=True)
         self.assertIsNone(lease.get("sync_url"))
@@ -3179,7 +3173,7 @@ class TestPendingIpChangeDetection(_ViewTestBase):
                 return_value=({("aa:bb:cc:dd:ee:01", 1): mac_rsv}, set()),
             ),
             patch("netbox_kea.sync.bulk_fetch_netbox_ips", return_value={}),
-            patch.object(server, "get_client", return_value=MagicMock(spec=KeaClient)),
+            stub_kea({"reservation-get": {"result": 3}}),
         ):
             _enrich_leases_with_badges([lease], server, 4, can_delete=False, can_change=True)
         self.assertIsNone(lease.get("create_reservation_url"))
@@ -3198,7 +3192,7 @@ class TestPendingIpChangeDetection(_ViewTestBase):
                 return_value=({("aa:bb:cc:dd:ee:01", 1): mac_rsv}, set()),
             ),
             patch("netbox_kea.sync.bulk_fetch_netbox_ips", return_value={}),
-            patch.object(server, "get_client", return_value=MagicMock(spec=KeaClient)),
+            stub_kea({"reservation-get": {"result": 3}}),
         ):
             _enrich_leases_with_badges([lease], server, 4, can_delete=False, can_change=True)
         self.assertIsNotNone(lease["reservation_url"])
@@ -3218,7 +3212,7 @@ class TestPendingIpChangeDetection(_ViewTestBase):
                 return_value=({("aa:bb:cc:dd:ee:01", 1): mac_rsv}, set()),
             ),
             patch("netbox_kea.sync.bulk_fetch_netbox_ips", return_value={}),
-            patch.object(server, "get_client", return_value=MagicMock(spec=KeaClient)),
+            stub_kea({"reservation-get": {"result": 3}}),
         ):
             _enrich_leases_with_badges([lease], server, 4, can_delete=False, can_change=False)
         self.assertTrue(lease["pending_ip_change"])
@@ -3240,7 +3234,7 @@ class TestPendingIpChangeDetection(_ViewTestBase):
             ),
             patch("netbox_kea.views.leases._fetch_reservation_by_mac_for_leases", return_value=({}, set())),
             patch("netbox_kea.sync.bulk_fetch_netbox_ips", return_value={}),
-            patch.object(server, "get_client", return_value=MagicMock(spec=KeaClient)),
+            stub_kea({"reservation-get": {"result": 3}}),
         ):
             _enrich_leases_with_badges([lease], server, 4, can_delete=False, can_change=True)
         self.assertFalse(lease["pending_ip_change"])
@@ -3252,7 +3246,6 @@ class TestPendingIpChangeDetection(_ViewTestBase):
 
         server = self.server
         lease = {"ip_address": "10.0.0.10", "hw_address": "aa:bb:cc:dd:ee:01", "subnet_id": 1}
-        mock_client = MagicMock(spec=KeaClient)
         with (
             patch(
                 "netbox_kea.views.leases._fetch_reservation_by_ip_for_leases",
@@ -3260,7 +3253,7 @@ class TestPendingIpChangeDetection(_ViewTestBase):
             ),
             patch("netbox_kea.views.leases._fetch_reservation_by_mac_for_leases") as mock_mac_fetch,
             patch("netbox_kea.sync.bulk_fetch_netbox_ips", return_value={}),
-            patch.object(server, "get_client", return_value=mock_client),
+            stub_kea({}),
         ):
             _enrich_leases_with_badges([lease], server, 4, can_delete=False, can_change=True)
         mock_mac_fetch.assert_not_called()
@@ -3275,7 +3268,7 @@ class TestPendingIpChangeDetection(_ViewTestBase):
             patch("netbox_kea.views.leases._fetch_reservation_by_ip_for_leases", return_value=({}, True, set())),
             patch("netbox_kea.views.leases._fetch_reservation_by_mac_for_leases", side_effect=RuntimeError("boom")),
             patch("netbox_kea.sync.bulk_fetch_netbox_ips", return_value={}),
-            patch.object(server, "get_client", return_value=MagicMock(spec=KeaClient)),
+            stub_kea({"reservation-get": {"result": 3}}),
         ):
             _enrich_leases_with_badges([lease], server, 4, can_delete=False, can_change=True)
         self.assertFalse(lease.get("pending_ip_change", False))
@@ -3884,9 +3877,9 @@ class TestGetLeasesPageSubnetEdgeCases(_ViewTestBase):
 class TestFetchSubnetChoices(TestCase):
     """_fetch_subnet_choices(): network-order sorting + 5-minute caching.
 
-    Uses a real Server and the real Django cache; only the Kea client boundary is
-    mocked (get_client returns a client whose .command() yields canned
-    ``config-get`` JSON).
+    Uses a real Server, the real Django cache, and the **real** ``KeaClient`` with
+    only the HTTP boundary stubbed via ``kea_stub.stub_kea`` — the real
+    ``config-get`` request payload and response parsing are exercised.
     """
 
     # subnet4 ids/CIDRs are intentionally out of order, and chosen so that
@@ -3922,18 +3915,12 @@ class TestFetchSubnetChoices(TestCase):
         for v in (4, 6):
             cache.delete(_subnet_choices_cache_key(self.server, v))
 
-    def _client_returning_config(self):
-        client = MagicMock(spec=KeaClient)
-        client.command.return_value = self._CONFIG
-        return client
-
     def test_choices_sorted_by_network_not_lexicographically(self):
-        client = self._client_returning_config()
-        with patch.object(Server, "get_client", return_value=client) as get_client:
+        with stub_kea({"config-get": self._CONFIG}) as kea:
             choices = _fetch_subnet_choices(self.server, 4)
         # The helper must request the protocol-specific client (dual-URL servers
-        # route v4/v6 to different endpoints).
-        get_client.assert_called_once_with(version=4)
+        # route v4/v6 to different endpoints) → config-get went to the dhcp4 service.
+        self.assertEqual(kea.bodies("config-get")[0]["service"], ["dhcp4"])
         self.assertEqual(
             [c[0] for c in choices],
             ["10.0.1.0/24", "10.0.2.0/24", "10.0.10.0/24", "192.168.0.0/16"],
@@ -3961,11 +3948,9 @@ class TestFetchSubnetChoices(TestCase):
                 },
             }
         ]
-        client = MagicMock(spec=KeaClient)
-        client.command.return_value = config6
-        with patch.object(Server, "get_client", return_value=client) as get_client:
+        with stub_kea({"config-get": config6}) as kea:
             choices = _fetch_subnet_choices(self.server, 6)
-        get_client.assert_called_once_with(version=6)
+        self.assertEqual(kea.bodies("config-get")[0]["service"], ["dhcp6"])
         self.assertEqual(choices, [("2001:db8:1::/64", 11), ("2001:db8:2::/64", 12)])
 
     def test_non_string_subnet_values_do_not_500(self):
@@ -3987,9 +3972,7 @@ class TestFetchSubnetChoices(TestCase):
                 },
             }
         ]
-        client = MagicMock(spec=KeaClient)
-        client.command.return_value = bad_config
-        with patch.object(Server, "get_client", return_value=client):
+        with stub_kea({"config-get": bad_config}):
             choices = _fetch_subnet_choices(self.server, 4)
         # Only the valid string CIDR survives; the call returns cleanly.
         self.assertEqual(choices, [("10.0.1.0/24", 1)])
@@ -3997,26 +3980,19 @@ class TestFetchSubnetChoices(TestCase):
     def test_non_list_subnet_containers_do_not_500(self):
         """Non-list subnet4 / shared-networks containers degrade to empty, not TypeError/500."""
         bad_config = [{"result": 0, "arguments": {"Dhcp4": {"subnet4": 1, "shared-networks": 1}}}]
-        client = MagicMock(spec=KeaClient)
-        client.command.return_value = bad_config
-        with patch.object(Server, "get_client", return_value=client):
+        with stub_kea({"config-get": bad_config}):
             choices = _fetch_subnet_choices(self.server, 4)
         self.assertEqual(choices, [])
 
     def test_non_dict_dhcp_conf_returns_empty(self):
         """A non-dict ``Dhcp4`` payload degrades to no choices (not an AttributeError)."""
-        client = MagicMock(spec=KeaClient)
-        client.command.return_value = [{"result": 0, "arguments": {"Dhcp4": "not-a-dict"}}]
-        with patch.object(Server, "get_client", return_value=client):
+        with stub_kea({"config-get": [{"result": 0, "arguments": {"Dhcp4": "not-a-dict"}}]}):
             self.assertEqual(_fetch_subnet_choices(self.server, 4), [])
 
     def test_non_dict_subnet_entry_is_skipped(self):
         """Non-dict entries inside subnet4 are skipped; valid dict entries still parse."""
-        client = MagicMock(spec=KeaClient)
-        client.command.return_value = [
-            {"result": 0, "arguments": {"Dhcp4": {"subnet4": [1, {"id": 2, "subnet": "10.0.0.0/24"}]}}}
-        ]
-        with patch.object(Server, "get_client", return_value=client):
+        config = [{"result": 0, "arguments": {"Dhcp4": {"subnet4": [1, {"id": 2, "subnet": "10.0.0.0/24"}]}}}]
+        with stub_kea({"config-get": config}):
             self.assertEqual(_fetch_subnet_choices(self.server, 4), [("10.0.0.0/24", 2)])
 
     def test_subnet_sort_key_handles_non_string_and_unparseable(self):
@@ -4026,28 +4002,24 @@ class TestFetchSubnetChoices(TestCase):
         self.assertEqual(_subnet_sort_key(("10.0.0.0/24", 3))[0], 0)  # real network sorts first
 
     def test_result_is_cached_second_call_skips_kea(self):
-        client = self._client_returning_config()
-        with patch.object(Server, "get_client", return_value=client) as get_client:
+        with stub_kea({"config-get": self._CONFIG}) as kea:
             first = _fetch_subnet_choices(self.server, 4)
             second = _fetch_subnet_choices(self.server, 4)
         self.assertEqual(first, second)
         # config-get hit Kea exactly once; the second render is served from cache.
-        self.assertEqual(client.command.call_count, 1)
-        # The single client request used the protocol-specific version.
-        get_client.assert_called_once_with(version=4)
+        self.assertEqual(kea.commands().count("config-get"), 1)
+        # The single request used the protocol-specific dhcp4 service.
+        self.assertEqual(kea.bodies("config-get")[0]["service"], ["dhcp4"])
 
     def test_transient_error_returns_empty_and_is_not_cached(self):
-        failing = MagicMock(spec=KeaClient)
-        failing.command.side_effect = RuntimeError("kea unreachable")
-        with patch.object(Server, "get_client", return_value=failing):
+        with stub_kea({"config-get": RuntimeError("kea unreachable")}):
             self.assertEqual(_fetch_subnet_choices(self.server, 4), [])
 
         # A failed fetch must not be cached, so the next render retries and succeeds.
-        ok = self._client_returning_config()
-        with patch.object(Server, "get_client", return_value=ok):
+        with stub_kea({"config-get": self._CONFIG}) as kea:
             choices = _fetch_subnet_choices(self.server, 4)
         self.assertTrue(choices)
-        self.assertEqual(ok.command.call_count, 1)
+        self.assertEqual(kea.commands().count("config-get"), 1)
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)

--- a/netbox_kea/tests/test_views_leases.py
+++ b/netbox_kea/tests/test_views_leases.py
@@ -1412,13 +1412,12 @@ class TestLeaseSignals(_ViewTestBase):
         "valid_lft": 3600,
     }
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_lease_add_fires_lease_added_signal(self, MockKeaClient):
+    # Pool-overlap advisory fetches the subnet; no pools → no overlap warning.
+    _SUBNET4 = {"result": 0, "arguments": {"subnet4": [{"id": 1, "subnet": "10.0.0.0/24", "pools": []}]}}
+
+    def test_lease_add_fires_lease_added_signal(self):
         """_BaseLeaseAddView.post must send lease_added signal after successful add."""
         from netbox_kea import signals
-
-        mock_client = MockKeaClient.return_value
-        mock_client.lease_add.return_value = None
 
         received = []
 
@@ -1428,7 +1427,8 @@ class TestLeaseSignals(_ViewTestBase):
         signals.lease_added.connect(handler)
         try:
             url = reverse("plugins:netbox_kea:server_lease4_add", args=[self.server.pk])
-            self.client.post(url, self._LEASE4)
+            with stub_kea({"lease4-add": {"result": 0}}):
+                self.client.post(url, self._LEASE4)
         finally:
             signals.lease_added.disconnect(handler)
 
@@ -1437,13 +1437,9 @@ class TestLeaseSignals(_ViewTestBase):
         self.assertEqual(received[0]["dhcp_version"], 4)
         self.assertEqual(received[0]["server"].pk, self.server.pk)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_lease_delete_fires_leases_deleted_signal(self, MockKeaClient):
+    def test_lease_delete_fires_leases_deleted_signal(self):
         """BaseServerLeasesDeleteView.post must send leases_deleted signal after successful delete."""
         from netbox_kea import signals
-
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = [{"result": 0, "text": "Success"}]
 
         received = []
 
@@ -1453,7 +1449,8 @@ class TestLeaseSignals(_ViewTestBase):
         signals.leases_deleted.connect(handler)
         try:
             url = reverse("plugins:netbox_kea:server_leases4_delete", args=[self.server.pk])
-            self.client.post(url, {"pk": "10.0.0.5", "_confirm": "1"})
+            with stub_kea({"lease4-del": {"result": 0}}):
+                self.client.post(url, {"pk": "10.0.0.5", "_confirm": "1"})
         finally:
             signals.leases_deleted.disconnect(handler)
 
@@ -1461,14 +1458,9 @@ class TestLeaseSignals(_ViewTestBase):
         self.assertIn("10.0.0.5", received[0]["ip_addresses"])
         self.assertEqual(received[0]["dhcp_version"], 4)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_reservation_add_fires_reservation_created_signal(self, MockKeaClient):
+    def test_reservation_add_fires_reservation_created_signal(self):
         """ServerReservation4AddView.post must send reservation_created signal."""
         from netbox_kea import signals
-
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_add.return_value = None
-        mock_client.command.return_value = [{"result": 0, "text": "Success"}]  # config-write
 
         received = []
 
@@ -1478,30 +1470,26 @@ class TestLeaseSignals(_ViewTestBase):
         signals.reservation_created.connect(handler)
         try:
             url = reverse("plugins:netbox_kea:server_reservation4_add", args=[self.server.pk])
-            self.client.post(
-                url,
-                {
-                    "subnet_id": 1,
-                    "ip_address": "10.0.0.10",
-                    "identifier_type": "hw-address",
-                    "identifier": "aa:bb:cc:dd:ee:01",
-                    "hostname": "",
-                },
-            )
+            with stub_kea({"subnet4-get": self._SUBNET4, "reservation-add": {"result": 0}}):
+                self.client.post(
+                    url,
+                    {
+                        "subnet_id": 1,
+                        "ip_address": "10.0.0.10",
+                        "identifier_type": "hw-address",
+                        "identifier": "aa:bb:cc:dd:ee:01",
+                        "hostname": "",
+                    },
+                )
         finally:
             signals.reservation_created.disconnect(handler)
 
         self.assertEqual(len(received), 1)
         self.assertEqual(received[0]["dhcp_version"], 4)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_reservation_delete_fires_reservation_deleted_signal(self, MockKeaClient):
+    def test_reservation_delete_fires_reservation_deleted_signal(self):
         """ServerReservation4DeleteView.post must send reservation_deleted signal."""
         from netbox_kea import signals
-
-        mock_client = MockKeaClient.return_value
-        mock_client.reservation_del.return_value = None
-        mock_client.command.return_value = [{"result": 0, "text": "Success"}]
 
         received = []
 
@@ -1514,7 +1502,8 @@ class TestLeaseSignals(_ViewTestBase):
                 "plugins:netbox_kea:server_reservation4_delete",
                 args=[self.server.pk, 1, "10.0.0.10"],
             )
-            self.client.post(url)
+            with stub_kea({"reservation-del": {"result": 0}}):
+                self.client.post(url)
         finally:
             signals.reservation_deleted.disconnect(handler)
 
@@ -1527,30 +1516,28 @@ class TestLeaseSignals(_ViewTestBase):
 class TestLeaseJournalEntries(_ViewTestBase):
     """Lease add and delete views must create JournalEntry records on the Server."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_lease_add_creates_journal_entry(self, MockKeaClient):
+    def test_lease_add_creates_journal_entry(self):
         """A successful lease add must create a JournalEntry attached to the server."""
         from django.contrib.contenttypes.models import ContentType
         from extras.models import JournalEntry
 
-        mock_client = MockKeaClient.return_value
-        mock_client.lease_add.return_value = None
         url = reverse("plugins:netbox_kea:server_lease4_add", args=[self.server.pk])
         server_ct = ContentType.objects.get_for_model(self.server)
         before = JournalEntry.objects.filter(
             assigned_object_id=self.server.pk,
             assigned_object_type=server_ct,
         ).count()
-        self.client.post(
-            url,
-            {
-                "ip_address": "10.0.0.5",
-                "hw_address": "aa:bb:cc:dd:ee:01",
-                "hostname": "journal-host",
-                "subnet_id": 1,
-                "valid_lft": 3600,
-            },
-        )
+        with stub_kea({"lease4-add": {"result": 0}}):
+            self.client.post(
+                url,
+                {
+                    "ip_address": "10.0.0.5",
+                    "hw_address": "aa:bb:cc:dd:ee:01",
+                    "hostname": "journal-host",
+                    "subnet_id": 1,
+                    "valid_lft": 3600,
+                },
+            )
         after = JournalEntry.objects.filter(assigned_object_id=self.server.pk, assigned_object_type=server_ct).count()
         self.assertEqual(after, before + 1)
         entry = JournalEntry.objects.filter(assigned_object_id=self.server.pk, assigned_object_type=server_ct).latest(
@@ -1558,18 +1545,16 @@ class TestLeaseJournalEntries(_ViewTestBase):
         )
         self.assertIn("10.0.0.5", entry.comments)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_lease_delete_creates_journal_entry(self, MockKeaClient):
+    def test_lease_delete_creates_journal_entry(self):
         """A successful lease delete must create a JournalEntry attached to the server."""
         from django.contrib.contenttypes.models import ContentType
         from extras.models import JournalEntry
 
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = [{"result": 0, "text": "Success"}]
         url = reverse("plugins:netbox_kea:server_leases4_delete", args=[self.server.pk])
         server_ct = ContentType.objects.get_for_model(self.server)
         before = JournalEntry.objects.filter(assigned_object_id=self.server.pk, assigned_object_type=server_ct).count()
-        self.client.post(url, {"pk": "10.0.0.5", "_confirm": "1"})
+        with stub_kea({"lease4-del": {"result": 0}}):
+            self.client.post(url, {"pk": "10.0.0.5", "_confirm": "1"})
         after = JournalEntry.objects.filter(assigned_object_id=self.server.pk, assigned_object_type=server_ct).count()
         self.assertEqual(after, before + 1)
         entry = JournalEntry.objects.filter(assigned_object_id=self.server.pk, assigned_object_type=server_ct).latest(
@@ -1742,59 +1727,44 @@ class TestEnrichLeasesReservationFlags(_ViewTestBase):
 class TestEnrichLeasesExceptionPaths(_ViewTestBase):
     """_enrich_leases_with_badges exception branches (KeaException result≠2 and generic)."""
 
+    _CONFIG4 = {"result": 0, "arguments": {"Dhcp4": {"subnet4": [{"id": 1, "subnet": "10.0.0.0/24"}]}}}
+    _LEASE4 = {
+        "ip-address": "10.0.0.1",
+        "hw-address": "aa:bb:cc:dd:ee:ff",
+        "subnet-id": 1,
+        "valid-lft": 3600,
+        "cltt": 0,
+    }
+
     def _url(self):
         return reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_kea_exception_non_hook_swallowed(self, MockKeaClient):
-        """KeaException with result≠2 is swallowed and view returns 200."""
+    def test_kea_exception_non_hook_swallowed(self):
+        """KeaException with result≠2 raised by the reservation fetch is swallowed; view returns 200."""
         from netbox_kea.kea import KeaException
 
-        mock_client = MockKeaClient.return_value
-        mock_client.lease4_get_page.return_value = (
-            [
-                {
-                    "ip-address": "10.0.0.1",
-                    "hw-address": "aa:bb:cc:dd:ee:ff",
-                    "hostname": "host1",
-                    "subnet-id": 1,
-                    "valid-lft": 3600,
-                    "cltt": 0,
-                }
-            ],
-            0,
-            0,
-        )
-        with patch(
-            "netbox_kea.views.leases._fetch_reservation_by_ip_for_leases",
-            side_effect=KeaException({"result": 1, "text": "error"}, index=0),
+        # Real lease search returns one lease; force the reservation fetch to raise so the
+        # enrichment outer handler is exercised. (failed_ips then short-circuits the MAC pass.)
+        with (
+            stub_kea({"config-get": self._CONFIG4, "lease4-get": {"result": 0, "arguments": dict(self._LEASE4)}}),
+            patch(
+                "netbox_kea.views.leases._fetch_reservation_by_ip_for_leases",
+                side_effect=KeaException({"result": 1, "text": "error"}, index=0),
+            ),
         ):
-            response = self.client.get(self._url())
+            response = self.client.get(self._url() + "?by=ip&q=10.0.0.1", HTTP_HX_REQUEST="true")
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_generic_exception_in_enrichment_swallowed(self, MockKeaClient):
+    def test_generic_exception_in_enrichment_swallowed(self):
         """Generic exception in enrichment is swallowed and view returns 200."""
-        mock_client = MockKeaClient.return_value
-        mock_client.lease4_get_page.return_value = (
-            [
-                {
-                    "ip-address": "10.0.0.2",
-                    "hw-address": "aa:bb:cc:dd:ee:01",
-                    "hostname": "host2",
-                    "subnet-id": 1,
-                    "valid-lft": 3600,
-                    "cltt": 0,
-                }
-            ],
-            0,
-            0,
-        )
-        with patch(
-            "netbox_kea.views.leases._fetch_reservation_by_ip_for_leases",
-            side_effect=RuntimeError("unexpected error"),
+        with (
+            stub_kea({"config-get": self._CONFIG4, "lease4-get": {"result": 0, "arguments": dict(self._LEASE4)}}),
+            patch(
+                "netbox_kea.views.leases._fetch_reservation_by_ip_for_leases",
+                side_effect=RuntimeError("unexpected error"),
+            ),
         ):
-            response = self.client.get(self._url())
+            response = self.client.get(self._url() + "?by=ip&q=10.0.0.1", HTTP_HX_REQUEST="true")
         self.assertEqual(response.status_code, 200)
 
 
@@ -1875,16 +1845,18 @@ class TestJournalHelperEdgeCases(_ViewTestBase):
 class TestHTMXExceptionHandler(_ViewTestBase):
     """Lines 731-736: exception during HTMX partial rendering returns error partial."""
 
+    _CONFIG4 = {"result": 0, "arguments": {"Dhcp4": {"subnet4": [{"id": 1, "subnet": "10.0.0.0/24"}]}}}
+
     def _url(self):
         return reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_htmx_exception_returns_error_partial(self, MockKeaClient):
-        MockKeaClient.return_value.command.side_effect = RuntimeError("boom")
-        response = self.client.get(
-            self._url() + "?q=10.0.0.1&by=ip",
-            HTTP_HX_REQUEST="true",
-        )
+    def test_htmx_exception_returns_error_partial(self):
+        # A RuntimeError from the lease fetch must be caught and rendered as the HTMX error partial.
+        with stub_kea({"config-get": self._CONFIG4, "lease4-get": RuntimeError("boom")}):
+            response = self.client.get(
+                self._url() + "?q=10.0.0.1&by=ip",
+                HTTP_HX_REQUEST="true",
+            )
         # Must not crash — returns HTMX error partial
         self.assertIn(response.status_code, (200, 500))
 
@@ -1898,41 +1870,39 @@ class TestHTMXExceptionHandler(_ViewTestBase):
 class TestLeaseEditGet(_ViewTestBase):
     """Lines 894-896, 899-900, 910: lease edit GET error paths."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_kea_exception_redirects(self, MockKeaClient):
+    def test_get_kea_exception_redirects(self):
         """KeaException in lease4 GET redirects to leases page."""
-        from netbox_kea.kea import KeaException
-
-        MockKeaClient.return_value.command.side_effect = KeaException({"result": 1, "text": "err"}, index=0)
+        # result=1 makes lease4-get raise KeaException in the real client.
         url = reverse("plugins:netbox_kea:server_lease4_edit", args=[self.server.pk, "10.0.0.1"])
-        response = self.client.get(url)
+        with stub_kea({"lease4-get": {"result": 1, "text": "err"}}):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 302)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_lease_not_found_redirects(self, MockKeaClient):
+    def test_get_lease_not_found_redirects(self):
         """result=3 (not found) in lease4 GET redirects to leases page."""
-        MockKeaClient.return_value.command.return_value = [{"result": 3, "arguments": None}]
         url = reverse("plugins:netbox_kea:server_lease4_edit", args=[self.server.pk, "10.0.0.1"])
-        response = self.client.get(url)
+        with stub_kea({"lease4-get": {"result": 3, "arguments": None}}):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 302)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_v6_lease_includes_duid(self, MockKeaClient):
+    def test_get_v6_lease_includes_duid(self):
         """v6 lease GET includes duid in form initial (line 910)."""
         server6 = _make_db_server(name="kea6-only", ca_url="https://kea6.example.com", dhcp4=False, dhcp6=True)
-        MockKeaClient.return_value.command.return_value = [
-            {
-                "result": 0,
-                "arguments": {
-                    "ip-address": "2001:db8::1",
-                    "duid": "00:01:00:01",
-                    "hostname": "v6host",
-                    "valid-lft": 3600,
-                },
-            }
-        ]
         url = reverse("plugins:netbox_kea:server_lease6_edit", args=[server6.pk, "2001:db8::1"])
-        response = self.client.get(url)
+        with stub_kea(
+            {
+                "lease6-get": {
+                    "result": 0,
+                    "arguments": {
+                        "ip-address": "2001:db8::1",
+                        "duid": "00:01:00:01",
+                        "hostname": "v6host",
+                        "valid-lft": 3600,
+                    },
+                }
+            }
+        ):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "00:01:00:01")
 
@@ -1946,11 +1916,13 @@ class TestLeaseEditGet(_ViewTestBase):
 class TestLeaseEditPostInvalidForm(_ViewTestBase):
     """Line 931: lease edit POST with invalid form re-renders with 200."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_invalid_form_rerenders(self, MockKeaClient):
+    def test_post_invalid_form_rerenders(self):
         url = reverse("plugins:netbox_kea:server_lease4_edit", args=[self.server.pk, "10.0.0.1"])
-        response = self.client.post(url, {"hostname": "", "valid_lft": "not-a-number"})
+        # Invalid form re-renders before any Kea call — empty registry proves none is issued.
+        with stub_kea({}) as kea:
+            response = self.client.post(url, {"hostname": "", "valid_lft": "not-a-number"})
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(kea.commands(), [])
 
 
 # ---------------------------------------------------------------------------
@@ -1962,20 +1934,20 @@ class TestLeaseEditPostInvalidForm(_ViewTestBase):
 class TestLeaseAddGenericException(_ViewTestBase):
     """Lines 1056-1058: generic exception on lease_add re-renders form."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_generic_exception_rerenders_form(self, MockKeaClient):
-        MockKeaClient.return_value.lease_add.side_effect = requests.RequestException("unexpected crash")
+    def test_generic_exception_rerenders_form(self):
         url = reverse("plugins:netbox_kea:server_lease4_add", args=[self.server.pk])
-        response = self.client.post(
-            url,
-            {
-                "ip_address": "10.0.0.99",
-                "subnet_id": "1",
-                "hw_address": "aa:bb:cc:dd:ee:ff",
-                "hostname": "testhost",
-                "valid_lft": "3600",
-            },
-        )
+        # A transport error from lease4-add must re-render the form with an error message.
+        with stub_kea({"lease4-add": requests.RequestException("unexpected crash")}):
+            response = self.client.post(
+                url,
+                {
+                    "ip_address": "10.0.0.99",
+                    "subnet_id": "1",
+                    "hw_address": "aa:bb:cc:dd:ee:ff",
+                    "hostname": "testhost",
+                    "valid_lft": "3600",
+                },
+            )
         self.assertEqual(response.status_code, 200)
         msgs = [m.message for m in response.context["messages"]]
         self.assertTrue(any("Failed to create lease" in m or "internal" in m.lower() for m in msgs))

--- a/netbox_kea/tests/test_views_leases.py
+++ b/netbox_kea/tests/test_views_leases.py
@@ -2707,16 +2707,17 @@ class TestHtmxHandlerExceptNarrowing(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_attribute_error_not_swallowed_by_htmx_handler(self, MockKeaClient):
+    def test_attribute_error_not_swallowed_by_htmx_handler(self):
         """An AttributeError inside the HTMX handler must propagate (not be caught silently)."""
-        MockKeaClient.return_value.command.side_effect = AttributeError("mock programming bug")
-        with self.assertRaises(AttributeError):
-            self.client.get(
-                self._url(),
-                HTTP_HX_REQUEST="true",
-                data={"by": "subnet", "q": "10.0.0.0/24"},
-            )
+        config = {"result": 0, "arguments": {"Dhcp4": {"subnet4": []}}}
+        # The HTMX handler narrows its except clauses, so an AttributeError propagates.
+        with stub_kea({"config-get": config, "lease4-get-page": AttributeError("stub programming bug")}):
+            with self.assertRaises(AttributeError):
+                self.client.get(
+                    self._url(),
+                    HTTP_HX_REQUEST="true",
+                    data={"by": "subnet", "q": "10.0.0.0/24"},
+                )
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
@@ -2726,47 +2727,40 @@ class TestLeaseDeleteLoopTransportErrors(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_leases4_delete", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_request_exception_continues_loop(self, MockKeaClient):
+    _CONFIG4 = {"result": 0, "arguments": {"Dhcp4": {"subnet4": []}}}
+
+    def test_request_exception_continues_loop(self):
         import requests as _requests
 
-        mock_client = MockKeaClient.return_value
-        call_count = {"n": 0}
+        # First IP's delete raises a transport error; the loop must still delete the second.
+        def del_resp(body):
+            if body["arguments"]["ip-address"] == "10.0.0.1":
+                return _requests.ConnectionError("down")
+            return {"result": 0}
 
-        def side_effect(cmd, **kwargs):
-            ip = kwargs.get("arguments", {}).get("ip-address", "")
-            call_count["n"] += 1
-            if ip == "10.0.0.1":
-                raise _requests.ConnectionError("down")
-
-        mock_client.command.side_effect = side_effect
-        response = self.client.post(
-            self._url(),
-            {"pk": ["10.0.0.1", "10.0.0.2"], "_confirm": "1"},
-            follow=True,
-        )
+        with stub_kea({"lease4-del": del_resp, "config-get": self._CONFIG4}) as kea:
+            response = self.client.post(
+                self._url(),
+                {"pk": ["10.0.0.1", "10.0.0.2"], "_confirm": "1"},
+                follow=True,
+            )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(call_count["n"], 2)
+        self.assertEqual(kea.commands().count("lease4-del"), 2)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_value_error_continues_loop(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        call_count = {"n": 0}
+    def test_value_error_continues_loop(self):
+        def del_resp(body):
+            if body["arguments"]["ip-address"] == "10.0.0.1":
+                return ValueError("bad JSON")
+            return {"result": 0}
 
-        def side_effect(cmd, **kwargs):
-            ip = kwargs.get("arguments", {}).get("ip-address", "")
-            call_count["n"] += 1
-            if ip == "10.0.0.1":
-                raise ValueError("bad JSON")
-
-        mock_client.command.side_effect = side_effect
-        response = self.client.post(
-            self._url(),
-            {"pk": ["10.0.0.1", "10.0.0.2"], "_confirm": "1"},
-            follow=True,
-        )
+        with stub_kea({"lease4-del": del_resp, "config-get": self._CONFIG4}) as kea:
+            response = self.client.post(
+                self._url(),
+                {"pk": ["10.0.0.1", "10.0.0.2"], "_confirm": "1"},
+                follow=True,
+            )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(call_count["n"], 2)
+        self.assertEqual(kea.commands().count("lease4-del"), 2)
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
@@ -2776,24 +2770,24 @@ class TestLeaseExportTransportErrors(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_request_exception_redirects_with_error(self, MockKeaClient):
+    _CONFIG4 = {"result": 0, "arguments": {"Dhcp4": {"subnet4": []}}}
+
+    def test_request_exception_redirects_with_error(self):
         import requests as _requests
 
-        MockKeaClient.return_value.command.side_effect = _requests.ConnectionError("down")
-        response = self.client.get(
-            self._url(),
-            {"export": "1", "by": "subnet", "q": "10.0.0.0/24"},
-        )
+        with stub_kea({"config-get": self._CONFIG4, "lease4-get-page": _requests.ConnectionError("down")}):
+            response = self.client.get(
+                self._url(),
+                {"export": "1", "by": "subnet", "q": "10.0.0.0/24"},
+            )
         self.assertIn(response.status_code, [200, 302])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_value_error_redirects_with_error(self, MockKeaClient):
-        MockKeaClient.return_value.command.side_effect = ValueError("bad JSON")
-        response = self.client.get(
-            self._url(),
-            {"export": "1", "by": "subnet", "q": "10.0.0.0/24"},
-        )
+    def test_value_error_redirects_with_error(self):
+        with stub_kea({"config-get": self._CONFIG4, "lease4-get-page": ValueError("bad JSON")}):
+            response = self.client.get(
+                self._url(),
+                {"export": "1", "by": "subnet", "q": "10.0.0.0/24"},
+            )
         self.assertIn(response.status_code, [200, 302])
 
 
@@ -2806,21 +2800,19 @@ class TestLeaseExportTransportErrors(_ViewTestBase):
 class TestSingleLeaseGetTransportErrors(_ViewTestBase):
     """Single-lease GET must handle RequestException/ValueError gracefully."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_request_exception_redirects(self, MockKeaClient):
+    def test_request_exception_redirects(self):
         """requests.RequestException from lease-get must redirect with error message."""
-        MockKeaClient.return_value.command.side_effect = requests.ConnectionError("down")
         url = reverse("plugins:netbox_kea:server_lease4_edit", args=[self.server.pk, "10.0.0.1"])
-        response = self.client.get(url)
+        with stub_kea({"lease4-get": requests.ConnectionError("down")}):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 302)
         self.assertIn(str(self.server.pk), response.url)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_value_error_redirects(self, MockKeaClient):
+    def test_value_error_redirects(self):
         """ValueError from lease-get must redirect with error message."""
-        MockKeaClient.return_value.command.side_effect = ValueError("bad JSON")
         url = reverse("plugins:netbox_kea:server_lease4_edit", args=[self.server.pk, "10.0.0.1"])
-        response = self.client.get(url)
+        with stub_kea({"lease4-get": ValueError("bad JSON")}):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 302)
         self.assertIn(str(self.server.pk), response.url)
 
@@ -2834,21 +2826,20 @@ class TestSingleLeaseGetTransportErrors(_ViewTestBase):
 class TestLeaseEditPostTransportErrors(_ViewTestBase):
     """Lease edit POST must handle RequestException/ValueError gracefully."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_request_exception_redirects(self, MockKeaClient):
+    def test_request_exception_redirects(self):
         """requests.RequestException from lease_update must redirect."""
-        MockKeaClient.return_value.lease_update.side_effect = requests.ConnectionError("down")
+        # lease_update's first command is lease{v}-get; raising there surfaces the transport error.
         url = reverse("plugins:netbox_kea:server_lease4_edit", args=[self.server.pk, "10.0.0.1"])
-        response = self.client.post(url, {"hostname": "host", "valid_lft": "3600"})
+        with stub_kea({"lease4-get": requests.ConnectionError("down")}):
+            response = self.client.post(url, {"hostname": "host", "valid_lft": "3600"})
         self.assertEqual(response.status_code, 302)
         self.assertIn(str(self.server.pk), response.url)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_value_error_redirects(self, MockKeaClient):
+    def test_value_error_redirects(self):
         """ValueError from lease_update must redirect."""
-        MockKeaClient.return_value.lease_update.side_effect = ValueError("bad value")
         url = reverse("plugins:netbox_kea:server_lease4_edit", args=[self.server.pk, "10.0.0.1"])
-        response = self.client.post(url, {"hostname": "host", "valid_lft": "3600"})
+        with stub_kea({"lease4-get": ValueError("bad value")}):
+            response = self.client.post(url, {"hostname": "host", "valid_lft": "3600"})
         self.assertEqual(response.status_code, 302)
         self.assertIn(str(self.server.pk), response.url)
 
@@ -2862,12 +2853,11 @@ class TestLeaseEditPostTransportErrors(_ViewTestBase):
 class TestLeaseAddValueError(_ViewTestBase):
     """Lease add POST must handle ValueError gracefully."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_value_error_rerenders_form(self, MockKeaClient):
+    def test_value_error_rerenders_form(self):
         """ValueError from lease_add must not propagate as 500."""
-        MockKeaClient.return_value.lease_add.side_effect = ValueError("bad value")
         url = reverse("plugins:netbox_kea:server_lease4_add", args=[self.server.pk])
-        response = self.client.post(url, {"ip_address": "10.0.0.99"})
+        with stub_kea({"lease4-add": ValueError("bad value")}):
+            response = self.client.post(url, {"ip_address": "10.0.0.99"})
         self.assertIn(response.status_code, [200, 302])
 
 
@@ -2880,28 +2870,26 @@ class TestLeaseAddValueError(_ViewTestBase):
 class TestLeaseJournalExceptionNarrowing(_ViewTestBase):
     """_add_lease_journal except must only catch DB errors, not all exceptions."""
 
-    @patch("netbox_kea.models.KeaClient")
     @patch("netbox_kea.views.leases._add_lease_journal")
-    def test_database_error_does_not_fail_request(self, mock_journal, MockKeaClient):
+    def test_database_error_does_not_fail_request(self, mock_journal):
         """DatabaseError from _add_lease_journal must be caught; lease add still redirects."""
         from django.db import DatabaseError
 
         mock_journal.side_effect = DatabaseError("DB error")
-        MockKeaClient.return_value.lease_add.return_value = [{"result": 0}]
         url = reverse("plugins:netbox_kea:server_lease4_add", args=[self.server.pk])
-        response = self.client.post(url, {"ip_address": "10.0.0.55"})
+        with stub_kea({"lease4-add": {"result": 0}}):
+            response = self.client.post(url, {"ip_address": "10.0.0.55"})
         self.assertIn(response.status_code, [200, 302])
 
-    @patch("netbox_kea.models.KeaClient")
     @patch("netbox_kea.views.leases._add_lease_journal")
-    def test_operational_error_does_not_fail_request(self, mock_journal, MockKeaClient):
+    def test_operational_error_does_not_fail_request(self, mock_journal):
         """OperationalError from _add_lease_journal must be caught; lease add still redirects."""
         from django.db import OperationalError
 
         mock_journal.side_effect = OperationalError("DB lock")
-        MockKeaClient.return_value.lease_add.return_value = [{"result": 0}]
         url = reverse("plugins:netbox_kea:server_lease4_add", args=[self.server.pk])
-        response = self.client.post(url, {"ip_address": "10.0.0.56"})
+        with stub_kea({"lease4-add": {"result": 0}}):
+            response = self.client.post(url, {"ip_address": "10.0.0.56"})
         self.assertIn(response.status_code, [200, 302])
 
 
@@ -2917,18 +2905,20 @@ class TestLeaseExportClientError(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_client_value_error_redirects(self, MockKeaClient):
+    def test_get_client_value_error_redirects(self):
         """ValueError from get_client in export redirects with error."""
-        MockKeaClient.side_effect = ValueError("bad TLS")
-        response = self.client.get(self._url(), {"export": "form", "by": "subnet", "q": "10.0.0.0/24"})
+        # A cert without a key makes the real KeaClient constructor raise ValueError.
+        bad = _make_db_server(name="badtls-export", client_cert_path="/x/cert.pem")
+        url = reverse("plugins:netbox_kea:server_leases4", args=[bad.pk])
+        with stub_kea({"config-get": {"result": 0, "arguments": {"Dhcp4": {"subnet4": []}}}}):
+            response = self.client.get(url, {"export": "form", "by": "subnet", "q": "10.0.0.0/24"})
         self.assertIn(response.status_code, [200, 302])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_runtime_error_during_fetch_redirects(self, MockKeaClient):
+    def test_runtime_error_during_fetch_redirects(self):
         """RuntimeError during lease fetch in export redirects with error."""
-        MockKeaClient.return_value.command.side_effect = RuntimeError("unexpected")
-        response = self.client.get(self._url(), {"export": "form", "by": "subnet", "q": "10.0.0.0/24"})
+        config = {"result": 0, "arguments": {"Dhcp4": {"subnet4": []}}}
+        with stub_kea({"config-get": config, "lease4-get-page": RuntimeError("unexpected")}):
+            response = self.client.get(self._url(), {"export": "form", "by": "subnet", "q": "10.0.0.0/24"})
         self.assertIn(response.status_code, [200, 302])
 
 
@@ -2944,28 +2934,27 @@ class TestLeaseHtmxErrorHandler(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_kea_exception_renders_htmx_error(self, MockKeaClient):
-        """KeaException in HTMX handler renders error template."""
-        from netbox_kea.kea import KeaException
+    _CONFIG4 = {"result": 0, "arguments": {"Dhcp4": {"subnet4": []}}}
 
-        MockKeaClient.return_value.command.side_effect = KeaException({"result": 1, "text": "err"}, index=0)
-        response = self.client.get(
-            self._url(),
-            {"by": "subnet", "q": "10.0.0.0/24"},
-            HTTP_HX_REQUEST="true",
-        )
+    def test_kea_exception_renders_htmx_error(self):
+        """KeaException in HTMX handler renders error template."""
+        # result=1 on lease4-get-page makes the real client raise KeaException.
+        with stub_kea({"config-get": self._CONFIG4, "lease4-get-page": {"result": 1, "text": "err"}}):
+            response = self.client.get(
+                self._url(),
+                {"by": "subnet", "q": "10.0.0.0/24"},
+                HTTP_HX_REQUEST="true",
+            )
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_request_exception_renders_htmx_error(self, MockKeaClient):
+    def test_request_exception_renders_htmx_error(self):
         """requests.RequestException in HTMX handler renders error template."""
-        MockKeaClient.return_value.command.side_effect = requests.ConnectionError("down")
-        response = self.client.get(
-            self._url(),
-            {"by": "subnet", "q": "10.0.0.0/24"},
-            HTTP_HX_REQUEST="true",
-        )
+        with stub_kea({"config-get": self._CONFIG4, "lease4-get-page": requests.ConnectionError("down")}):
+            response = self.client.get(
+                self._url(),
+                {"by": "subnet", "q": "10.0.0.0/24"},
+                HTTP_HX_REQUEST="true",
+            )
         self.assertEqual(response.status_code, 200)
 
 
@@ -2981,32 +2970,35 @@ class TestLeaseEditGetValidation(_ViewTestBase):
     def _url(self, ip="10.0.0.1"):
         return reverse("plugins:netbox_kea:server_lease4_edit", args=[self.server.pk, ip])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_lease_not_found_result3_redirects(self, MockKeaClient):
+    _CONFIG4 = {"result": 0, "arguments": {"Dhcp4": {"subnet4": []}}}
+
+    def test_lease_not_found_result3_redirects(self):
         """result=3 from Kea (lease not found) shows warning and redirects."""
-        MockKeaClient.return_value.command.return_value = [{"result": 3, "text": "not found"}]
-        response = self.client.get(self._url(), follow=True)
+        with stub_kea({"lease4-get": {"result": 3, "text": "not found"}, "config-get": self._CONFIG4}):
+            response = self.client.get(self._url(), follow=True)
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_bad_response_shape_redirects(self, MockKeaClient):
-        """Non-dict response redirects with error."""
-        MockKeaClient.return_value.command.return_value = ["not a dict"]
-        response = self.client.get(self._url(), follow=True)
+    def test_bad_response_shape_redirects(self):
+        """An empty (shapeless) response list redirects with error."""
+        # A real command returning [] passes the result-code check but fails the
+        # view's resp[0] shape guard → redirect.
+        with stub_kea({"lease4-get": lambda body: [], "config-get": self._CONFIG4}):
+            response = self.client.get(self._url(), follow=True)
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_bad_arguments_redirects(self, MockKeaClient):
-        """arguments=None in response redirects with error."""
-        MockKeaClient.return_value.command.return_value = [{"result": 0, "arguments": "not a dict"}]
-        response = self.client.get(self._url(), follow=True)
+    def test_bad_arguments_redirects(self):
+        """Non-dict arguments in response redirects with error."""
+        with stub_kea({"lease4-get": {"result": 0, "arguments": "not a dict"}, "config-get": self._CONFIG4}):
+            response = self.client.get(self._url(), follow=True)
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_client_value_error_redirects(self, MockKeaClient):
+    def test_get_client_value_error_redirects(self):
         """ValueError from get_client redirects with error."""
-        MockKeaClient.side_effect = ValueError("bad TLS")
-        response = self.client.get(self._url(), follow=True)
+        # A cert without a key makes the real KeaClient constructor raise ValueError.
+        bad = _make_db_server(name="badtls-edit", client_cert_path="/x/cert.pem")
+        url = reverse("plugins:netbox_kea:server_lease4_edit", args=[bad.pk, "10.0.0.1"])
+        with stub_kea({"config-get": self._CONFIG4}):
+            response = self.client.get(url, follow=True)
         self.assertEqual(response.status_code, 200)
 
 
@@ -3022,18 +3014,19 @@ class TestLeaseUpdatePostErrors(_ViewTestBase):
     def _url(self, ip="10.0.0.1"):
         return reverse("plugins:netbox_kea:server_lease4_edit", args=[self.server.pk, ip])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_request_exception_redirects(self, MockKeaClient):
+    _CONFIG4 = {"result": 0, "arguments": {"Dhcp4": {"subnet4": []}}}
+
+    def test_request_exception_redirects(self):
         """RequestException from lease_update redirects with error."""
-        MockKeaClient.return_value.lease_update.side_effect = requests.ConnectionError("down")
-        response = self.client.post(self._url(), {"hostname": "test", "valid_lft": "3600"}, follow=True)
+        # lease_update's first command is lease4-get; raising there surfaces the transport error.
+        with stub_kea({"lease4-get": requests.ConnectionError("down"), "config-get": self._CONFIG4}):
+            response = self.client.post(self._url(), {"hostname": "test", "valid_lft": "3600"}, follow=True)
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_value_error_redirects(self, MockKeaClient):
+    def test_value_error_redirects(self):
         """ValueError from lease_update redirects with error."""
-        MockKeaClient.return_value.lease_update.side_effect = ValueError("bad JSON")
-        response = self.client.post(self._url(), {"hostname": "test", "valid_lft": "3600"}, follow=True)
+        with stub_kea({"lease4-get": ValueError("bad JSON"), "config-get": self._CONFIG4}):
+            response = self.client.post(self._url(), {"hostname": "test", "valid_lft": "3600"}, follow=True)
         self.assertEqual(response.status_code, 200)
 
 
@@ -3052,27 +3045,23 @@ class TestLeaseAddPostErrors(_ViewTestBase):
     def _valid_form(self):
         return {"ip_address": "10.0.0.1", "subnet_id": "1", "hw_address": "aa:bb:cc:00:00:01", "valid_lft": "3600"}
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_kea_exception_rerenders_form(self, MockKeaClient):
+    def test_kea_exception_rerenders_form(self):
         """KeaException from lease_add re-renders form with error."""
-        from netbox_kea.kea import KeaException
-
-        MockKeaClient.return_value.lease_add.side_effect = KeaException({"result": 1, "text": "dup"}, index=0)
-        response = self.client.post(self._url(), self._valid_form())
+        # result=1 on lease4-add makes the real client raise KeaException.
+        with stub_kea({"lease4-add": {"result": 1, "text": "dup"}}):
+            response = self.client.post(self._url(), self._valid_form())
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_request_exception_rerenders_form(self, MockKeaClient):
+    def test_request_exception_rerenders_form(self):
         """RequestException from lease_add re-renders form with error."""
-        MockKeaClient.return_value.lease_add.side_effect = requests.ConnectionError("down")
-        response = self.client.post(self._url(), self._valid_form())
+        with stub_kea({"lease4-add": requests.ConnectionError("down")}):
+            response = self.client.post(self._url(), self._valid_form())
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_value_error_rerenders_form(self, MockKeaClient):
+    def test_value_error_rerenders_form(self):
         """ValueError from lease_add re-renders form with error."""
-        MockKeaClient.return_value.lease_add.side_effect = ValueError("bad JSON")
-        response = self.client.post(self._url(), self._valid_form())
+        with stub_kea({"lease4-add": ValueError("bad JSON")}):
+            response = self.client.post(self._url(), self._valid_form())
         self.assertEqual(response.status_code, 200)
 
 
@@ -3092,14 +3081,14 @@ class TestLeaseAddSideEffectErrors(_ViewTestBase):
         return {"ip_address": "10.0.0.1", "subnet_id": "1", "hw_address": "aa:bb:cc:00:00:01", "valid_lft": "3600"}
 
     @patch("netbox_kea.views.leases._add_lease_journal")
-    @patch("netbox_kea.models.KeaClient")
-    def test_journal_db_error_still_succeeds(self, MockKeaClient, mock_journal):
+    def test_journal_db_error_still_succeeds(self, mock_journal):
         """DatabaseError in journal entry creation still redirects successfully."""
         from django.db import DatabaseError
 
-        MockKeaClient.return_value.lease_add.return_value = None
         mock_journal.side_effect = DatabaseError("DB error")
-        response = self.client.post(self._url(), self._valid_form(), follow=True)
+        config = {"result": 0, "arguments": {"Dhcp4": {"subnet4": []}}}
+        with stub_kea({"lease4-add": {"result": 0}, "config-get": config}):
+            response = self.client.post(self._url(), self._valid_form(), follow=True)
         self.assertEqual(response.status_code, 200)
 
 

--- a/netbox_kea/tests/test_views_leases.py
+++ b/netbox_kea/tests/test_views_leases.py
@@ -3288,42 +3288,37 @@ class TestPendingIpChangeBadgeRendering(_ViewTestBase):
     def _htmx_get(self, url, data):
         return self.client.get(url, data=data, HTTP_HX_REQUEST="true")
 
-    @patch("netbox_kea.sync.bulk_fetch_netbox_ips")
+    _CONFIG4 = {"result": 0, "arguments": {"Dhcp4": {"subnet4": [{"id": 7, "subnet": "10.0.0.0/24"}]}}}
+    _MAC_RSV = {"subnet-id": 7, "ip-address": "10.0.0.20", "hw-address": "aa:bb:cc:dd:ee:01"}
+
+    def _stub(self):
+        """Real lease search + IP reservation lookup that finds nothing (result 3)."""
+        return stub_kea(
+            {
+                "config-get": self._CONFIG4,
+                "lease4-get": {"result": 0, "arguments": dict(self._LEASE4)},
+                "reservation-get": {"result": 3},  # no IP-based match
+            }
+        )
+
     @patch("netbox_kea.views.leases._fetch_reservation_by_mac_for_leases")
-    @patch("netbox_kea.models.KeaClient")
-    def test_pending_ip_badge_renders_in_response(self, MockKeaClient, mock_mac_fetch, mock_bulk_fetch):
+    def test_pending_ip_badge_renders_in_response(self, mock_mac_fetch):
         """The lease table must show a 'Pending' badge with the reserved IP when pending change detected."""
-        mock_client = MockKeaClient.return_value
-        mock_client.clone.return_value = mock_client
-        mock_client.__enter__ = lambda s: s
-        mock_client.__exit__ = lambda s, *a: None
-        mock_client.command.return_value = [{"result": 0, "arguments": {"ip-address": "10.0.0.10", **self._LEASE4}}]
-        mock_client.reservation_get.return_value = None  # No IP-based match
-        mac_rsv = {"subnet-id": 7, "ip-address": "10.0.0.20", "hw-address": "aa:bb:cc:dd:ee:01"}
-        mock_mac_fetch.return_value = ({("aa:bb:cc:dd:ee:01", 7): mac_rsv}, set())
-        mock_bulk_fetch.return_value = {}
+        mock_mac_fetch.return_value = ({("aa:bb:cc:dd:ee:01", 7): self._MAC_RSV}, set())
         url = reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
-        response = self._htmx_get(url, {"by": "ip", "q": "10.0.0.10"})
+        with self._stub():
+            response = self._htmx_get(url, {"by": "ip", "q": "10.0.0.10"})
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Pending")
         self.assertContains(response, "10.0.0.20")
 
-    @patch("netbox_kea.sync.bulk_fetch_netbox_ips")
     @patch("netbox_kea.views.leases._fetch_reservation_by_mac_for_leases")
-    @patch("netbox_kea.models.KeaClient")
-    def test_pending_ip_badge_does_not_show_sync_button(self, MockKeaClient, mock_mac_fetch, mock_bulk_fetch):
+    def test_pending_ip_badge_does_not_show_sync_button(self, mock_mac_fetch):
         """When pending IP change detected, the Sync button must NOT appear."""
-        mock_client = MockKeaClient.return_value
-        mock_client.clone.return_value = mock_client
-        mock_client.__enter__ = lambda s: s
-        mock_client.__exit__ = lambda s, *a: None
-        mock_client.command.return_value = [{"result": 0, "arguments": {"ip-address": "10.0.0.10", **self._LEASE4}}]
-        mock_client.reservation_get.return_value = None
-        mac_rsv = {"subnet-id": 7, "ip-address": "10.0.0.20", "hw-address": "aa:bb:cc:dd:ee:01"}
-        mock_mac_fetch.return_value = ({("aa:bb:cc:dd:ee:01", 7): mac_rsv}, set())
-        mock_bulk_fetch.return_value = {}
+        mock_mac_fetch.return_value = ({("aa:bb:cc:dd:ee:01", 7): self._MAC_RSV}, set())
         url = reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
-        response = self._htmx_get(url, {"by": "ip", "q": "10.0.0.10"})
+        with self._stub():
+            response = self._htmx_get(url, {"by": "ip", "q": "10.0.0.10"})
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, "Sync</button>")
 
@@ -3332,18 +3327,17 @@ class TestPendingIpChangeBadgeRendering(_ViewTestBase):
 class TestFetchReservationByMac(_ViewTestBase):
     """Tests for _fetch_reservation_by_mac_for_leases helper function."""
 
+    def _client(self):
+        return self.server.get_client(version=4)
+
     def test_returns_reservation_when_ip_differs(self):
         """MAC reservation at different IP must be included in result."""
         from netbox_kea.views.leases import _fetch_reservation_by_mac_for_leases
 
-        mock_client = MagicMock(spec=KeaClient)
         rsv = {"ip-address": "10.0.0.20", "hw-address": "aa:bb:cc:dd:ee:01", "subnet-id": 1}
-        mock_client.clone.return_value = mock_client
-        mock_client.__enter__ = lambda s: s
-        mock_client.__exit__ = lambda s, *a: None
-        mock_client.reservation_get.return_value = rsv
         leases = [{"ip_address": "10.0.0.10", "hw_address": "aa:bb:cc:dd:ee:01", "subnet_id": 1}]
-        result, failed = _fetch_reservation_by_mac_for_leases(mock_client, 4, leases, set(), set())
+        with stub_kea({"reservation-get": {"result": 0, "arguments": rsv}}):
+            result, failed = _fetch_reservation_by_mac_for_leases(self._client(), 4, leases, set(), set())
         self.assertIn(("aa:bb:cc:dd:ee:01", 1), result)
         self.assertEqual(result[("aa:bb:cc:dd:ee:01", 1)]["ip-address"], "10.0.0.20")
         self.assertEqual(failed, set())
@@ -3352,66 +3346,49 @@ class TestFetchReservationByMac(_ViewTestBase):
         """MAC reservation at same IP as lease must NOT be included (already handled by IP lookup)."""
         from netbox_kea.views.leases import _fetch_reservation_by_mac_for_leases
 
-        mock_client = MagicMock(spec=KeaClient)
         rsv = {"ip-address": "10.0.0.10", "hw-address": "aa:bb:cc:dd:ee:01", "subnet-id": 1}
-        mock_client.clone.return_value = mock_client
-        mock_client.__enter__ = lambda s: s
-        mock_client.__exit__ = lambda s, *a: None
-        mock_client.reservation_get.return_value = rsv
         leases = [{"ip_address": "10.0.0.10", "hw_address": "aa:bb:cc:dd:ee:01", "subnet_id": 1}]
-        result, failed = _fetch_reservation_by_mac_for_leases(mock_client, 4, leases, set(), set())
+        with stub_kea({"reservation-get": {"result": 0, "arguments": rsv}}):
+            result, failed = _fetch_reservation_by_mac_for_leases(self._client(), 4, leases, set(), set())
         self.assertEqual(result, {})
 
     def test_skips_already_matched_ips(self):
         """Leases in already_matched_ips must not trigger a MAC lookup."""
         from netbox_kea.views.leases import _fetch_reservation_by_mac_for_leases
 
-        mock_client = MagicMock(spec=KeaClient)
-        mock_client.clone.return_value = mock_client
-        mock_client.__enter__ = lambda s: s
-        mock_client.__exit__ = lambda s, *a: None
         leases = [{"ip_address": "10.0.0.10", "hw_address": "aa:bb:cc:dd:ee:01", "subnet_id": 1}]
-        result, failed = _fetch_reservation_by_mac_for_leases(mock_client, 4, leases, {"10.0.0.10"}, set())
+        # Empty registry: any reservation-get would raise, proving none is issued.
+        with stub_kea({}) as kea:
+            result, failed = _fetch_reservation_by_mac_for_leases(self._client(), 4, leases, {"10.0.0.10"}, set())
         self.assertEqual(result, {})
-        mock_client.reservation_get.assert_not_called()
+        self.assertEqual(kea.commands(), [])
 
     def test_skips_failed_ips(self):
         """Leases in failed_ips must not trigger a MAC lookup."""
         from netbox_kea.views.leases import _fetch_reservation_by_mac_for_leases
 
-        mock_client = MagicMock(spec=KeaClient)
-        mock_client.clone.return_value = mock_client
-        mock_client.__enter__ = lambda s: s
-        mock_client.__exit__ = lambda s, *a: None
         leases = [{"ip_address": "10.0.0.10", "hw_address": "aa:bb:cc:dd:ee:01", "subnet_id": 1}]
-        result, failed = _fetch_reservation_by_mac_for_leases(mock_client, 4, leases, set(), {"10.0.0.10"})
+        with stub_kea({}) as kea:
+            result, failed = _fetch_reservation_by_mac_for_leases(self._client(), 4, leases, set(), {"10.0.0.10"})
         self.assertEqual(result, {})
-        mock_client.reservation_get.assert_not_called()
+        self.assertEqual(kea.commands(), [])
 
     def test_returns_empty_for_no_mac_reservation(self):
         """When reservation_get returns None, result must be empty."""
         from netbox_kea.views.leases import _fetch_reservation_by_mac_for_leases
 
-        mock_client = MagicMock(spec=KeaClient)
-        mock_client.clone.return_value = mock_client
-        mock_client.__enter__ = lambda s: s
-        mock_client.__exit__ = lambda s, *a: None
-        mock_client.reservation_get.return_value = None
         leases = [{"ip_address": "10.0.0.10", "hw_address": "aa:bb:cc:dd:ee:01", "subnet_id": 1}]
-        result, failed = _fetch_reservation_by_mac_for_leases(mock_client, 4, leases, set(), set())
+        with stub_kea({"reservation-get": {"result": 3}}):
+            result, failed = _fetch_reservation_by_mac_for_leases(self._client(), 4, leases, set(), set())
         self.assertEqual(result, {})
 
     def test_exception_in_worker_is_swallowed(self):
         """An exception from reservation_get must not crash; MAC is simply omitted."""
         from netbox_kea.views.leases import _fetch_reservation_by_mac_for_leases
 
-        mock_client = MagicMock(spec=KeaClient)
-        mock_client.clone.return_value = mock_client
-        mock_client.__enter__ = lambda s: s
-        mock_client.__exit__ = lambda s, *a: None
-        mock_client.reservation_get.side_effect = RuntimeError("connection failed")
         leases = [{"ip_address": "10.0.0.10", "hw_address": "aa:bb:cc:dd:ee:01", "subnet_id": 1}]
-        result, failed = _fetch_reservation_by_mac_for_leases(mock_client, 4, leases, set(), set())
+        with stub_kea({"reservation-get": RuntimeError("connection failed")}):
+            result, failed = _fetch_reservation_by_mac_for_leases(self._client(), 4, leases, set(), set())
         self.assertEqual(result, {})
         self.assertIn(("aa:bb:cc:dd:ee:01", 1), failed)
 
@@ -3419,17 +3396,13 @@ class TestFetchReservationByMac(_ViewTestBase):
         """Multiple leases with the same MAC must only trigger one reservation_get call."""
         from netbox_kea.views.leases import _fetch_reservation_by_mac_for_leases
 
-        mock_client = MagicMock(spec=KeaClient)
-        mock_client.clone.return_value = mock_client
-        mock_client.__enter__ = lambda s: s
-        mock_client.__exit__ = lambda s, *a: None
-        mock_client.reservation_get.return_value = None
         leases = [
             {"ip_address": "10.0.0.10", "hw_address": "aa:bb:cc:dd:ee:01", "subnet_id": 1},
             {"ip_address": "10.0.0.11", "hw_address": "aa:bb:cc:dd:ee:01", "subnet_id": 1},
         ]
-        _fetch_reservation_by_mac_for_leases(mock_client, 4, leases, set(), set())
-        self.assertEqual(mock_client.reservation_get.call_count, 1)
+        with stub_kea({"reservation-get": {"result": 3}}) as kea:
+            _fetch_reservation_by_mac_for_leases(self._client(), 4, leases, set(), set())
+        self.assertEqual(kea.commands().count("reservation-get"), 1)
 
 
 # ---------------------------------------------------------------------------

--- a/netbox_kea/tests/test_views_leases.py
+++ b/netbox_kea/tests/test_views_leases.py
@@ -3414,32 +3414,30 @@ class TestFetchReservationByMac(_ViewTestBase):
 class TestGetLeasesPageDefensiveChecks(_ViewTestBase):
     """Cover the isinstance guards and RuntimeError paths in get_leases_page()."""
 
+    _CONFIG4 = {"result": 0, "arguments": {"Dhcp4": {"subnet4": []}}}
+
     def _url(self):
         return reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_non_list_leases_raises_runtime_error(self, MockKeaClient):
+    def test_non_list_leases_raises_runtime_error(self):
         """When Kea returns leases as non-list, the view catches the RuntimeError."""
-        MockKeaClient.return_value.command.return_value = [
-            {"result": 0, "arguments": {"leases": "not-a-list", "count": 0}}
-        ]
-        response = self.client.get(self._url(), {"by": "subnet", "q": "10.0.0.0/24"}, HTTP_HX_REQUEST="true")
+        page = {"result": 0, "arguments": {"leases": "not-a-list", "count": 0}}
+        with stub_kea({"config-get": self._CONFIG4, "lease4-get-page": page}):
+            response = self.client.get(self._url(), {"by": "subnet", "q": "10.0.0.0/24"}, HTTP_HX_REQUEST="true")
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_non_int_count_raises_runtime_error(self, MockKeaClient):
+    def test_non_int_count_raises_runtime_error(self):
         """When Kea returns count as non-int, the view catches the RuntimeError."""
-        MockKeaClient.return_value.command.return_value = [{"result": 0, "arguments": {"leases": [], "count": "bad"}}]
-        response = self.client.get(self._url(), {"by": "subnet", "q": "10.0.0.0/24"}, HTTP_HX_REQUEST="true")
+        page = {"result": 0, "arguments": {"leases": [], "count": "bad"}}
+        with stub_kea({"config-get": self._CONFIG4, "lease4-get-page": page}):
+            response = self.client.get(self._url(), {"by": "subnet", "q": "10.0.0.0/24"}, HTTP_HX_REQUEST="true")
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_filtered_out_items_on_partial_page_returns_empty(self, MockKeaClient):
+    def test_filtered_out_items_on_partial_page_returns_empty(self):
         """Items without ip-address are filtered; partial page returns empty gracefully."""
-        MockKeaClient.return_value.command.return_value = [
-            {"result": 0, "arguments": {"leases": [{"no-ip": "bad"}], "count": 1}}
-        ]
-        response = self.client.get(self._url(), {"by": "subnet", "q": "10.0.0.0/24"}, HTTP_HX_REQUEST="true")
+        page = {"result": 0, "arguments": {"leases": [{"no-ip": "bad"}], "count": 1}}
+        with stub_kea({"config-get": self._CONFIG4, "lease4-get-page": page}):
+            response = self.client.get(self._url(), {"by": "subnet", "q": "10.0.0.0/24"}, HTTP_HX_REQUEST="true")
         self.assertEqual(response.status_code, 200)
 
 
@@ -3450,42 +3448,26 @@ class TestExportAllDefensiveChecks(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_non_list_leases_in_export_redirects(self, MockKeaClient):
+    def test_non_list_leases_in_export_redirects(self):
         """When export_all gets non-list leases, it redirects with error."""
-        MockKeaClient.return_value.command.return_value = [
-            {"result": 0, "arguments": {"leases": "not-a-list", "count": 0}}
-        ]
-        response = self.client.get(self._url(), {"export_all": "1"})
+        page = {"result": 0, "arguments": {"leases": "not-a-list", "count": 0}}
+        with stub_kea({"lease4-get-page": page}):
+            response = self.client.get(self._url(), {"export_all": "1"})
         self.assertEqual(response.status_code, 302)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_non_int_count_in_export_redirects(self, MockKeaClient):
+    def test_non_int_count_in_export_redirects(self):
         """When export_all gets non-int count, it redirects with error."""
-        MockKeaClient.return_value.command.return_value = [{"result": 0, "arguments": {"leases": [], "count": "bad"}}]
-        response = self.client.get(self._url(), {"export_all": "1"})
+        page = {"result": 0, "arguments": {"leases": [], "count": "bad"}}
+        with stub_kea({"lease4-get-page": page}):
+            response = self.client.get(self._url(), {"export_all": "1"})
         self.assertEqual(response.status_code, 302)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_full_page_all_filtered_aborts_export(self, MockKeaClient):
+    def test_full_page_all_filtered_aborts_export(self):
         """When a full page has all entries filtered out, export aborts with error."""
-
-        # export_all uses per_page=1000; send 1000 invalid items to match.
-        def _side_effect(cmd, service=None, arguments=None, check=None):
-            if cmd == "lease4-get-page":
-                return [
-                    {
-                        "result": 0,
-                        "arguments": {
-                            "leases": [{"no-ip": f"bad-{i}"} for i in range(1000)],
-                            "count": 1000,
-                        },
-                    }
-                ]
-            return [{"result": 0, "arguments": {}}]
-
-        MockKeaClient.return_value.command.side_effect = _side_effect
-        response = self.client.get(self._url(), {"export_all": "1"})
+        # export_all uses per_page=1000; a full page of invalid items aborts the export.
+        page = {"result": 0, "arguments": {"leases": [{"no-ip": f"bad-{i}"} for i in range(1000)], "count": 1000}}
+        with stub_kea({"lease4-get-page": page}):
+            response = self.client.get(self._url(), {"export_all": "1"})
         self.assertEqual(response.status_code, 302)
 
 
@@ -3556,70 +3538,59 @@ class TestGetLeasesPageMalformedResponse(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_non_list_leases_payload_renders_error(self, MockKeaClient):
+    _CONFIG4 = {"result": 0, "arguments": {"Dhcp4": {"subnet4": []}}}
+
+    def test_non_list_leases_payload_renders_error(self):
         """When Kea returns non-list 'leases', the HTMX handler catches RuntimeError."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = [{"result": 0, "arguments": {"leases": "not-a-list", "count": 1}}]
-        response = self._htmx_get(self._url(), {"by": "subnet", "q": "10.0.0.0/24"})
+        page = {"result": 0, "arguments": {"leases": "not-a-list", "count": 1}}
+        with stub_kea({"config-get": self._CONFIG4, "lease4-get-page": page}):
+            response = self._htmx_get(self._url(), {"by": "subnet", "q": "10.0.0.0/24"})
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "error")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_non_int_count_renders_error(self, MockKeaClient):
+    def test_non_int_count_renders_error(self):
         """When Kea returns non-int 'count', the HTMX handler catches RuntimeError."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = [{"result": 0, "arguments": {"leases": [], "count": "not-an-int"}}]
-        response = self._htmx_get(self._url(), {"by": "subnet", "q": "10.0.0.0/24"})
+        page = {"result": 0, "arguments": {"leases": [], "count": "not-an-int"}}
+        with stub_kea({"config-get": self._CONFIG4, "lease4-get-page": page}):
+            response = self._htmx_get(self._url(), {"by": "subnet", "q": "10.0.0.0/24"})
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "error")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_full_page_all_filtered_renders_error(self, MockKeaClient):
+    def test_full_page_all_filtered_renders_error(self):
         """Full page (count==per_page) but all entries invalid must trigger RuntimeError."""
-        mock_client = MockKeaClient.return_value
-        # Return entries that are not valid dicts (will be filtered out by _is_valid_lease_entry)
+        # Entries that are not valid dicts (filtered out by _is_valid_lease_entry).
         per_page = 50
-        mock_client.command.return_value = [
-            {
-                "result": 0,
-                "arguments": {
-                    "leases": ["not-a-dict"] * per_page,
-                    "count": per_page,
-                },
-            }
-        ]
-        response = self._htmx_get(
-            self._url(),
-            {"by": "subnet", "q": "10.0.0.0/24", "per_page": str(per_page)},
-        )
+        page = {"result": 0, "arguments": {"leases": ["not-a-dict"] * per_page, "count": per_page}}
+        with stub_kea({"config-get": self._CONFIG4, "lease4-get-page": page}):
+            response = self._htmx_get(
+                self._url(),
+                {"by": "subnet", "q": "10.0.0.0/24", "per_page": str(per_page)},
+            )
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "error")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_none_arguments_renders_error(self, MockKeaClient):
+    def test_none_arguments_renders_error(self):
         """When resp[0]['arguments'] is None, the HTMX handler catches RuntimeError."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = [{"result": 0, "arguments": None}]
-        response = self._htmx_get(self._url(), {"by": "subnet", "q": "10.0.0.0/24"})
+        with stub_kea({"config-get": self._CONFIG4, "lease4-get-page": {"result": 0, "arguments": None}}):
+            response = self._htmx_get(self._url(), {"by": "subnet", "q": "10.0.0.0/24"})
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "error")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_empty_response_list_renders_error(self, MockKeaClient):
+    def test_empty_response_list_renders_error(self):
         """When Kea returns an empty list, get_leases_page raises RuntimeError."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = []
-        response = self._htmx_get(self._url(), {"by": "subnet", "q": "10.0.0.0/24"})
+        # A real command returning [] passes the result-code check but fails the resp guard.
+        with stub_kea({"config-get": self._CONFIG4, "lease4-get-page": lambda body: []}):
+            response = self._htmx_get(self._url(), {"by": "subnet", "q": "10.0.0.0/24"})
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "error")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_non_dict_first_element_renders_error(self, MockKeaClient):
+    def test_non_dict_first_element_renders_error(self):
         """When resp[0] is not a dict, the HTMX handler catches RuntimeError."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = ["not-a-dict"]
-        response = self._htmx_get(self._url(), {"by": "subnet", "q": "10.0.0.0/24"})
+        # A non-dict entry can't survive the real command's result-code check
+        # (check_response would TypeError first), so this defensive guard is only
+        # reachable by returning it straight from command() — mock that one method.
+        with patch.object(KeaClient, "command", return_value=["not-a-dict"]):
+            response = self._htmx_get(self._url(), {"by": "subnet", "q": "10.0.0.0/24"})
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "error")
 
@@ -3637,43 +3608,39 @@ class TestGetLeasesSingleResultValidation(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_single_result_missing_ip_address_renders_error(self, MockKeaClient):
+    _CONFIG4 = {"result": 0, "arguments": {"Dhcp4": {"subnet4": []}}}
+
+    def test_single_result_missing_ip_address_renders_error(self):
         """Single-result response without 'ip-address' key must trigger RuntimeError."""
-        mock_client = MockKeaClient.return_value
-        # Single result mode (by ip), but response args lack 'ip-address'
-        mock_client.command.return_value = [
-            {"result": 0, "arguments": {"hw-address": "aa:bb:cc:dd:ee:ff", "subnet-id": 1}}
-        ]
-        response = self._htmx_get(self._url(), {"by": "ip", "q": "10.0.0.5"})
+        # Single result mode (by ip), but response args lack 'ip-address'.
+        resp = {"result": 0, "arguments": {"hw-address": "aa:bb:cc:dd:ee:ff", "subnet-id": 1}}
+        with stub_kea({"config-get": self._CONFIG4, "lease4-get": resp}):
+            response = self._htmx_get(self._url(), {"by": "ip", "q": "10.0.0.5"})
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "error")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_multiple_result_all_non_dict_renders_error(self, MockKeaClient):
+    def test_multiple_result_all_non_dict_renders_error(self):
         """Multiple-result with all non-dict entries filtered out must trigger RuntimeError."""
-        mock_client = MockKeaClient.return_value
-        # by=hw returns multiple mode; all entries are non-dict
-        mock_client.command.return_value = [{"result": 0, "arguments": {"leases": ["bad", 123, None], "count": 3}}]
-        response = self._htmx_get(self._url(), {"by": "hw", "q": "aa:bb:cc:dd:ee:ff"})
+        # by=hw returns multiple mode; all entries are non-dict.
+        resp = {"result": 0, "arguments": {"leases": ["bad", 123, None], "count": 3}}
+        with stub_kea({"config-get": self._CONFIG4, "lease4-get-by-hw-address": resp}):
+            response = self._htmx_get(self._url(), {"by": "hw", "q": "aa:bb:cc:dd:ee:ff"})
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "error")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_multiple_result_none_arguments_renders_error(self, MockKeaClient):
+    def test_multiple_result_none_arguments_renders_error(self):
         """Multiple-result with None arguments must trigger RuntimeError."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = [{"result": 0, "arguments": None}]
-        response = self._htmx_get(self._url(), {"by": "hw", "q": "aa:bb:cc:dd:ee:ff"})
+        resp = {"result": 0, "arguments": None}
+        with stub_kea({"config-get": self._CONFIG4, "lease4-get-by-hw-address": resp}):
+            response = self._htmx_get(self._url(), {"by": "hw", "q": "aa:bb:cc:dd:ee:ff"})
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "error")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_multiple_result_non_list_leases_renders_error(self, MockKeaClient):
+    def test_multiple_result_non_list_leases_renders_error(self):
         """Multiple-result with non-list leases must trigger RuntimeError."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = [{"result": 0, "arguments": {"leases": "not-a-list"}}]
-        response = self._htmx_get(self._url(), {"by": "hw", "q": "aa:bb:cc:dd:ee:ff"})
+        resp = {"result": 0, "arguments": {"leases": "not-a-list"}}
+        with stub_kea({"config-get": self._CONFIG4, "lease4-get-by-hw-address": resp}):
+            response = self._htmx_get(self._url(), {"by": "hw", "q": "aa:bb:cc:dd:ee:ff"})
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "error")
 
@@ -3685,62 +3652,43 @@ class TestExportErrorPaths(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_export_request_exception_redirects(self, MockKeaClient):
+    _CONFIG4 = {"result": 0, "arguments": {"Dhcp4": {"subnet4": []}}}
+
+    def test_export_request_exception_redirects(self):
         """RequestException during export fetch must redirect with error message."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.side_effect = requests.RequestException("connection refused")
-        response = self.client.get(
-            self._url(),
-            {"export": "all", "by": "ip", "q": "10.0.0.5"},
-        )
+        with stub_kea({"config-get": self._CONFIG4, "lease4-get": requests.RequestException("connection refused")}):
+            response = self.client.get(self._url(), {"export": "all", "by": "ip", "q": "10.0.0.5"})
         self.assertEqual(response.status_code, 302)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_export_runtime_error_redirects(self, MockKeaClient):
+    def test_export_runtime_error_redirects(self):
         """RuntimeError during export fetch must redirect with error message."""
-        mock_client = MockKeaClient.return_value
-        # Return malformed data so get_leases() raises RuntimeError internally
-        mock_client.command.return_value = [{"result": 0, "arguments": {"hw-address": "aa:bb:cc:dd:ee:ff"}}]
-        response = self.client.get(
-            self._url(),
-            {"export": "all", "by": "ip", "q": "10.0.0.5"},
-        )
+        # Single-result response lacking 'ip-address' → get_leases() raises RuntimeError.
+        resp = {"result": 0, "arguments": {"hw-address": "aa:bb:cc:dd:ee:ff"}}
+        with stub_kea({"config-get": self._CONFIG4, "lease4-get": resp}):
+            response = self.client.get(self._url(), {"export": "all", "by": "ip", "q": "10.0.0.5"})
         self.assertEqual(response.status_code, 302)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_export_kea_exception_redirects(self, MockKeaClient):
+    def test_export_kea_exception_redirects(self):
         """KeaException during export fetch must redirect with error hint."""
-        from netbox_kea.kea import KeaException
-
-        mock_client = MockKeaClient.return_value
-        mock_client.command.side_effect = KeaException({"result": 1, "text": "internal error"}, index=0)
-        response = self.client.get(
-            self._url(),
-            {"export": "all", "by": "ip", "q": "10.0.0.5"},
-        )
+        with stub_kea({"config-get": self._CONFIG4, "lease4-get": {"result": 1, "text": "internal error"}}):
+            response = self.client.get(self._url(), {"export": "all", "by": "ip", "q": "10.0.0.5"})
         self.assertEqual(response.status_code, 302)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_export_client_creation_failure_redirects(self, MockKeaClient):
+    def test_export_client_creation_failure_redirects(self):
         """ValueError during get_client() for export must redirect with error message."""
-        MockKeaClient.side_effect = ValueError("bad config")
-        response = self.client.get(
-            self._url(),
-            {"export": "all", "by": "ip", "q": "10.0.0.5"},
-        )
+        # A cert without a key makes the real KeaClient constructor raise ValueError.
+        bad = _make_db_server(name="badtls-export2", client_cert_path="/x/cert.pem")
+        url = reverse("plugins:netbox_kea:server_leases4", args=[bad.pk])
+        with stub_kea({"config-get": self._CONFIG4}):
+            response = self.client.get(url, {"export": "all", "by": "ip", "q": "10.0.0.5"})
         self.assertEqual(response.status_code, 302)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_export_subnet_runtime_error_redirects(self, MockKeaClient):
+    def test_export_subnet_runtime_error_redirects(self):
         """RuntimeError during paginated subnet export must redirect with error message."""
-        mock_client = MockKeaClient.return_value
-        # Return malformed response for get_leases_page (non-list leases)
-        mock_client.command.return_value = [{"result": 0, "arguments": {"leases": "not-a-list", "count": 1}}]
-        response = self.client.get(
-            self._url(),
-            {"export": "all", "by": "subnet", "q": "10.0.0.0/24"},
-        )
+        # Malformed response for get_leases_page (non-list leases).
+        page = {"result": 0, "arguments": {"leases": "not-a-list", "count": 1}}
+        with stub_kea({"config-get": self._CONFIG4, "lease4-get-page": page}):
+            response = self.client.get(self._url(), {"export": "all", "by": "subnet", "q": "10.0.0.0/24"})
         self.assertEqual(response.status_code, 302)
 
 
@@ -3751,27 +3699,14 @@ class TestLeaseDeletePartialFailure(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_leases4_delete", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_partial_failure_shows_mixed_messages(self, MockKeaClient):
+    def test_partial_failure_shows_mixed_messages(self):
         """Some leases succeed, others fail with KeaException → mixed messages."""
-        from netbox_kea.kea import KeaException
-
-        mock_client = MockKeaClient.return_value
-        call_count = {"n": 0}
-
-        def side_effect(cmd, **kwargs):
-            if cmd != "lease4-del":
-                return [{"result": 0}]
-            call_count["n"] += 1
-            if call_count["n"] == 1:
-                return [{"result": 0}]  # first IP succeeds
-            raise KeaException({"result": 1, "text": "lease not found"})
-
-        mock_client.command.side_effect = side_effect
-        response = self.client.post(
-            self._url(),
-            {"pk": ["10.0.0.1", "10.0.0.2"], "_confirm": "1"},
-        )
+        # First lease4-del succeeds (result 0), second fails (result 1 → KeaException).
+        with stub_kea({"lease4-del": [{"result": 0}, {"result": 1, "text": "lease not found"}]}):
+            response = self.client.post(
+                self._url(),
+                {"pk": ["10.0.0.1", "10.0.0.2"], "_confirm": "1"},
+            )
         self.assertEqual(response.status_code, 302)
         # Follow redirect to check messages
         msgs = list(response.wsgi_request._messages)
@@ -3784,25 +3719,20 @@ class TestLeaseDeletePartialFailure(_ViewTestBase):
         self.assertTrue(has_error, f"Expected error message, got: {msg_texts}")
         self.assertTrue(has_warning, f"Expected warning message, got: {msg_texts}")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_partial_failure_request_exception(self, MockKeaClient):
+    def test_partial_failure_request_exception(self):
         """RequestException on some leases must show per-lease error messages."""
-        mock_client = MockKeaClient.return_value
-        call_count = {"n": 0}
 
-        def side_effect(cmd, **kwargs):
-            if cmd != "lease4-del":
-                return [{"result": 0}]
-            call_count["n"] += 1
-            if call_count["n"] == 1:
-                return [{"result": 0}]  # first IP succeeds
-            raise requests.RequestException("timeout")
+        # First lease4-del succeeds; the second raises a transport error.
+        def del_resp(body):
+            if body["arguments"]["ip-address"] == "10.0.0.2":
+                return requests.RequestException("timeout")
+            return {"result": 0}
 
-        mock_client.command.side_effect = side_effect
-        response = self.client.post(
-            self._url(),
-            {"pk": ["10.0.0.1", "10.0.0.2"], "_confirm": "1"},
-        )
+        with stub_kea({"lease4-del": del_resp}):
+            response = self.client.post(
+                self._url(),
+                {"pk": ["10.0.0.1", "10.0.0.2"], "_confirm": "1"},
+            )
         self.assertEqual(response.status_code, 302)
         msgs = list(response.wsgi_request._messages)
         msg_texts = [str(m) for m in msgs]
@@ -3810,18 +3740,16 @@ class TestLeaseDeletePartialFailure(_ViewTestBase):
         self.assertTrue(has_error, f"Expected transport error message, got: {msg_texts}")
 
     @patch("netbox_kea.views.leases._add_lease_journal")
-    @patch("netbox_kea.models.KeaClient")
-    def test_journal_database_error_still_completes(self, MockKeaClient, mock_journal):
+    def test_journal_database_error_still_completes(self, mock_journal):
         """DatabaseError from journal creation must not prevent deletion from completing."""
         from django.db import DatabaseError
 
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = [{"result": 0}]
         mock_journal.side_effect = DatabaseError("table locked")
-        response = self.client.post(
-            self._url(),
-            {"pk": ["10.0.0.1"], "_confirm": "1"},
-        )
+        with stub_kea({"lease4-del": {"result": 0}}):
+            response = self.client.post(
+                self._url(),
+                {"pk": ["10.0.0.1"], "_confirm": "1"},
+            )
         self.assertEqual(response.status_code, 302)
         msgs = list(response.wsgi_request._messages)
         msg_texts = [str(m) for m in msgs]
@@ -3829,17 +3757,14 @@ class TestLeaseDeletePartialFailure(_ViewTestBase):
         has_success = any("Deleted 1" in t for t in msg_texts)
         self.assertTrue(has_success, f"Expected success message despite journal error, got: {msg_texts}")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_all_leases_fail_shows_only_errors(self, MockKeaClient):
+    def test_all_leases_fail_shows_only_errors(self):
         """When every lease deletion fails, no success message should appear."""
-        from netbox_kea.kea import KeaException
-
-        mock_client = MockKeaClient.return_value
-        mock_client.command.side_effect = KeaException({"result": 1, "text": "not found"})
-        response = self.client.post(
-            self._url(),
-            {"pk": ["10.0.0.1", "10.0.0.2"], "_confirm": "1"},
-        )
+        # Every lease4-del returns result 1 → KeaException for each IP.
+        with stub_kea({"lease4-del": {"result": 1, "text": "not found"}}):
+            response = self.client.post(
+                self._url(),
+                {"pk": ["10.0.0.1", "10.0.0.2"], "_confirm": "1"},
+            )
         self.assertEqual(response.status_code, 302)
         msgs = list(response.wsgi_request._messages)
         msg_texts = [str(m) for m in msgs]
@@ -3858,11 +3783,12 @@ class TestFetchOneMacValueError(_ViewTestBase):
     def _htmx_get(self, url, data):
         return self.client.get(url, data=data, HTTP_HX_REQUEST="true")
 
-    @patch("netbox_kea.sync.bulk_fetch_netbox_ips")
-    @patch("netbox_kea.models.KeaClient")
-    def test_non_numeric_subnet_id_does_not_crash(self, MockKeaClient, mock_bulk_fetch):
+    _CONFIG4 = {"result": 0, "arguments": {"Dhcp4": {"subnet4": []}}}
+
+    def test_non_numeric_subnet_id_does_not_crash(self):
         """Lease with non-numeric subnet-id must not crash during MAC reservation lookup."""
-        mock_client = MockKeaClient.return_value
+        # A non-int subnet-id makes enrichment mark the IP indeterminate without any
+        # reservation-get, so no reservation command is registered.
         lease = {
             "ip-address": "10.0.0.5",
             "hw-address": "aa:bb:cc:dd:ee:ff",
@@ -3871,23 +3797,14 @@ class TestFetchOneMacValueError(_ViewTestBase):
             "valid-lft": 3600,
             "cltt": 1_700_000_000,
         }
-        mock_client.command.return_value = [{"result": 0, "arguments": {"ip-address": "10.0.0.5", **lease}}]
-        # No reservation for this IP — forces MAC-based lookup path
-        mock_client.reservation_get.return_value = None
-        mock_client.clone.return_value = mock_client
-        mock_client.__enter__ = lambda s: s
-        mock_client.__exit__ = lambda s, *a: None
-        mock_bulk_fetch.return_value = {}
         url = reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
-        response = self._htmx_get(url, {"by": "ip", "q": "10.0.0.5"})
+        with stub_kea({"config-get": self._CONFIG4, "lease4-get": {"result": 0, "arguments": lease}}):
+            response = self._htmx_get(url, {"by": "ip", "q": "10.0.0.5"})
         # Must render OK, not 500
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.sync.bulk_fetch_netbox_ips")
-    @patch("netbox_kea.models.KeaClient")
-    def test_none_subnet_id_does_not_crash(self, MockKeaClient, mock_bulk_fetch):
+    def test_none_subnet_id_does_not_crash(self):
         """Lease with subnet-id=None must not crash during MAC reservation lookup."""
-        mock_client = MockKeaClient.return_value
         lease = {
             "ip-address": "10.0.0.6",
             "hw-address": "aa:bb:cc:dd:ee:01",
@@ -3895,14 +3812,9 @@ class TestFetchOneMacValueError(_ViewTestBase):
             "valid-lft": 3600,
             "cltt": 1_700_000_000,
         }
-        mock_client.command.return_value = [{"result": 0, "arguments": {"ip-address": "10.0.0.6", **lease}}]
-        mock_client.reservation_get.return_value = None
-        mock_client.clone.return_value = mock_client
-        mock_client.__enter__ = lambda s: s
-        mock_client.__exit__ = lambda s, *a: None
-        mock_bulk_fetch.return_value = {}
         url = reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
-        response = self._htmx_get(url, {"by": "ip", "q": "10.0.0.6"})
+        with stub_kea({"config-get": self._CONFIG4, "lease4-get": {"result": 0, "arguments": lease}}):
+            response = self._htmx_get(url, {"by": "ip", "q": "10.0.0.6"})
         self.assertEqual(response.status_code, 200)
 
 
@@ -3916,51 +3828,44 @@ class TestGetLeasesPageSubnetEdgeCases(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_result_3_returns_empty_table(self, MockKeaClient):
+    _CONFIG4 = {"result": 0, "arguments": {"Dhcp4": {"subnet4": []}}}
+
+    def test_result_3_returns_empty_table(self):
         """result=3 (no leases) must render an empty table, not an error."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = [{"result": 3, "arguments": None}]
-        response = self._htmx_get(self._url(), {"by": "subnet", "q": "10.0.0.0/24"})
+        with stub_kea({"config-get": self._CONFIG4, "lease4-get-page": {"result": 3, "arguments": None}}):
+            response = self._htmx_get(self._url(), {"by": "subnet", "q": "10.0.0.0/24"})
         self.assertEqual(response.status_code, 200)
         # Should NOT contain the error template content
         self.assertNotContains(response, "error_id")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_leases_outside_subnet_are_truncated(self, MockKeaClient):
+    def test_leases_outside_subnet_are_truncated(self):
         """Leases with IPs outside the queried subnet must be excluded."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = [
-            {
-                "result": 0,
-                "arguments": {
-                    "leases": [
-                        {
-                            "ip-address": "10.0.0.5",
-                            "hw-address": "aa:bb:cc:dd:ee:ff",
-                            "hostname": "in-subnet",
-                            "subnet-id": 1,
-                            "valid-lft": 3600,
-                            "cltt": 1_700_000_000,
-                        },
-                        {
-                            "ip-address": "10.0.1.5",
-                            "hw-address": "aa:bb:cc:dd:ee:01",
-                            "hostname": "out-of-subnet",
-                            "subnet-id": 1,
-                            "valid-lft": 3600,
-                            "cltt": 1_700_000_000,
-                        },
-                    ],
-                    "count": 2,
-                },
-            }
-        ]
-        mock_client.reservation_get.return_value = None
-        mock_client.clone.return_value = mock_client
-        mock_client.__enter__ = lambda s: s
-        mock_client.__exit__ = lambda s, *a: None
-        response = self._htmx_get(self._url(), {"by": "subnet", "q": "10.0.0.0/24"})
+        page = {
+            "result": 0,
+            "arguments": {
+                "leases": [
+                    {
+                        "ip-address": "10.0.0.5",
+                        "hw-address": "aa:bb:cc:dd:ee:ff",
+                        "hostname": "in-subnet",
+                        "subnet-id": 1,
+                        "valid-lft": 3600,
+                        "cltt": 1_700_000_000,
+                    },
+                    {
+                        "ip-address": "10.0.1.5",
+                        "hw-address": "aa:bb:cc:dd:ee:01",
+                        "hostname": "out-of-subnet",
+                        "subnet-id": 1,
+                        "valid-lft": 3600,
+                        "cltt": 1_700_000_000,
+                    },
+                ],
+                "count": 2,
+            },
+        }
+        with stub_kea({"config-get": self._CONFIG4, "lease4-get-page": page, "reservation-get": {"result": 3}}):
+            response = self._htmx_get(self._url(), {"by": "subnet", "q": "10.0.0.0/24"})
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "10.0.0.5")
         self.assertNotContains(response, "10.0.1.5")

--- a/netbox_kea/tests/test_views_leases.py
+++ b/netbox_kea/tests/test_views_leases.py
@@ -33,7 +33,7 @@ from netbox_kea.kea import KeaClient
 from netbox_kea.models import Server
 from netbox_kea.views.leases import _fetch_subnet_choices, _subnet_choices_cache_key, _subnet_sort_key
 
-from .kea_stub import stub_kea
+from .kea_stub import queued, stub_kea
 from .utils import _PLUGINS_CONFIG, _make_db_server, _ViewTestBase
 
 
@@ -200,6 +200,10 @@ class TestReservedBadgeOnLeases(_ViewTestBase):
             response = self._htmx_get(url, {"by": "ip", "q": "192.168.1.100"})
 
         self.assertEqual(response.status_code, 200)
+        # HX-Push-Url is set only on the success render path, and the lease row must
+        # appear — together these prove the table rendered, not the exception partial.
+        self.assertIn("HX-Push-Url", response.headers)
+        self.assertContains(response, "192.168.1.100")
         # The column header says "Reserved" — check no badge link is rendered
         self.assertNotContains(response, 'text-decoration-none">Reserved</a>')
 
@@ -216,8 +220,11 @@ class TestReservedBadgeOnLeases(_ViewTestBase):
         ):
             response = self._htmx_get(url, {"by": "ip", "q": "192.168.1.100"})
 
-        # Must not 500; page renders normally without badge
+        # Must not 500; page renders normally (success path sets HX-Push-Url and
+        # shows the lease row) without a reservation badge.
         self.assertEqual(response.status_code, 200)
+        self.assertIn("HX-Push-Url", response.headers)
+        self.assertContains(response, "192.168.1.100")
         self.assertNotContains(response, 'text-decoration-none">Reserved</a>')
 
 
@@ -444,10 +451,10 @@ class TestLeaseExport(_ViewTestBase):
         with stub_kea(
             {
                 "config-get": self._CONFIG4,
-                "lease4-get-page": [
+                "lease4-get-page": queued(
                     {"result": 0, "arguments": {"leases": page1_leases, "count": 3}},
                     {"result": 3, "arguments": None},
-                ],
+                ),
             }
         ) as kea:
             # Pass per_page=3 so that count(3) == per_page(3) triggers the next-page fetch.
@@ -750,10 +757,10 @@ class TestLeaseExportAll(_ViewTestBase):
         ]
         with stub_kea(
             {
-                "lease4-get-page": [
+                "lease4-get-page": queued(
                     {"result": 0, "arguments": {"leases": page1, "count": 1000}},
                     {"result": 3, "arguments": None},
-                ]
+                )
             }
         ) as kea:
             response = self.client.get(self._url4(), {"export_all": "1"})
@@ -1369,7 +1376,7 @@ class TestBulkLeaseImportView(_ViewTestBase):
             ]
         )
         # Row 1 succeeds (result 0), row 2 fails (result 1 → real client raises KeaException).
-        with stub_kea({"lease4-add": [{"result": 0}, {"result": 1, "text": "bad"}]}):
+        with stub_kea({"lease4-add": queued({"result": 0}, {"result": 1, "text": "bad"})}):
             response = self.client.post(self._url(version=4), self._post(version=4, csv_bytes=csv_bytes))
         self.assertEqual(response.status_code, 200)
         result = response.context["result"]
@@ -2047,7 +2054,7 @@ class TestFetchAllLeasesFromServer(_ViewTestBase):
         # Each element of *responses* is a one-service Kea reply list; unwrap to the
         # single dict and feed them as a FIFO on lease4-get-page (the last repeats).
         page_responses = [r[0] for r in responses]
-        with stub_kea({"lease4-get-page": page_responses}):
+        with stub_kea({"lease4-get-page": queued(*page_responses)}):
             return _fetch_all_leases_from_server(self.server, version=4, max_leases=max_leases)
 
     def test_result_3_stops_loop(self):
@@ -2123,7 +2130,7 @@ class TestFetchReservationByIP(_ViewTestBase):
             for (hosts, nf, ns) in pages
         ]
         client = self.server.get_client(version=4)
-        with stub_kea({"reservation-get-page": responses}):
+        with stub_kea({"reservation-get-page": queued(*responses)}):
             return _fetch_reservation_by_ip(client, version=4)
 
     def test_single_ip_reservation(self):
@@ -2550,7 +2557,7 @@ class TestLeasePartialDelete(_ViewTestBase):
         """When the first IP fails, the second IP is still deleted."""
         # First lease4-del fails (result 1 → KeaException), second succeeds.
         with stub_kea(
-            {"lease4-del": [{"result": 1, "text": "not found"}, {"result": 0}], "config-get": self._CONFIG4}
+            {"lease4-del": queued({"result": 1, "text": "not found"}, {"result": 0}), "config-get": self._CONFIG4}
         ) as kea:
             response = self.client.post(
                 self._url(),
@@ -2573,7 +2580,9 @@ class TestLeasePartialDelete(_ViewTestBase):
 
     def test_partial_failure_shows_warning(self):
         """When some IPs fail, a warning message about partial failure is shown."""
-        with stub_kea({"lease4-del": [{"result": 1, "text": "not found"}, {"result": 0}], "config-get": self._CONFIG4}):
+        with stub_kea(
+            {"lease4-del": queued({"result": 1, "text": "not found"}, {"result": 0}), "config-get": self._CONFIG4}
+        ):
             response = self.client.post(
                 self._url(),
                 {"lease_ips": ["10.0.0.1", "10.0.0.2"], "_confirm": "1", "pk": ["10.0.0.1", "10.0.0.2"]},
@@ -2679,7 +2688,7 @@ class TestLeaseExportStateFilter(_ViewTestBase):
             {"result": 3, "arguments": None},
         ]
         # Request export with state=1 (declined only)
-        with stub_kea({"config-get": config, "lease4-get-page": pages}):
+        with stub_kea({"config-get": config, "lease4-get-page": queued(*pages)}):
             response = self.client.get(
                 self._url(),
                 {
@@ -3702,7 +3711,7 @@ class TestLeaseDeletePartialFailure(_ViewTestBase):
     def test_partial_failure_shows_mixed_messages(self):
         """Some leases succeed, others fail with KeaException → mixed messages."""
         # First lease4-del succeeds (result 0), second fails (result 1 → KeaException).
-        with stub_kea({"lease4-del": [{"result": 0}, {"result": 1, "text": "lease not found"}]}):
+        with stub_kea({"lease4-del": queued({"result": 0}, {"result": 1, "text": "lease not found"})}):
             response = self.client.post(
                 self._url(),
                 {"pk": ["10.0.0.1", "10.0.0.2"], "_confirm": "1"},

--- a/netbox_kea/tests/test_views_leases.py
+++ b/netbox_kea/tests/test_views_leases.py
@@ -33,6 +33,7 @@ from netbox_kea.kea import KeaClient
 from netbox_kea.models import Server
 from netbox_kea.views.leases import _fetch_subnet_choices, _subnet_choices_cache_key, _subnet_sort_key
 
+from .kea_stub import stub_kea
 from .utils import _PLUGINS_CONFIG, _make_db_server, _ViewTestBase
 
 
@@ -107,21 +108,22 @@ class TestServerLeases4DeleteView(_ViewTestBase):
         self.assertEqual(response.status_code, 302)
         self._assert_no_none_pk_redirect(response)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_htmx_single_lease_returns_hx_refresh(self, MockKeaClient):
+    def test_post_htmx_single_lease_returns_hx_refresh(self):
         """An HTMX POST with a single IP and _confirm returns HX-Refresh: true instead of redirect."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = [{"result": 0, "text": "Success"}]
         url = reverse("plugins:netbox_kea:server_leases4_delete", args=[self.server.pk])
-        response = self.client.post(
-            url,
-            {"pk": "192.0.2.1", "_confirm": "1"},
-            HTTP_HX_REQUEST="true",
-        )
+        with stub_kea({"lease4-del": {"result": 0, "text": "Success"}}) as kea:
+            response = self.client.post(
+                url,
+                {"pk": "192.0.2.1", "_confirm": "1"},
+                HTTP_HX_REQUEST="true",
+            )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.headers.get("HX-Refresh"), "true")
-        cmd_names = [c.args[0] for c in mock_client.command.call_args_list]
-        self.assertIn("lease4-del", cmd_names)
+        # De-mocked: assert the real request payload built by KeaClient.command(), not a mock call.
+        self.assertEqual(kea.commands(), ["lease4-del"])
+        body = kea.bodies("lease4-del")[0]
+        self.assertEqual(body["arguments"], {"ip-address": "192.0.2.1"})
+        self.assertEqual(body["service"], ["dhcp4"])
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)

--- a/netbox_kea/tests/test_views_leases.py
+++ b/netbox_kea/tests/test_views_leases.py
@@ -713,30 +713,18 @@ class TestLeaseExportAll(_ViewTestBase):
     def _url6(self):
         return reverse("plugins:netbox_kea:server_leases6", args=[self.server.pk])
 
-    def _single_page_side_effect(self, cmd, service=None, arguments=None, check=None):
-        """Kea returns one page with one lease, then empty (result=3) on next call."""
-        if cmd == "lease4-get-page":
-            frm = arguments.get("from", "")
-            if frm == "0.0.0.0":
-                return [{"result": 0, "arguments": {"leases": [self._LEASE], "count": 1}}]
-            return [{"result": 3, "arguments": None}]
-        return [{"result": 0, "arguments": {}}]
-
-    @patch("netbox_kea.models.KeaClient")
-    def test_export_all_returns_csv(self, MockKeaClient):
+    def test_export_all_returns_csv(self):
         """?export_all=1 must return text/csv."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.side_effect = self._single_page_side_effect
-        response = self.client.get(self._url4(), {"export_all": "1"})
+        # One page of one lease (count 1 < per_page 1000) ends pagination after one call.
+        with stub_kea({"lease4-get-page": {"result": 0, "arguments": {"leases": [self._LEASE], "count": 1}}}):
+            response = self.client.get(self._url4(), {"export_all": "1"})
         self.assertEqual(response.status_code, 200)
         self.assertIn("text/csv", response.get("Content-Type", ""))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_export_all_includes_lease_data(self, MockKeaClient):
+    def test_export_all_includes_lease_data(self):
         """?export_all=1 CSV must contain the lease IP address."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.side_effect = self._single_page_side_effect
-        response = self.client.get(self._url4(), {"export_all": "1"})
+        with stub_kea({"lease4-get-page": {"result": 0, "arguments": {"leases": [self._LEASE], "count": 1}}}):
+            response = self.client.get(self._url4(), {"export_all": "1"})
         self.assertEqual(response.status_code, 200)
         content = (
             b"".join(response.streaming_content).decode()
@@ -745,12 +733,10 @@ class TestLeaseExportAll(_ViewTestBase):
         )
         self.assertIn("10.0.0.1", content)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_export_all_paginates_all_leases(self, MockKeaClient):
+    def test_export_all_paginates_all_leases(self):
         """?export_all=1 must paginate until Kea returns result=3."""
-        # The view uses per_page=1000. Return count=1000 on the first call so the
-        # view sees a full page and issues a second request; the second call returns
-        # result=3 to signal end-of-data.
+        # The view uses per_page=1000. Report count==1000 on the first page so the
+        # view sees a full page and issues a second request; page 2 returns result=3.
         page1 = [
             {
                 "ip-address": f"10.0.0.{i}",
@@ -762,56 +748,36 @@ class TestLeaseExportAll(_ViewTestBase):
             }
             for i in range(1, 3)
         ]
-        call_count = {"n": 0}
-
-        def paginate_side_effect(cmd, service=None, arguments=None, check=None):
-            if cmd != "lease4-get-page":
-                return [{"result": 0, "arguments": {}}]
-            call_count["n"] += 1
-            if call_count["n"] == 1:
-                # Report count==1000 so the view thinks there may be more pages.
-                return [{"result": 0, "arguments": {"leases": page1, "count": 1000}}]
-            return [{"result": 3, "arguments": None}]
-
-        MockKeaClient.return_value.command.side_effect = paginate_side_effect
-        response = self.client.get(self._url4(), {"export_all": "1"})
+        with stub_kea(
+            {
+                "lease4-get-page": [
+                    {"result": 0, "arguments": {"leases": page1, "count": 1000}},
+                    {"result": 3, "arguments": None},
+                ]
+            }
+        ) as kea:
+            response = self.client.get(self._url4(), {"export_all": "1"})
         self.assertEqual(response.status_code, 200)
         self.assertIn("text/csv", response.get("Content-Type", ""))
-        self.assertGreaterEqual(call_count["n"], 2)
+        self.assertGreaterEqual(kea.commands().count("lease4-get-page"), 2)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_export_all_v6_starts_from_double_colon(self, MockKeaClient):
+    def test_export_all_v6_starts_from_double_colon(self):
         """?export_all=1 for v6 must start the cursor from '::'."""
-        call_args_list = []
-
-        def v6_side_effect(cmd, service=None, arguments=None, check=None):
-            if cmd == "lease6-get-page":
-                call_args_list.append(arguments)
-                return [{"result": 3, "arguments": None}]
-            return [{"result": 0, "arguments": {}}]
-
-        MockKeaClient.return_value.command.side_effect = v6_side_effect
-        response = self.client.get(self._url6(), {"export_all": "1"})
+        with stub_kea({"lease6-get-page": {"result": 3, "arguments": None}}) as kea:
+            response = self.client.get(self._url6(), {"export_all": "1"})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(call_args_list), 1)
-        self.assertEqual(call_args_list[0]["from"], "::")
+        pages = kea.bodies("lease6-get-page")
+        self.assertEqual(len(pages), 1)
+        self.assertEqual(pages[0]["arguments"]["from"], "::")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_export_all_v4_starts_from_zero_ip(self, MockKeaClient):
+    def test_export_all_v4_starts_from_zero_ip(self):
         """?export_all=1 for v4 must start the cursor from '0.0.0.0'."""
-        call_args_list = []
-
-        def v4_side_effect(cmd, service=None, arguments=None, check=None):
-            if cmd == "lease4-get-page":
-                call_args_list.append(arguments)
-                return [{"result": 3, "arguments": None}]
-            return [{"result": 0, "arguments": {}}]
-
-        MockKeaClient.return_value.command.side_effect = v4_side_effect
-        response = self.client.get(self._url4(), {"export_all": "1"})
+        with stub_kea({"lease4-get-page": {"result": 3, "arguments": None}}) as kea:
+            response = self.client.get(self._url4(), {"export_all": "1"})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(call_args_list), 1)
-        self.assertEqual(call_args_list[0]["from"], "0.0.0.0")
+        pages = kea.bodies("lease4-get-page")
+        self.assertEqual(len(pages), 1)
+        self.assertEqual(pages[0]["arguments"]["from"], "0.0.0.0")
 
 
 # TestLeaseEditView
@@ -855,58 +821,57 @@ class TestLeaseEditView(_ViewTestBase):
         self.assertIn("leases", url)
         self.assertIn("edit", url)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_returns_200(self, MockKeaClient):
+    def test_get_returns_200(self):
         """GET returns 200 OK."""
-        MockKeaClient.return_value.command.return_value = _LEASE4_GET_RESP
-        response = self.client.get(self._url())
+        with stub_kea({"lease4-get": _LEASE4_GET_RESP[0]}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_prefills_hostname(self, MockKeaClient):
+    def test_get_prefills_hostname(self):
         """GET pre-fills hostname from the existing lease."""
-        MockKeaClient.return_value.command.return_value = _LEASE4_GET_RESP
-        response = self.client.get(self._url())
+        with stub_kea({"lease4-get": _LEASE4_GET_RESP[0]}):
+            response = self.client.get(self._url())
         content = response.content.decode()
         self.assertIn("host1.example.com", content)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_prefills_hw_address(self, MockKeaClient):
+    def test_get_prefills_hw_address(self):
         """GET pre-fills hw_address from the existing lease (v4 only)."""
-        MockKeaClient.return_value.command.return_value = _LEASE4_GET_RESP
-        response = self.client.get(self._url())
+        with stub_kea({"lease4-get": _LEASE4_GET_RESP[0]}):
+            response = self.client.get(self._url())
         content = response.content.decode()
         self.assertIn("aa:bb:cc:dd:ee:ff", content)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_calls_lease_update_and_redirects(self, MockKeaClient):
+    def test_post_calls_lease_update_and_redirects(self):
         """POST with valid data calls lease_update and redirects."""
-        MockKeaClient.return_value.lease_update.return_value = None
-        response = self.client.post(
-            self._url(),
-            {
-                "hostname": "newhost.example.com",
-                "hw_address": "11:22:33:44:55:66",
-                "valid_lft": "7200",
-            },
-        )
+        # lease_update reads the current lease (lease4-get) then writes lease4-update.
+        with stub_kea({"lease4-get": _LEASE4_GET_RESP[0], "lease4-update": {"result": 0}}) as kea:
+            response = self.client.post(
+                self._url(),
+                {
+                    "hostname": "newhost.example.com",
+                    "hw_address": "11:22:33:44:55:66",
+                    "valid_lft": "7200",
+                },
+            )
         self.assertEqual(response.status_code, 302)
-        MockKeaClient.return_value.lease_update.assert_called_once()
+        self.assertIn("lease4-update", kea.commands())
+        update_args = kea.bodies("lease4-update")[0]["arguments"]
+        self.assertEqual(update_args["hostname"], "newhost.example.com")
+        self.assertEqual(update_args["hw-address"], "11:22:33:44:55:66")
+        self.assertEqual(update_args["valid-lft"], 7200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_kea_exception_redirects_with_error(self, MockKeaClient):
+    def test_post_kea_exception_redirects_with_error(self):
         """POST that raises KeaException shows error and redirects."""
-        from netbox_kea.kea import KeaException
-
-        MockKeaClient.return_value.lease_update.side_effect = KeaException({"result": 1, "text": "lease not found"})
-        response = self.client.post(
-            self._url(),
-            {
-                "hostname": "newhost.example.com",
-                "hw_address": "11:22:33:44:55:66",
-                "valid_lft": "7200",
-            },
-        )
+        # result=1 on lease4-update makes the real client raise KeaException.
+        with stub_kea({"lease4-get": _LEASE4_GET_RESP[0], "lease4-update": {"result": 1, "text": "lease not found"}}):
+            response = self.client.post(
+                self._url(),
+                {
+                    "hostname": "newhost.example.com",
+                    "hw_address": "11:22:33:44:55:66",
+                    "valid_lft": "7200",
+                },
+            )
         self.assertEqual(response.status_code, 302)
 
     def test_get_requires_login(self):
@@ -997,83 +962,91 @@ class TestLeaseStateFilter(_ViewTestBase):
     def _url4(self):
         return reverse("plugins:netbox_kea:server_leases4", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_state_column_rendered_in_table(self, MockKeaClient):
+    # Subnet quick-select fetched via config-get; reservation enrichment finds none.
+    _CONFIG4 = {"result": 0, "arguments": {"Dhcp4": {"subnet4": [{"id": 1, "subnet": "10.0.0.0/24"}]}}}
+
+    def test_state_column_rendered_in_table(self):
         """Lease table includes a state_label column header."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = _STATE_LEASES_RESP
-        mock_client.reservation_get_page.return_value = ([], 0, 0)
-        response = self._htmx_get(self._url4(), {"by": "hw", "q": "aa:bb:cc:dd:ee:01"})
+        with stub_kea(
+            {
+                "config-get": self._CONFIG4,
+                "lease4-get-by-hw-address": _STATE_LEASES_RESP[0],
+                "reservation-get": {"result": 3},
+            }
+        ):
+            response = self._htmx_get(self._url4(), {"by": "hw", "q": "aa:bb:cc:dd:ee:01"})
         self.assertEqual(response.status_code, 200)
         # State column header must be present
         self.assertContains(response, "State")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_state_label_active_rendered(self, MockKeaClient):
+    def test_state_label_active_rendered(self):
         """Active lease shows 'Active' state badge."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = [
+        active_lease = _STATE_LEASES_RESP[0]["arguments"]["leases"][0]
+        with stub_kea(
             {
-                "result": 0,
-                "arguments": {"leases": [_STATE_LEASES_RESP[0]["arguments"]["leases"][0]]},
+                "config-get": self._CONFIG4,
+                "lease4-get-by-hw-address": {"result": 0, "arguments": {"leases": [active_lease]}},
+                "reservation-get": {"result": 3},
             }
-        ]
-        mock_client.reservation_get_page.return_value = ([], 0, 0)
-        response = self._htmx_get(self._url4(), {"by": "hw", "q": "aa:bb:cc:dd:ee:01"})
+        ):
+            response = self._htmx_get(self._url4(), {"by": "hw", "q": "aa:bb:cc:dd:ee:01"})
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Active")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_state_label_declined_rendered(self, MockKeaClient):
+    def test_state_label_declined_rendered(self):
         """Declined lease shows 'Declined' state badge."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = [
+        declined_lease = _STATE_LEASES_RESP[0]["arguments"]["leases"][1]
+        with stub_kea(
             {
-                "result": 0,
-                "arguments": {"leases": [_STATE_LEASES_RESP[0]["arguments"]["leases"][1]]},
+                "config-get": self._CONFIG4,
+                "lease4-get-by-hw-address": {"result": 0, "arguments": {"leases": [declined_lease]}},
+                "reservation-get": {"result": 3},
             }
-        ]
-        mock_client.reservation_get_page.return_value = ([], 0, 0)
-        response = self._htmx_get(self._url4(), {"by": "hw", "q": "aa:bb:cc:dd:ee:02"})
+        ):
+            response = self._htmx_get(self._url4(), {"by": "hw", "q": "aa:bb:cc:dd:ee:02"})
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Declined")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_state_filter_declined_hides_active(self, MockKeaClient):
+    def test_state_filter_declined_hides_active(self):
         """State filter=1 (Declined) excludes Active leases from search results."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = _STATE_LEASES_RESP
-        mock_client.reservation_get_page.return_value = ([], 0, 0)
-        response = self._htmx_get(self._url4(), {"by": "hostname", "q": "host", "state": "1"})
+        with stub_kea(
+            {
+                "config-get": self._CONFIG4,
+                "lease4-get-by-hostname": _STATE_LEASES_RESP[0],
+                "reservation-get": {"result": 3},
+            }
+        ):
+            response = self._htmx_get(self._url4(), {"by": "hostname", "q": "host", "state": "1"})
         self.assertEqual(response.status_code, 200)
         # Active and Expired hosts should not appear
         self.assertNotContains(response, "active-host")
         self.assertNotContains(response, "expired-host")
         self.assertContains(response, "declined-host")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_state_filter_any_returns_all(self, MockKeaClient):
+    def test_state_filter_any_returns_all(self):
         """Empty state filter (Any) returns all leases."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = _STATE_LEASES_RESP
-        mock_client.reservation_get_page.return_value = ([], 0, 0)
-        response = self._htmx_get(self._url4(), {"by": "hostname", "q": "host", "state": ""})
+        with stub_kea(
+            {
+                "config-get": self._CONFIG4,
+                "lease4-get-by-hostname": _STATE_LEASES_RESP[0],
+                "reservation-get": {"result": 3},
+            }
+        ):
+            response = self._htmx_get(self._url4(), {"by": "hostname", "q": "host", "state": ""})
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "active-host")
         self.assertContains(response, "declined-host")
         self.assertContains(response, "expired-host")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_state_filter_applied_on_paginated_subnet_search(self, MockKeaClient):
+    def test_state_filter_applied_on_paginated_subnet_search(self):
         """State filter also applies to paginated subnet-based search."""
-        mock_client = MockKeaClient.return_value
-        # First call: lease4-get-page; second: reservation_get_page
-        mock_client.command.return_value = _PAGE_LEASES_RESP
-        mock_client.reservation_get_page.return_value = ([], 0, 0)
-        response = self._htmx_get(
-            self._url4(),
-            {"by": "subnet", "q": "10.0.0.0/24", "state": "1"},
-        )
+        with stub_kea(
+            {"config-get": self._CONFIG4, "lease4-get-page": _PAGE_LEASES_RESP[0], "reservation-get": {"result": 3}}
+        ):
+            response = self._htmx_get(
+                self._url4(),
+                {"by": "subnet", "q": "10.0.0.0/24", "state": "1"},
+            )
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, "page-active")
         self.assertContains(response, "page-declined")

--- a/netbox_kea/tests/test_views_leases.py
+++ b/netbox_kea/tests/test_views_leases.py
@@ -1099,75 +1099,64 @@ class TestLeaseAddView(_ViewTestBase):
         self.assertIn("leases", url)
         self.assertIn("add", url)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_lease4_add_returns_200(self, MockKeaClient):
+    def test_get_lease4_add_returns_200(self):
         """GET /leases4/add/ returns 200 and renders the add form."""
         response = self.client.get(self._url(version=4))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "ip_address")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_lease6_add_returns_200(self, MockKeaClient):
+    def test_get_lease6_add_returns_200(self):
         """GET /leases6/add/ returns 200 and shows duid + iaid fields."""
         response = self.client.get(self._url(version=6))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "duid")
         self.assertContains(response, "iaid")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_lease4_add_valid_redirects(self, MockKeaClient):
+    def test_post_lease4_add_valid_redirects(self):
         """POST valid v4 lease data redirects to the lease list."""
-        MockKeaClient.return_value.lease_add.return_value = None
-        response = self.client.post(self._url(version=4), self._valid_post4())
+        with stub_kea({"lease4-add": {"result": 0}}):
+            response = self.client.post(self._url(version=4), self._valid_post4())
         self.assertEqual(response.status_code, 302)
         self.assertNotIn("None", response.url)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_lease4_add_calls_kea_with_correct_args(self, MockKeaClient):
+    def test_post_lease4_add_calls_kea_with_correct_args(self):
         """POST v4 calls lease_add with ip-address, hw-address, and subnet-id."""
-        mock_client = MockKeaClient.return_value
-        mock_client.lease_add.return_value = None
-        self.client.post(self._url(version=4), self._valid_post4())
-        mock_client.lease_add.assert_called_once()
-        args = mock_client.lease_add.call_args
-        lease = args[0][1] if args[0] else args[1].get("lease", args[0][1])
+        with stub_kea({"lease4-add": {"result": 0}}) as kea:
+            self.client.post(self._url(version=4), self._valid_post4())
+        self.assertIn("lease4-add", kea.commands())
+        lease = kea.bodies("lease4-add")[0]["arguments"]
         self.assertEqual(lease["ip-address"], "10.0.0.200")
         self.assertEqual(lease.get("hw-address"), "aa:bb:cc:dd:ee:ff")
         self.assertEqual(lease.get("subnet-id"), 1)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_lease4_add_invalid_ip_shows_form_errors(self, MockKeaClient):
+    def test_post_lease4_add_invalid_ip_shows_form_errors(self):
         """POST with a non-IPv4 string re-renders form with validation errors."""
-        response = self.client.post(self._url(version=4), self._valid_post4(ip_address="not-an-ip"))
+        # Empty registry: any Kea command would raise — proves no lease was created.
+        with stub_kea({}) as kea:
+            response = self.client.post(self._url(version=4), self._valid_post4(ip_address="not-an-ip"))
         self.assertEqual(response.status_code, 200)
-        MockKeaClient.return_value.lease_add.assert_not_called()
+        self.assertEqual(kea.commands(), [])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_lease4_add_kea_exception_shows_error_message(self, MockKeaClient):
+    def test_post_lease4_add_kea_exception_shows_error_message(self):
         """POST that triggers a KeaException shows error and re-renders (no redirect)."""
-        from netbox_kea.kea import KeaException
-
-        MockKeaClient.return_value.lease_add.side_effect = KeaException({"result": 1, "text": "address already in use"})
-        response = self.client.post(self._url(version=4), self._valid_post4())
+        # result=1 on lease4-add makes the real client raise KeaException.
+        with stub_kea({"lease4-add": {"result": 1, "text": "address already in use"}}):
+            response = self.client.post(self._url(version=4), self._valid_post4())
         self.assertIn(response.status_code, (200, 302))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_lease6_add_valid_redirects(self, MockKeaClient):
+    def test_post_lease6_add_valid_redirects(self):
         """POST valid v6 lease data redirects to the lease list."""
-        MockKeaClient.return_value.lease_add.return_value = None
-        response = self.client.post(self._url(version=6), self._valid_post6())
+        with stub_kea({"lease6-add": {"result": 0}}):
+            response = self.client.post(self._url(version=6), self._valid_post6())
         self.assertEqual(response.status_code, 302)
         self.assertNotIn("None", response.url)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_lease6_add_calls_kea_with_correct_args(self, MockKeaClient):
+    def test_post_lease6_add_calls_kea_with_correct_args(self):
         """POST v6 calls lease_add with ip-address, duid, and iaid."""
-        mock_client = MockKeaClient.return_value
-        mock_client.lease_add.return_value = None
-        self.client.post(self._url(version=6), self._valid_post6())
-        mock_client.lease_add.assert_called_once()
-        args = mock_client.lease_add.call_args
-        lease = args[0][1] if args[0] else args[1].get("lease")
+        with stub_kea({"lease6-add": {"result": 0}}) as kea:
+            self.client.post(self._url(version=6), self._valid_post6())
+        self.assertIn("lease6-add", kea.commands())
+        lease = kea.bodies("lease6-add")[0]["arguments"]
         self.assertEqual(lease["ip-address"], "2001:db8::200")
         self.assertEqual(lease.get("duid"), "00:01:02:03:04:05")
         self.assertEqual(lease.get("iaid"), 12345)
@@ -1203,47 +1192,45 @@ class TestLeaseAddSyncToNetBox(_ViewTestBase):
             data["sync_to_netbox"] = "on"
         return data
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_lease4_add_form_has_sync_to_netbox_field(self, MockKeaClient):
+    # A followed redirect lands on the leases page, which fetches the subnet quick-select.
+    _CONFIG4 = {"result": 0, "arguments": {"Dhcp4": {"subnet4": []}}}
+
+    def test_lease4_add_form_has_sync_to_netbox_field(self):
         """GET lease4 add page renders a sync_to_netbox checkbox."""
         response = self.client.get(self._url(version=4))
         self.assertEqual(response.status_code, 200)
         self.assertIn("sync_to_netbox", response.content.decode())
 
     @patch("netbox_kea.views.leases.sync_lease_to_netbox")
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_lease4_add_with_sync_calls_sync_lease(self, MockKeaClient, mock_sync):
+    def test_post_lease4_add_with_sync_calls_sync_lease(self, mock_sync):
         """POST with sync_to_netbox=on calls sync_lease_to_netbox() with the lease dict."""
-        MockKeaClient.return_value.lease_add.return_value = None
-        mock_sync.return_value = (MagicMock(spec=NbIP), True)
-        response = self.client.post(self._url(version=4), self._post4(sync=True))
+        mock_sync.return_value = (MagicMock(spec=NbIP), True, False)
+        with stub_kea({"lease4-add": {"result": 0}}):
+            response = self.client.post(self._url(version=4), self._post4(sync=True))
         self.assertEqual(response.status_code, 302)
         mock_sync.assert_called_once()
         lease = mock_sync.call_args[0][0]
         self.assertEqual(lease["ip-address"], "10.0.0.200")
 
     @patch("netbox_kea.views.leases.sync_lease_to_netbox")
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_lease4_add_without_sync_does_not_call_sync(self, MockKeaClient, mock_sync):
+    def test_post_lease4_add_without_sync_does_not_call_sync(self, mock_sync):
         """POST without sync_to_netbox does NOT call sync_lease_to_netbox()."""
-        MockKeaClient.return_value.lease_add.return_value = None
-        response = self.client.post(self._url(version=4), self._post4(sync=False))
+        with stub_kea({"lease4-add": {"result": 0}}):
+            response = self.client.post(self._url(version=4), self._post4(sync=False))
         self.assertEqual(response.status_code, 302)
         mock_sync.assert_not_called()
 
     @patch("netbox_kea.views.leases.sync_lease_to_netbox")
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_lease4_add_sync_failure_does_not_prevent_kea_success(self, MockKeaClient, mock_sync):
+    def test_post_lease4_add_sync_failure_does_not_prevent_kea_success(self, mock_sync):
         """Sync failure is a warning; the lease creation still succeeds (302 redirect)."""
-        MockKeaClient.return_value.lease_add.return_value = None
         mock_sync.side_effect = ValueError("NetBox unreachable")
-        response = self.client.post(self._url(version=4), self._post4(sync=True))
+        with stub_kea({"lease4-add": {"result": 0}}) as kea:
+            response = self.client.post(self._url(version=4), self._post4(sync=True))
         self.assertEqual(response.status_code, 302)
-        MockKeaClient.return_value.lease_add.assert_called_once()
+        self.assertEqual(kea.commands().count("lease4-add"), 1)
 
     @patch("netbox_kea.views.leases.sync_lease_to_netbox")
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_lease4_add_sync_skipped_without_ipam_permission(self, MockKeaClient, mock_sync):
+    def test_post_lease4_add_sync_skipped_without_ipam_permission(self, mock_sync):
         """A user with server-change but no IPAM write permission must not trigger the IPAM sync."""
         from django.contrib.auth import get_user_model
         from django.contrib.contenttypes.models import ContentType
@@ -1256,22 +1243,21 @@ class TestLeaseAddSyncToNetBox(_ViewTestBase):
         perm.users.add(limited)
         self.client.force_login(limited)
 
-        MockKeaClient.return_value.lease_add.return_value = None
-        response = self.client.post(self._url(version=4), self._post4(sync=True))
+        with stub_kea({"lease4-add": {"result": 0}}) as kea:
+            response = self.client.post(self._url(version=4), self._post4(sync=True))
         # Lease still created in Kea (302), but the IPAM sync was gated out.
         self.assertEqual(response.status_code, 302)
-        MockKeaClient.return_value.lease_add.assert_called_once()
+        self.assertEqual(kea.commands().count("lease4-add"), 1)
         mock_sync.assert_not_called()
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_lease4_add_reports_foreign_ip_skip(self, MockKeaClient):
+    def test_post_lease4_add_reports_foreign_ip_skip(self):
         """A foreign NetBox IP (force=False) is skipped and reported as such, not 'synced'."""
         from ipam.models import IPAddress
 
-        MockKeaClient.return_value.lease_add.return_value = None
         # self.client is the superuser (has IPAM perms) → reaches the real sync.
         IPAddress.objects.create(address="10.0.0.200/24", status="active", description="Router loopback")
-        response = self.client.post(self._url(version=4), self._post4(sync=True), follow=True)
+        with stub_kea({"lease4-add": {"result": 0}, "config-get": self._CONFIG4}):
+            response = self.client.post(self._url(version=4), self._post4(sync=True), follow=True)
         self.assertEqual(response.status_code, 200)
         msgs = [m.message for m in response.context["messages"]]
         self.assertTrue(
@@ -1283,14 +1269,13 @@ class TestLeaseAddSyncToNetBox(_ViewTestBase):
         self.assertEqual(ip.status, "active")
         self.assertEqual(ip.description, "Router loopback")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_lease4_add_reports_successful_sync(self, MockKeaClient):
+    def test_post_lease4_add_reports_successful_sync(self):
         """A fresh IP synced to NetBox reports a created/updated success message."""
         from ipam.models import IPAddress
 
-        MockKeaClient.return_value.lease_add.return_value = None
         # No pre-existing row → the real sync creates it, no conflict → success message.
-        response = self.client.post(self._url(version=4), self._post4(sync=True), follow=True)
+        with stub_kea({"lease4-add": {"result": 0}, "config-get": self._CONFIG4}):
+            response = self.client.post(self._url(version=4), self._post4(sync=True), follow=True)
         self.assertEqual(response.status_code, 200)
         msgs = [m.message for m in response.context["messages"]]
         self.assertTrue(
@@ -1333,45 +1318,36 @@ class TestBulkLeaseImportView(_ViewTestBase):
         f.name = "leases.csv"
         return {"csv_file": f}
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_v4_returns_200(self, MockKeaClient):
+    def test_get_v4_returns_200(self):
         """GET lease4 bulk import page returns 200."""
         response = self.client.get(self._url(version=4))
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_v6_returns_200(self, MockKeaClient):
+    def test_get_v6_returns_200(self):
         """GET lease6 bulk import page returns 200."""
         response = self.client.get(self._url(version=6))
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_v4_valid_csv_calls_lease_add(self, MockKeaClient):
+    def test_post_v4_valid_csv_calls_lease_add(self):
         """POST with valid v4 CSV calls lease_add once per row."""
-        MockKeaClient.return_value.lease_add.return_value = None
-        response = self.client.post(self._url(version=4), self._post(version=4))
+        with stub_kea({"lease4-add": {"result": 0}}) as kea:
+            response = self.client.post(self._url(version=4), self._post(version=4))
         self.assertEqual(response.status_code, 200)
-        MockKeaClient.return_value.lease_add.assert_called_once()
-        args = MockKeaClient.return_value.lease_add.call_args[0]
-        self.assertEqual(args[0], 4)
-        self.assertEqual(args[1]["ip-address"], "10.0.0.10")
+        self.assertEqual(kea.commands().count("lease4-add"), 1)
+        self.assertEqual(kea.bodies("lease4-add")[0]["arguments"]["ip-address"], "10.0.0.10")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_v6_valid_csv_calls_lease_add(self, MockKeaClient):
+    def test_post_v6_valid_csv_calls_lease_add(self):
         """POST with valid v6 CSV calls lease_add with correct duid and iaid."""
-        MockKeaClient.return_value.lease_add.return_value = None
-        response = self.client.post(self._url(version=6), self._post(version=6))
+        with stub_kea({"lease6-add": {"result": 0}}) as kea:
+            response = self.client.post(self._url(version=6), self._post(version=6))
         self.assertEqual(response.status_code, 200)
-        MockKeaClient.return_value.lease_add.assert_called_once()
-        args = MockKeaClient.return_value.lease_add.call_args[0]
-        self.assertEqual(args[0], 6)
-        self.assertEqual(args[1]["duid"], "00:01:02:03")
-        self.assertEqual(args[1]["iaid"], 12345)
+        self.assertEqual(kea.commands().count("lease6-add"), 1)
+        args = kea.bodies("lease6-add")[0]["arguments"]
+        self.assertEqual(args["duid"], "00:01:02:03")
+        self.assertEqual(args["iaid"], 12345)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_multiple_rows_calls_lease_add_per_row(self, MockKeaClient):
+    def test_post_multiple_rows_calls_lease_add_per_row(self):
         """Each CSV row triggers one lease_add call."""
-        MockKeaClient.return_value.lease_add.return_value = None
         csv_bytes = self._csv4(
             rows=[
                 "10.0.0.10,aa:bb:cc:dd:ee:01,1,3600,h1\n",
@@ -1379,36 +1355,35 @@ class TestBulkLeaseImportView(_ViewTestBase):
                 "10.0.0.12,aa:bb:cc:dd:ee:03,1,3600,h3\n",
             ]
         )
-        response = self.client.post(self._url(version=4), self._post(version=4, csv_bytes=csv_bytes))
+        with stub_kea({"lease4-add": {"result": 0}}) as kea:
+            response = self.client.post(self._url(version=4), self._post(version=4, csv_bytes=csv_bytes))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(MockKeaClient.return_value.lease_add.call_count, 3)
+        self.assertEqual(kea.commands().count("lease4-add"), 3)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_partial_failure_shows_error_count(self, MockKeaClient):
+    def test_post_partial_failure_shows_error_count(self):
         """If some rows fail, result context shows correct created/error counts."""
-        from netbox_kea.kea import KeaException
-
-        mock_client = MockKeaClient.return_value
-        mock_client.lease_add.side_effect = [None, KeaException({"result": 1, "text": "bad"}, index=0)]
         csv_bytes = self._csv4(
             rows=[
                 "10.0.0.10,aa:bb:cc:dd:ee:01,1,3600,h1\n",
                 "10.0.0.11,aa:bb:cc:dd:ee:02,1,3600,h2\n",
             ]
         )
-        response = self.client.post(self._url(version=4), self._post(version=4, csv_bytes=csv_bytes))
+        # Row 1 succeeds (result 0), row 2 fails (result 1 → real client raises KeaException).
+        with stub_kea({"lease4-add": [{"result": 0}, {"result": 1, "text": "bad"}]}):
+            response = self.client.post(self._url(version=4), self._post(version=4, csv_bytes=csv_bytes))
         self.assertEqual(response.status_code, 200)
         result = response.context["result"]
         self.assertEqual(result["created"], 1)
         self.assertEqual(result["errors"], 1)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_empty_csv_shows_form_error(self, MockKeaClient):
+    def test_post_empty_csv_shows_form_error(self):
         """Uploading a CSV with only a header (no data rows) returns 200 with empty result."""
-        MockKeaClient.return_value.lease_add.return_value = None
         csv_bytes = b"ip-address,hw-address\n"
-        response = self.client.post(self._url(version=4), self._post(version=4, csv_bytes=csv_bytes))
+        # Header-only CSV → zero rows → no lease command issued (empty registry proves it).
+        with stub_kea({}) as kea:
+            response = self.client.post(self._url(version=4), self._post(version=4, csv_bytes=csv_bytes))
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(kea.commands(), [])
         result = response.context.get("result")
         if result is not None:
             self.assertEqual(result["created"], 0)

--- a/netbox_kea/tests/test_views_leases.py
+++ b/netbox_kea/tests/test_views_leases.py
@@ -229,7 +229,14 @@ class TestReservedBadgeOnLeases(_ViewTestBase):
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestLeaseSearchPaths(_ViewTestBase):
     """Each search-by type in BaseServerLeasesView.get_leases() must dispatch the
-    correct Kea command with correct arguments, via HTMX GET."""
+    correct Kea command with correct arguments, via HTMX GET.
+
+    De-mocked: exercises the real ``KeaClient`` so the actual request payload built
+    by ``KeaClient.command()`` — command name, ``arguments``, and ``service`` — is
+    asserted, not a ``MagicMock`` call-arg. Only the HTTP boundary
+    (``requests.Session.post``) is stubbed. A search issues ``config-get`` (subnet
+    quick-select) → ``lease{v}-get…`` → per-lease ``reservation-get`` enrichment.
+    """
 
     _LEASE4 = {
         "ip-address": "10.0.0.5",
@@ -240,6 +247,12 @@ class TestLeaseSearchPaths(_ViewTestBase):
         "valid-lft": 3600,
         "cltt": 1_700_000_000,
     }
+    # The lease-search page fetches the subnet quick-select via config-get first.
+    _CONFIG4 = {"result": 0, "arguments": {"Dhcp4": {"subnet4": [{"id": 1, "subnet": "10.0.0.0/24"}]}}}
+    _CONFIG6 = {"result": 0, "arguments": {"Dhcp6": {"subnet6": [{"id": 1, "subnet": "2001:db8::/64"}]}}}
+    # Reservation enrichment runs for every returned lease; "not found" (result 3)
+    # means no reservation, which is all these lease-command tests care about.
+    _NO_RESERVATION = {"result": 3}
 
     def _htmx_get(self, url, data):
         return self.client.get(url, data=data, HTTP_HX_REQUEST="true")
@@ -250,89 +263,123 @@ class TestLeaseSearchPaths(_ViewTestBase):
     def _url6(self):
         return reverse("plugins:netbox_kea:server_leases6", args=[self.server.pk])
 
-    def _setup_mock(self, MockKeaClient, leases, multiple=True):
-        mock_client = MockKeaClient.return_value
-        if multiple:
-            mock_client.command.return_value = [{"result": 0, "arguments": {"leases": leases, "count": len(leases)}}]
-        else:
-            mock_client.command.return_value = [{"result": 0, "arguments": leases[0] if leases else {}}]
-        mock_client.reservation_get_page.return_value = ([], 0, 0)
-        return mock_client
+    def _multi(self, leases):
+        """Multi-result lease-get response envelope (leases list + count)."""
+        return {"result": 0, "arguments": {"leases": leases, "count": len(leases)}}
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_search_by_hw_address_sends_correct_command(self, MockKeaClient):
+    def _single(self, lease):
+        """Single-result lease-get response envelope (lease fields under arguments)."""
+        return {"result": 0, "arguments": dict(lease)}
+
+    def test_search_by_hw_address_sends_correct_command(self):
         """BY_HW_ADDRESS must call lease4-get-by-hw-address with hw-address argument."""
-        mock_client = self._setup_mock(MockKeaClient, [dict(self._LEASE4)])
-        response = self._htmx_get(self._url4(), {"by": "hw", "q": "aa:bb:cc:dd:ee:ff"})
+        with stub_kea(
+            {
+                "config-get": self._CONFIG4,
+                "lease4-get-by-hw-address": self._multi([dict(self._LEASE4)]),
+                "reservation-get": self._NO_RESERVATION,
+            }
+        ) as kea:
+            response = self._htmx_get(self._url4(), {"by": "hw", "q": "aa:bb:cc:dd:ee:ff"})
         self.assertEqual(response.status_code, 200)
-        cmd_names = [c.args[0] for c in mock_client.command.call_args_list]
-        self.assertIn("lease4-get-by-hw-address", cmd_names)
-        call = next(c for c in mock_client.command.call_args_list if c.args[0] == "lease4-get-by-hw-address")
-        self.assertEqual(call.kwargs["arguments"]["hw-address"], "aa:bb:cc:dd:ee:ff")
+        self.assertIn("lease4-get-by-hw-address", kea.commands())
+        body = kea.bodies("lease4-get-by-hw-address")[0]
+        self.assertEqual(body["arguments"]["hw-address"], "aa:bb:cc:dd:ee:ff")
+        self.assertEqual(body["service"], ["dhcp4"])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_search_by_hostname_sends_correct_command(self, MockKeaClient):
+    def test_search_by_hostname_sends_correct_command(self):
         """BY_HOSTNAME must call lease4-get-by-hostname with hostname argument."""
-        mock_client = self._setup_mock(MockKeaClient, [dict(self._LEASE4)])
-        response = self._htmx_get(self._url4(), {"by": "hostname", "q": "search-host"})
+        with stub_kea(
+            {
+                "config-get": self._CONFIG4,
+                "lease4-get-by-hostname": self._multi([dict(self._LEASE4)]),
+                "reservation-get": self._NO_RESERVATION,
+            }
+        ) as kea:
+            response = self._htmx_get(self._url4(), {"by": "hostname", "q": "search-host"})
         self.assertEqual(response.status_code, 200)
-        cmd_names = [c.args[0] for c in mock_client.command.call_args_list]
-        self.assertIn("lease4-get-by-hostname", cmd_names)
-        call = next(c for c in mock_client.command.call_args_list if c.args[0] == "lease4-get-by-hostname")
-        self.assertEqual(call.kwargs["arguments"]["hostname"], "search-host")
+        self.assertIn("lease4-get-by-hostname", kea.commands())
+        body = kea.bodies("lease4-get-by-hostname")[0]
+        self.assertEqual(body["arguments"]["hostname"], "search-host")
+        self.assertEqual(body["service"], ["dhcp4"])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_search_by_client_id_sends_correct_command(self, MockKeaClient):
+    def test_search_by_client_id_sends_correct_command(self):
         """BY_CLIENT_ID must call lease4-get-by-client-id with client-id argument."""
-        mock_client = self._setup_mock(MockKeaClient, [dict(self._LEASE4)])
-        response = self._htmx_get(self._url4(), {"by": "client_id", "q": "01:aa:bb:cc:dd:ee:ff"})
+        with stub_kea(
+            {
+                "config-get": self._CONFIG4,
+                "lease4-get-by-client-id": self._multi([dict(self._LEASE4)]),
+                "reservation-get": self._NO_RESERVATION,
+            }
+        ) as kea:
+            response = self._htmx_get(self._url4(), {"by": "client_id", "q": "01:aa:bb:cc:dd:ee:ff"})
         self.assertEqual(response.status_code, 200)
-        cmd_names = [c.args[0] for c in mock_client.command.call_args_list]
-        self.assertIn("lease4-get-by-client-id", cmd_names)
-        call = next(c for c in mock_client.command.call_args_list if c.args[0] == "lease4-get-by-client-id")
-        self.assertEqual(call.kwargs["arguments"]["client-id"], "01:aa:bb:cc:dd:ee:ff")
+        self.assertIn("lease4-get-by-client-id", kea.commands())
+        body = kea.bodies("lease4-get-by-client-id")[0]
+        self.assertEqual(body["arguments"]["client-id"], "01:aa:bb:cc:dd:ee:ff")
+        self.assertEqual(body["service"], ["dhcp4"])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_search_by_subnet_id_sends_correct_command(self, MockKeaClient):
+    def test_search_by_subnet_id_sends_correct_command(self):
         """BY_SUBNET_ID must call lease4-get-all with subnets=[<id>]."""
-        mock_client = self._setup_mock(MockKeaClient, [dict(self._LEASE4)])
-        response = self._htmx_get(self._url4(), {"by": "subnet_id", "q": "1"})
+        with stub_kea(
+            {
+                "config-get": self._CONFIG4,
+                "lease4-get-all": self._multi([dict(self._LEASE4)]),
+                "reservation-get": self._NO_RESERVATION,
+            }
+        ) as kea:
+            response = self._htmx_get(self._url4(), {"by": "subnet_id", "q": "1"})
         self.assertEqual(response.status_code, 200)
-        cmd_names = [c.args[0] for c in mock_client.command.call_args_list]
-        self.assertIn("lease4-get-all", cmd_names)
-        call = next(c for c in mock_client.command.call_args_list if c.args[0] == "lease4-get-all")
-        self.assertEqual(call.kwargs["arguments"]["subnets"], [1])
+        self.assertIn("lease4-get-all", kea.commands())
+        body = kea.bodies("lease4-get-all")[0]
+        self.assertEqual(body["arguments"]["subnets"], [1])
+        self.assertEqual(body["service"], ["dhcp4"])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_search_by_ip_returns_200(self, MockKeaClient):
+    def test_search_by_ip_returns_200(self):
         """BY_IP must call lease4-get with ip-address argument and return 200."""
-        mock_client = self._setup_mock(MockKeaClient, [dict(self._LEASE4)], multiple=False)
-        response = self._htmx_get(self._url4(), {"by": "ip", "q": "10.0.0.5"})
+        with stub_kea(
+            {
+                "config-get": self._CONFIG4,
+                "lease4-get": self._single(self._LEASE4),
+                "reservation-get": self._NO_RESERVATION,
+            }
+        ) as kea:
+            response = self._htmx_get(self._url4(), {"by": "ip", "q": "10.0.0.5"})
         self.assertEqual(response.status_code, 200)
-        cmd_names = [c.args[0] for c in mock_client.command.call_args_list]
-        self.assertIn("lease4-get", cmd_names)
+        self.assertIn("lease4-get", kea.commands())
+        body = kea.bodies("lease4-get")[0]
+        self.assertEqual(body["arguments"]["ip-address"], "10.0.0.5")
+        self.assertEqual(body["service"], ["dhcp4"])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_search_result_3_returns_empty_table(self, MockKeaClient):
+    def test_search_result_3_returns_empty_table(self):
         """result=3 (not found) must render an empty table, not a 500."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = [{"result": 3, "arguments": None}]
-        mock_client.reservation_get_page.return_value = ([], 0, 0)
-        response = self._htmx_get(self._url4(), {"by": "ip", "q": "10.0.0.99"})
+        # Empty result short-circuits enrichment, so no reservation-get is issued.
+        with stub_kea(
+            {
+                "config-get": self._CONFIG4,
+                "lease4-get": {"result": 3, "arguments": None},
+            }
+        ) as kea:
+            response = self._htmx_get(self._url4(), {"by": "ip", "q": "10.0.0.99"})
         self.assertEqual(response.status_code, 200)
+        self.assertIn("lease4-get", kea.commands())
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_search_by_duid_v6_sends_correct_command(self, MockKeaClient):
+    def test_search_by_duid_v6_sends_correct_command(self):
         """BY_DUID on the v6 endpoint must call lease6-get-by-duid."""
         server6 = _make_db_server(name="kea-v6-search", ca_url="https://kea6.example.com", dhcp4=False, dhcp6=True)
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = [{"result": 0, "arguments": {"leases": [], "count": 0}}]
-        mock_client.reservation_get_page.return_value = ([], 0, 0)
         url = reverse("plugins:netbox_kea:server_leases6", args=[server6.pk])
-        response = self._htmx_get(url, {"by": "duid", "q": "00:01:aa:bb:cc:dd"})
+        with stub_kea(
+            {
+                "config-get": self._CONFIG6,
+                "lease6-get-by-duid": self._multi([]),
+            }
+        ) as kea:
+            response = self._htmx_get(url, {"by": "duid", "q": "00:01:aa:bb:cc:dd"})
         self.assertEqual(response.status_code, 200)
-        cmd_names = [c.args[0] for c in mock_client.command.call_args_list]
-        self.assertIn("lease6-get-by-duid", cmd_names)
+        self.assertIn("lease6-get-by-duid", kea.commands())
+        body = kea.bodies("lease6-get-by-duid")[0]
+        self.assertEqual(body["arguments"]["duid"], "00:01:aa:bb:cc:dd")
+        self.assertEqual(body["service"], ["dhcp6"])
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/netbox_kea/tests/test_views_options.py
+++ b/netbox_kea/tests/test_views_options.py
@@ -6,16 +6,42 @@ Covers the views in ``netbox_kea/views/options.py`` (e.g.
 ``ServerSubnetOptionsEditView``, ``ServerOptionDefAddView``,
 ``ServerOptionDef4DeleteView``, etc.).
 
-All Kea HTTP calls are mocked so no running Kea instance is required.
+These tests drive the **real** ``KeaClient``; only the HTTP boundary is stubbed
+via ``kea_stub.stub_kea``, so the request payloads the views actually send to Kea
+are exercised. Free Kea has no option-set hook, so every option-data / option-def
+mutation is a read-modify-write cycle:
+
+    config-get  →  config-test  →  config-set  →  config-write
+
+(``config-write`` runs because ``persist_config`` defaults to True.) The old
+mocked tests asserted on ``subnet_update_options.call_args``; these assert on the
+**config-set body** the real read-modify-write pushes back
+(``kea.bodies("config-set")[0]["arguments"]``), which proves the version, subnet,
+and option payload end to end.
+
+Error paths are driven through the real client too:
+- ``KeaConfigTestError`` ← ``config-test`` returns result 1 (non-2 error);
+- ``PartialPersistError`` ← ``config-write`` returns result 1 on a persisting op;
+- generic ``KeaException`` ← ``config-get`` returns result 1;
+- transport / ``ValueError`` / ``RuntimeError`` ← the failing command is registered
+  as that exception instance (the stub raises it at the boundary);
+- get-client ``ValueError`` ← a server built with ``client_cert_path`` but no key
+  (``KeaClient.__init__`` rejects cert-without-key).
 """
 
-from unittest.mock import patch
+import copy
 
+import requests
 from django.contrib import messages as django_messages
 from django.test import override_settings
 from django.urls import reverse
 
+from .kea_stub import stub_kea
 from .utils import _PLUGINS_CONFIG, _make_db_server, _ViewTestBase
+
+# ---------------------------------------------------------------------------
+# config-get fixtures (read by the read-modify-write mutations and GET prefill)
+# ---------------------------------------------------------------------------
 
 _OPTIONS_CONFIG_GET = [
     {
@@ -37,194 +63,22 @@ _OPTIONS_CONFIG_GET = [
     }
 ]
 
-
-@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
-class TestSubnetOptionsView(_ViewTestBase):
-    """Tests for ServerSubnet4/6OptionsEditView (GET prefill + POST update)."""
-
-    def _url(self, version=4, subnet_id=42):
-        return reverse(
-            f"plugins:netbox_kea:server_subnet{version}_options_edit",
-            args=[self.server.pk, subnet_id],
-        )
-
-    def test_url_registered_v4(self):
-        """URL server_subnet4_options_edit is registered."""
-        url = self._url(version=4)
-        self.assertIn("options", url)
-
-    def test_url_registered_v6(self):
-        """URL server_subnet6_options_edit is registered."""
-        url = self._url(version=6)
-        self.assertIn("options", url)
-
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_returns_200(self, MockKeaClient):
-        """GET returns 200 OK."""
-        MockKeaClient.return_value.command.return_value = _OPTIONS_CONFIG_GET
-        response = self.client.get(self._url())
-        self.assertEqual(response.status_code, 200)
-
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_prefills_existing_options(self, MockKeaClient):
-        """GET pre-populates formset with existing option-data from config-get."""
-        MockKeaClient.return_value.command.return_value = _OPTIONS_CONFIG_GET
-        response = self.client.get(self._url())
-        content = response.content.decode()
-        self.assertIn("domain-name-servers", content)
-        self.assertIn("8.8.8.8", content)
-
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_calls_subnet_update_options(self, MockKeaClient):
-        """POST with valid formset calls subnet_update_options and redirects."""
-        MockKeaClient.return_value.subnet_update_options.return_value = None
-        response = self.client.post(
-            self._url(),
-            {
-                "form-TOTAL_FORMS": "1",
-                "form-INITIAL_FORMS": "0",
-                "form-MIN_NUM_FORMS": "0",
-                "form-MAX_NUM_FORMS": "1000",
-                "form-0-name": "routers",
-                "form-0-data": "10.0.0.1",
-                "form-0-always_send": "",
-                "form-0-DELETE": "",
-            },
-        )
-        self.assertEqual(response.status_code, 302)
-        self._assert_redirect_to_integer_pk(response)
-        MockKeaClient.return_value.subnet_update_options.assert_called_once()
-
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_passes_correct_version_and_subnet_id(self, MockKeaClient):
-        """POST calls subnet_update_options with the correct version and subnet_id."""
-        MockKeaClient.return_value.subnet_update_options.return_value = None
-        self.client.post(
-            self._url(version=4, subnet_id=42),
-            {
-                "form-TOTAL_FORMS": "1",
-                "form-INITIAL_FORMS": "0",
-                "form-MIN_NUM_FORMS": "0",
-                "form-MAX_NUM_FORMS": "1000",
-                "form-0-name": "routers",
-                "form-0-data": "10.0.0.1",
-                "form-0-always_send": "",
-                "form-0-DELETE": "",
-            },
-        )
-        call_args = MockKeaClient.return_value.subnet_update_options.call_args
-        self.assertIsNotNone(call_args)
-        self.assertEqual(call_args.kwargs["version"], 4)  # version
-        self.assertEqual(call_args.kwargs["subnet_id"], 42)  # subnet_id
-
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_deleted_rows_excluded_from_options(self, MockKeaClient):
-        """Rows with DELETE=on are excluded from the options list passed to subnet_update_options."""
-        MockKeaClient.return_value.subnet_update_options.return_value = None
-        self.client.post(
-            self._url(),
-            {
-                "form-TOTAL_FORMS": "2",
-                "form-INITIAL_FORMS": "0",
-                "form-MIN_NUM_FORMS": "0",
-                "form-MAX_NUM_FORMS": "1000",
-                "form-0-name": "routers",
-                "form-0-data": "10.0.0.1",
-                "form-0-always_send": "",
-                "form-0-DELETE": "",
-                "form-1-name": "domain-name-servers",
-                "form-1-data": "8.8.8.8",
-                "form-1-always_send": "",
-                "form-1-DELETE": "on",
-            },
-        )
-        call_kwargs = MockKeaClient.return_value.subnet_update_options.call_args
-        self.assertIsNotNone(call_kwargs, "subnet_update_options was not called")
-        # options argument — use explicit keyword or positional lookup
-        options_arg = call_kwargs.kwargs.get("options") or (call_kwargs.args[2] if len(call_kwargs.args) > 2 else [])
-        self.assertEqual(len(options_arg), 1)
-        self.assertEqual(options_arg[0]["name"], "routers")
-
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_kea_exception_shows_error_message(self, MockKeaClient):
-        """POST that raises KeaException shows an error message, stays on form."""
-        from netbox_kea.kea import KeaException
-
-        MockKeaClient.return_value.subnet_update_options.side_effect = KeaException(
-            {"result": 1, "text": "subnet not found"}
-        )
-        response = self.client.post(
-            self._url(),
-            {
-                "form-TOTAL_FORMS": "1",
-                "form-INITIAL_FORMS": "0",
-                "form-MIN_NUM_FORMS": "0",
-                "form-MAX_NUM_FORMS": "1000",
-                "form-0-name": "routers",
-                "form-0-data": "10.0.0.1",
-                "form-0-always_send": "",
-                "form-0-DELETE": "",
-            },
-        )
-        self.assertEqual(response.status_code, 302)  # redirect back to subnets
-        self._assert_redirect_to_integer_pk(response)
-        msgs = list(django_messages.get_messages(response.wsgi_request))
-        self.assertTrue(any(m.level == django_messages.ERROR for m in msgs))
-
-    def test_get_requires_login(self):
-        """Unauthenticated GET is redirected."""
-        self.client.logout()
-        response = self.client.get(self._url())
-        self.assertIn(response.status_code, (302, 403))
-
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_v6_returns_200(self, MockKeaClient):
-        """GET for DHCPv6 subnet options returns 200 OK."""
-        MockKeaClient.return_value.command.return_value = [
-            {
-                "result": 0,
-                "arguments": {
-                    "Dhcp6": {
-                        "subnet6": [
-                            {
-                                "id": 42,
-                                "subnet": "2001:db8::/64",
-                                "option-data": [{"name": "dns-servers", "data": "2001:4860:4860::8888"}],
-                            }
-                        ]
+_OPTIONS_CONFIG_GET_V6 = [
+    {
+        "result": 0,
+        "arguments": {
+            "Dhcp6": {
+                "subnet6": [
+                    {
+                        "id": 42,
+                        "subnet": "2001:db8::/64",
+                        "option-data": [{"name": "dns-servers", "data": "2001:4860:4860::8888"}],
                     }
-                },
+                ]
             }
-        ]
-        response = self.client.get(self._url(version=6, subnet_id=42))
-        self.assertEqual(response.status_code, 200)
-        self.assertIn("dns-servers", response.content.decode())
-
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_passes_correct_version_and_subnet_id_v6(self, MockKeaClient):
-        """POST for DHCPv6 subnet calls subnet_update_options with version=6 and subnet_id=42."""
-        MockKeaClient.return_value.subnet_update_options.return_value = None
-        self.client.post(
-            self._url(version=6, subnet_id=42),
-            {
-                "form-TOTAL_FORMS": "1",
-                "form-INITIAL_FORMS": "0",
-                "form-MIN_NUM_FORMS": "0",
-                "form-MAX_NUM_FORMS": "1000",
-                "form-0-name": "dns-servers",
-                "form-0-data": "2001:4860:4860::8888",
-                "form-0-always_send": "",
-                "form-0-DELETE": "",
-            },
-        )
-        call_args = MockKeaClient.return_value.subnet_update_options.call_args
-        self.assertIsNotNone(call_args)
-        self.assertEqual(call_args.kwargs["version"], 6)
-        self.assertEqual(call_args.kwargs["subnet_id"], 42)
-
-
-# TestServerOptionsView
-# ---------------------------------------------------------------------------
+        },
+    }
+]
 
 _SERVER_OPTIONS_CONFIG_GET = [
     {
@@ -241,6 +95,195 @@ _SERVER_OPTIONS_CONFIG_GET = [
     }
 ]
 
+_SERVER_OPTIONS_CONFIG_GET_V6 = [
+    {
+        "result": 0,
+        "arguments": {
+            "Dhcp6": {
+                "option-data": [{"name": "dns-servers", "data": "2001:4860:4860::8888"}],
+                "subnet6": [],
+            }
+        },
+    }
+]
+
+_OPTION_DEF_LIST_V4 = [
+    {"name": "my-opt", "code": 200, "type": "string", "space": "dhcp4"},
+    {"name": "other-opt", "code": 201, "type": "uint32", "space": "dhcp4"},
+]
+
+_OPTION_DEF_LIST_EMPTY: list = []
+
+
+# ---------------------------------------------------------------------------
+# Stub builders (real KeaClient + HTTP-boundary stub)
+# ---------------------------------------------------------------------------
+
+_CONFIG_OK = {"result": 0}
+
+
+def _option_def_config(defs, version=4):
+    """A ``config-get`` payload exposing ``Dhcp{v}.option-def`` (what ``option_def_list`` reads)."""
+    return [{"result": 0, "arguments": {f"Dhcp{version}": {"option-def": list(defs)}}}]
+
+
+def _persist_stub(config_get, **overrides):
+    """Stub the read-modify-write chain: config-get → config-test → config-set → config-write.
+
+    *config_get* is deep-copied so the read-modify-write mutation (which edits the
+    config in place) never corrupts the shared module-level fixture. Assert on the
+    resulting config-set body via ``kea.bodies("config-set")[0]["arguments"]``.
+
+    ``stat-lease{4,6}-get`` are pre-registered (harmless when unused) so tests that
+    POST with ``follow=True`` and land on the subnets list — which enriches subnets
+    with utilisation stats — render without tripping the strict stub.
+    """
+    base = {
+        "config-get": copy.deepcopy(config_get),
+        "config-test": _CONFIG_OK,
+        "config-set": _CONFIG_OK,
+        "config-write": _CONFIG_OK,
+        "stat-lease4-get": {"result": 0, "arguments": {}},
+        "stat-lease6-get": {"result": 0, "arguments": {}},
+    }
+    base.update(overrides)
+    return stub_kea(base)
+
+
+def _written_config(kea):
+    """Return the config dict the real read-modify-write pushed to Kea via config-set."""
+    bodies = kea.bodies("config-set")
+    assert bodies, "config-set was never issued (read-modify-write did not complete)"
+    return bodies[0]["arguments"]
+
+
+@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
+class TestSubnetOptionsView(_ViewTestBase):
+    """Tests for ServerSubnet4/6OptionsEditView (GET prefill + POST update)."""
+
+    def _url(self, version=4, subnet_id=42):
+        return reverse(
+            f"plugins:netbox_kea:server_subnet{version}_options_edit",
+            args=[self.server.pk, subnet_id],
+        )
+
+    def _post_data(self, name="routers", data="10.0.0.1", always_send="", delete=""):
+        return {
+            "form-TOTAL_FORMS": "1",
+            "form-INITIAL_FORMS": "0",
+            "form-MIN_NUM_FORMS": "0",
+            "form-MAX_NUM_FORMS": "1000",
+            "form-0-name": name,
+            "form-0-data": data,
+            "form-0-always_send": always_send,
+            "form-0-DELETE": delete,
+        }
+
+    def test_url_registered_v4(self):
+        """URL server_subnet4_options_edit is registered."""
+        url = self._url(version=4)
+        self.assertIn("options", url)
+
+    def test_url_registered_v6(self):
+        """URL server_subnet6_options_edit is registered."""
+        url = self._url(version=6)
+        self.assertIn("options", url)
+
+    def test_get_returns_200(self):
+        """GET returns 200 OK."""
+        with stub_kea({"config-get": _OPTIONS_CONFIG_GET}):
+            response = self.client.get(self._url())
+        self.assertEqual(response.status_code, 200)
+
+    def test_get_prefills_existing_options(self):
+        """GET pre-populates formset with existing option-data from config-get."""
+        with stub_kea({"config-get": _OPTIONS_CONFIG_GET}):
+            response = self.client.get(self._url())
+        content = response.content.decode()
+        self.assertIn("domain-name-servers", content)
+        self.assertIn("8.8.8.8", content)
+
+    def test_post_calls_subnet_update_options(self):
+        """POST with valid formset runs the read-modify-write and redirects."""
+        with _persist_stub(_OPTIONS_CONFIG_GET) as kea:
+            response = self.client.post(self._url(), self._post_data())
+        self.assertEqual(response.status_code, 302)
+        self._assert_redirect_to_integer_pk(response)
+        self.assertIn("config-set", kea.commands())
+
+    def test_post_passes_correct_version_and_subnet_id(self):
+        """POST rewrites subnet 42's option-data in the DHCPv4 config (version + subnet_id)."""
+        with _persist_stub(_OPTIONS_CONFIG_GET) as kea:
+            self.client.post(self._url(version=4, subnet_id=42), self._post_data())
+        subnet = _written_config(kea)["Dhcp4"]["subnet4"][0]
+        self.assertEqual(subnet["id"], 42)
+        self.assertEqual([o["name"] for o in subnet["option-data"]], ["routers"])
+
+    def test_post_deleted_rows_excluded_from_options(self):
+        """Rows with DELETE=on are excluded from the option-data written back."""
+        data = {
+            "form-TOTAL_FORMS": "2",
+            "form-INITIAL_FORMS": "0",
+            "form-MIN_NUM_FORMS": "0",
+            "form-MAX_NUM_FORMS": "1000",
+            "form-0-name": "routers",
+            "form-0-data": "10.0.0.1",
+            "form-0-always_send": "",
+            "form-0-DELETE": "",
+            "form-1-name": "domain-name-servers",
+            "form-1-data": "8.8.8.8",
+            "form-1-always_send": "",
+            "form-1-DELETE": "on",
+        }
+        with _persist_stub(_OPTIONS_CONFIG_GET) as kea:
+            self.client.post(self._url(), data)
+        opts = _written_config(kea)["Dhcp4"]["subnet4"][0]["option-data"]
+        self.assertEqual(len(opts), 1)
+        self.assertEqual(opts[0]["name"], "routers")
+
+    def test_post_kea_exception_shows_error_message(self):
+        """A KeaException from the mutation shows an error message and redirects.
+
+        With no subnet 42 in the returned config, the real ``subnet_update_options``
+        raises ``KeaException`` ("subnet not found") before any config-test.
+        """
+        empty = [{"result": 0, "arguments": {"Dhcp4": {"subnet4": [], "shared-networks": []}}}]
+        with stub_kea({"config-get": empty}):
+            response = self.client.post(self._url(), self._post_data())
+        self.assertEqual(response.status_code, 302)
+        self._assert_redirect_to_integer_pk(response)
+        msgs = list(django_messages.get_messages(response.wsgi_request))
+        self.assertTrue(any(m.level == django_messages.ERROR for m in msgs))
+
+    def test_get_requires_login(self):
+        """Unauthenticated GET is redirected."""
+        self.client.logout()
+        response = self.client.get(self._url())
+        self.assertIn(response.status_code, (302, 403))
+
+    def test_get_v6_returns_200(self):
+        """GET for DHCPv6 subnet options returns 200 OK."""
+        with stub_kea({"config-get": _OPTIONS_CONFIG_GET_V6}):
+            response = self.client.get(self._url(version=6, subnet_id=42))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("dns-servers", response.content.decode())
+
+    def test_post_passes_correct_version_and_subnet_id_v6(self):
+        """POST for a DHCPv6 subnet rewrites subnet 42's option-data in the DHCPv6 config."""
+        with _persist_stub(_OPTIONS_CONFIG_GET_V6) as kea:
+            self.client.post(
+                self._url(version=6, subnet_id=42),
+                self._post_data(name="dns-servers", data="2001:4860:4860::8888"),
+            )
+        subnet = _written_config(kea)["Dhcp6"]["subnet6"][0]
+        self.assertEqual(subnet["id"], 42)
+        self.assertEqual([o["name"] for o in subnet["option-data"]], ["dns-servers"])
+
+
+# ---------------------------------------------------------------------------
+# TestServerOptionsView
+# ---------------------------------------------------------------------------
+
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestServerOptionsView(_ViewTestBase):
@@ -252,6 +295,18 @@ class TestServerOptionsView(_ViewTestBase):
             args=[self.server.pk],
         )
 
+    def _post_data(self, name="routers", data="10.0.0.1", always_send="", delete=""):
+        return {
+            "form-TOTAL_FORMS": "1",
+            "form-INITIAL_FORMS": "0",
+            "form-MIN_NUM_FORMS": "0",
+            "form-MAX_NUM_FORMS": "1000",
+            "form-0-name": name,
+            "form-0-data": data,
+            "form-0-always_send": always_send,
+            "form-0-DELETE": delete,
+        }
+
     def test_url_registered_v4(self):
         """URL server_dhcp4_options_edit is registered."""
         url = self._url(version=4)
@@ -262,114 +317,65 @@ class TestServerOptionsView(_ViewTestBase):
         url = self._url(version=6)
         self.assertIn("options", url)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_returns_200(self, MockKeaClient):
+    def test_get_returns_200(self):
         """GET returns 200 OK."""
-        MockKeaClient.return_value.command.return_value = _SERVER_OPTIONS_CONFIG_GET
-        response = self.client.get(self._url())
+        with stub_kea({"config-get": _SERVER_OPTIONS_CONFIG_GET}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_prefills_existing_options(self, MockKeaClient):
+    def test_get_prefills_existing_options(self):
         """GET pre-populates formset with existing server-level option-data."""
-        MockKeaClient.return_value.command.return_value = _SERVER_OPTIONS_CONFIG_GET
-        response = self.client.get(self._url())
+        with stub_kea({"config-get": _SERVER_OPTIONS_CONFIG_GET}):
+            response = self.client.get(self._url())
         content = response.content.decode()
         self.assertIn("domain-name-servers", content)
         self.assertIn("8.8.8.8", content)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_calls_server_update_options(self, MockKeaClient):
-        """POST with valid formset calls server_update_options and redirects."""
-        MockKeaClient.return_value.server_update_options.return_value = None
-        response = self.client.post(
-            self._url(),
-            {
-                "form-TOTAL_FORMS": "1",
-                "form-INITIAL_FORMS": "0",
-                "form-MIN_NUM_FORMS": "0",
-                "form-MAX_NUM_FORMS": "1000",
-                "form-0-name": "routers",
-                "form-0-data": "10.0.0.1",
-                "form-0-always_send": "",
-                "form-0-DELETE": "",
-            },
-        )
+    def test_post_calls_server_update_options(self):
+        """POST with valid formset runs the read-modify-write and redirects."""
+        with _persist_stub(_SERVER_OPTIONS_CONFIG_GET) as kea:
+            response = self.client.post(self._url(), self._post_data())
         self.assertEqual(response.status_code, 302)
         self._assert_redirect_to_integer_pk(response)
-        MockKeaClient.return_value.server_update_options.assert_called_once()
+        self.assertIn("config-set", kea.commands())
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_passes_correct_version(self, MockKeaClient):
-        """POST calls server_update_options with the correct version."""
-        MockKeaClient.return_value.server_update_options.return_value = None
-        self.client.post(
-            self._url(version=4),
-            {
-                "form-TOTAL_FORMS": "1",
-                "form-INITIAL_FORMS": "0",
-                "form-MIN_NUM_FORMS": "0",
-                "form-MAX_NUM_FORMS": "1000",
-                "form-0-name": "routers",
-                "form-0-data": "10.0.0.1",
-                "form-0-always_send": "",
-                "form-0-DELETE": "",
-            },
-        )
-        call_args = MockKeaClient.return_value.server_update_options.call_args
-        self.assertIsNotNone(call_args)
-        self.assertEqual(call_args.kwargs["version"], 4)  # version
+    def test_post_passes_correct_version(self):
+        """POST rewrites the DHCPv4 server-level option-data."""
+        with _persist_stub(_SERVER_OPTIONS_CONFIG_GET) as kea:
+            self.client.post(self._url(version=4), self._post_data())
+        opts = _written_config(kea)["Dhcp4"]["option-data"]
+        self.assertEqual([o["name"] for o in opts], ["routers"])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_deleted_rows_excluded(self, MockKeaClient):
-        """Rows with DELETE=on are excluded from the options list."""
-        MockKeaClient.return_value.server_update_options.return_value = None
-        self.client.post(
-            self._url(),
-            {
-                "form-TOTAL_FORMS": "2",
-                "form-INITIAL_FORMS": "0",
-                "form-MIN_NUM_FORMS": "0",
-                "form-MAX_NUM_FORMS": "1000",
-                "form-0-name": "routers",
-                "form-0-data": "10.0.0.1",
-                "form-0-always_send": "",
-                "form-0-DELETE": "",
-                "form-1-name": "domain-name-servers",
-                "form-1-data": "8.8.8.8",
-                "form-1-always_send": "",
-                "form-1-DELETE": "on",
-            },
-        )
-        call_kwargs = MockKeaClient.return_value.server_update_options.call_args
-        self.assertIsNotNone(call_kwargs, "server_update_options was not called")
-        options_arg = (call_kwargs.kwargs or {}).get("options") or (
-            call_kwargs.args[1] if len(call_kwargs.args) > 1 else []
-        )
-        self.assertEqual(len(options_arg), 1)
-        self.assertEqual(options_arg[0]["name"], "routers")
+    def test_post_deleted_rows_excluded(self):
+        """Rows with DELETE=on are excluded from the option-data written back."""
+        data = {
+            "form-TOTAL_FORMS": "2",
+            "form-INITIAL_FORMS": "0",
+            "form-MIN_NUM_FORMS": "0",
+            "form-MAX_NUM_FORMS": "1000",
+            "form-0-name": "routers",
+            "form-0-data": "10.0.0.1",
+            "form-0-always_send": "",
+            "form-0-DELETE": "",
+            "form-1-name": "domain-name-servers",
+            "form-1-data": "8.8.8.8",
+            "form-1-always_send": "",
+            "form-1-DELETE": "on",
+        }
+        with _persist_stub(_SERVER_OPTIONS_CONFIG_GET) as kea:
+            self.client.post(self._url(), data)
+        opts = _written_config(kea)["Dhcp4"]["option-data"]
+        self.assertEqual(len(opts), 1)
+        self.assertEqual(opts[0]["name"], "routers")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_kea_exception_redirects(self, MockKeaClient):
-        """POST that raises KeaException shows error message and redirects."""
-        from netbox_kea.kea import KeaException
+    def test_post_kea_exception_redirects(self):
+        """A KeaException from the mutation shows an error message and redirects.
 
-        MockKeaClient.return_value.server_update_options.side_effect = KeaException(
-            {"result": 1, "text": "internal error"}
-        )
-        response = self.client.post(
-            self._url(),
-            {
-                "form-TOTAL_FORMS": "1",
-                "form-INITIAL_FORMS": "0",
-                "form-MIN_NUM_FORMS": "0",
-                "form-MAX_NUM_FORMS": "1000",
-                "form-0-name": "routers",
-                "form-0-data": "10.0.0.1",
-                "form-0-always_send": "",
-                "form-0-DELETE": "",
-            },
-        )
+        A config-get result 1 makes the real ``server_update_options`` raise
+        ``KeaException`` before any write.
+        """
+        with stub_kea({"config-get": {"result": 1, "text": "internal error"}}):
+            response = self.client.post(self._url(), self._post_data())
         self.assertEqual(response.status_code, 302)
         msgs = list(django_messages.get_messages(response.wsgi_request))
         self.assertTrue(any(m.level == django_messages.ERROR for m in msgs))
@@ -380,55 +386,19 @@ class TestServerOptionsView(_ViewTestBase):
         response = self.client.get(self._url())
         self.assertIn(response.status_code, (302, 403))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_v6_returns_200(self, MockKeaClient):
+    def test_get_v6_returns_200(self):
         """GET for DHCPv6 server options returns 200 OK."""
-        MockKeaClient.return_value.command.return_value = [
-            {
-                "result": 0,
-                "arguments": {
-                    "Dhcp6": {
-                        "option-data": [{"name": "dns-servers", "data": "2001:4860:4860::8888"}],
-                        "subnet6": [],
-                    }
-                },
-            }
-        ]
-        response = self.client.get(self._url(version=6))
+        with stub_kea({"config-get": _SERVER_OPTIONS_CONFIG_GET_V6}):
+            response = self.client.get(self._url(version=6))
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_passes_version_6(self, MockKeaClient):
-        """POST for DHCPv6 server options calls server_update_options with version=6."""
-        MockKeaClient.return_value.server_update_options.return_value = None
-        self.client.post(
-            self._url(version=6),
-            {
-                "form-TOTAL_FORMS": "1",
-                "form-INITIAL_FORMS": "0",
-                "form-MIN_NUM_FORMS": "0",
-                "form-MAX_NUM_FORMS": "1000",
-                "form-0-name": "dns-servers",
-                "form-0-data": "2001:4860:4860::8888",
-                "form-0-always_send": "",
-                "form-0-DELETE": "",
-            },
-        )
-        call_args = MockKeaClient.return_value.server_update_options.call_args
-        self.assertIsNotNone(call_args)
-        self.assertEqual(call_args.kwargs["version"], 6)
+    def test_post_passes_version_6(self):
+        """POST for DHCPv6 server options rewrites the DHCPv6 server-level option-data."""
+        with _persist_stub(_SERVER_OPTIONS_CONFIG_GET_V6) as kea:
+            self.client.post(self._url(version=6), self._post_data(name="dns-servers", data="2001:4860:4860::8888"))
+        opts = _written_config(kea)["Dhcp6"]["option-data"]
+        self.assertEqual([o["name"] for o in opts], ["dns-servers"])
 
-
-# ---------------------------------------------------------------------------
-# option-def fixtures
-# ---------------------------------------------------------------------------
-
-_OPTION_DEF_LIST_V4 = [
-    {"name": "my-opt", "code": 200, "type": "string", "space": "dhcp4"},
-    {"name": "other-opt", "code": 201, "type": "uint32", "space": "dhcp4"},
-]
-
-_OPTION_DEF_LIST_EMPTY: list = []
 
 # ---------------------------------------------------------------------------
 # ServerOptionDef4ListView / ServerOptionDef6ListView
@@ -442,39 +412,36 @@ class TestServerOptionDef4ListView(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_option_def4", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_returns_200(self, MockKeaClient):
+    def test_get_returns_200(self):
         """GET returns 200 OK."""
-        MockKeaClient.return_value.option_def_list.return_value = _OPTION_DEF_LIST_V4
-        response = self.client.get(self._url())
+        with stub_kea({"config-get": _option_def_config(_OPTION_DEF_LIST_V4)}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_shows_option_def_name(self, MockKeaClient):
+    def test_shows_option_def_name(self):
         """GET renders option names in the response."""
-        MockKeaClient.return_value.option_def_list.return_value = _OPTION_DEF_LIST_V4
-        response = self.client.get(self._url())
+        with stub_kea({"config-get": _option_def_config(_OPTION_DEF_LIST_V4)}):
+            response = self.client.get(self._url())
         self.assertContains(response, "my-opt")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_shows_option_def_code(self, MockKeaClient):
+    def test_shows_option_def_code(self):
         """GET renders option codes in the response."""
-        MockKeaClient.return_value.option_def_list.return_value = _OPTION_DEF_LIST_V4
-        response = self.client.get(self._url())
+        with stub_kea({"config-get": _option_def_config(_OPTION_DEF_LIST_V4)}):
+            response = self.client.get(self._url())
         self.assertContains(response, "200")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_empty_list_shows_200(self, MockKeaClient):
+    def test_empty_list_shows_200(self):
         """GET with empty option-def list returns 200 without errors."""
-        MockKeaClient.return_value.option_def_list.return_value = _OPTION_DEF_LIST_EMPTY
-        response = self.client.get(self._url())
+        with stub_kea({"config-get": _option_def_config(_OPTION_DEF_LIST_EMPTY)}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
 
     def test_get_with_dhcp4_disabled_redirects(self):
-        """Server with dhcp4=False redirects away from option_def4 tab."""
+        """Server with dhcp4=False redirects away from option_def4 tab (before any Kea call)."""
         v6_only = _make_db_server(name="v6only-od", dhcp4=False, dhcp6=True)
         url = reverse("plugins:netbox_kea:server_option_def4", args=[v6_only.pk])
-        response = self.client.get(url)
+        with stub_kea({}):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 302)
         self._assert_no_none_pk_redirect(response)
 
@@ -484,13 +451,12 @@ class TestServerOptionDef4ListView(_ViewTestBase):
         response = self.client.get(self._url())
         self.assertIn(response.status_code, (302, 403))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_sets_tab_in_context(self, MockKeaClient):
+    def test_get_sets_tab_in_context(self):
         """F2: GET response must include 'tab' in context for tab bar highlighting."""
         from netbox_kea.views import ServerOptionDef4View
 
-        MockKeaClient.return_value.option_def_list.return_value = _OPTION_DEF_LIST_V4
-        response = self.client.get(self._url())
+        with stub_kea({"config-get": _option_def_config(_OPTION_DEF_LIST_V4)}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         self.assertIs(response.context["tab"], ServerOptionDef4View.tab)
 
@@ -502,27 +468,24 @@ class TestServerOptionDef6ListView(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_option_def6", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_returns_200(self, MockKeaClient):
+    def test_get_returns_200(self):
         """GET returns 200 OK."""
-        MockKeaClient.return_value.option_def_list.return_value = []
-        response = self.client.get(self._url())
+        with stub_kea({"config-get": _option_def_config([], version=6)}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_calls_option_def_list_with_version_6(self, MockKeaClient):
-        """GET calls option_def_list with version=6."""
-        MockKeaClient.return_value.option_def_list.return_value = []
-        self.client.get(self._url())
-        MockKeaClient.return_value.option_def_list.assert_called_once_with(version=6)
+    def test_calls_option_def_list_with_version_6(self):
+        """GET queries config-get against the dhcp6 service (option_def_list version=6)."""
+        with stub_kea({"config-get": _option_def_config([], version=6)}) as kea:
+            self.client.get(self._url())
+        self.assertEqual(kea.bodies("config-get")[0].get("service"), ["dhcp6"])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_sets_tab_in_context(self, MockKeaClient):
+    def test_get_sets_tab_in_context(self):
         """F2: option definitions render under the shared 'Config' tab."""
         from netbox_kea.views.options import _CONFIG_TAB
 
-        MockKeaClient.return_value.option_def_list.return_value = []
-        response = self.client.get(self._url())
+        with stub_kea({"config-get": _option_def_config([], version=6)}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         self.assertIs(response.context["tab"], _CONFIG_TAB)
 
@@ -539,73 +502,59 @@ class TestServerOptionDef4AddView(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_option_def4_add", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_returns_200_with_form(self, MockKeaClient):
+    def test_get_returns_200_with_form(self):
         """GET renders the add option-def form."""
-        response = self.client.get(self._url())
+        with stub_kea({}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_valid_calls_option_def_add(self, MockKeaClient):
-        """POST with valid data calls option_def_add and redirects."""
-        MockKeaClient.return_value.option_def_add.return_value = None
-        response = self.client.post(
-            self._url(),
-            {"name": "my-opt", "code": 200, "type": "string", "space": "dhcp4", "array": False},
-        )
+    def test_post_valid_calls_option_def_add(self):
+        """POST with valid data appends the option-def and redirects."""
+        with _persist_stub(_option_def_config([])) as kea:
+            response = self.client.post(
+                self._url(),
+                {"name": "my-opt", "code": 200, "type": "string", "space": "dhcp4", "array": False},
+            )
         self.assertEqual(response.status_code, 302)
         self._assert_no_none_pk_redirect(response)
-        MockKeaClient.return_value.option_def_add.assert_called_once()
-        call_args = MockKeaClient.return_value.option_def_add.call_args
-        opt = (call_args.kwargs or {}).get("option_def") or (call_args.args[1] if len(call_args.args) > 1 else {})
-        self.assertEqual(opt.get("name"), "my-opt")
-        self.assertEqual(opt.get("code"), 200)
-        self.assertEqual(opt.get("type"), "string")
-        self.assertEqual(opt.get("space"), "dhcp4")
+        defs = _written_config(kea)["Dhcp4"]["option-def"]
+        added = next(d for d in defs if d.get("code") == 200)
+        self.assertEqual(added["name"], "my-opt")
+        self.assertEqual(added["type"], "string")
+        self.assertEqual(added["space"], "dhcp4")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_passes_correct_version(self, MockKeaClient):
-        """POST calls option_def_add with version=4."""
-        MockKeaClient.return_value.option_def_add.return_value = None
-        self.client.post(
-            self._url(),
-            {"name": "my-opt", "code": 200, "type": "string", "space": "dhcp4", "array": False},
-        )
-        call_args = MockKeaClient.return_value.option_def_add.call_args
-        self.assertIsNotNone(call_args, "option_def_add was not called")
-        kwargs = call_args.kwargs or call_args[1]
-        args = call_args.args or call_args[0]
-        version = kwargs.get("version") or (args[0] if args else None)
-        self.assertEqual(version, 4)
-        opt = kwargs.get("option_def") or (call_args.args[1] if len(call_args.args) > 1 else {})
-        self.assertEqual(opt.get("name"), "my-opt")
-        self.assertEqual(opt.get("code"), 200)
-        self.assertEqual(opt.get("type"), "string")
-        self.assertEqual(opt.get("space"), "dhcp4")
+    def test_post_passes_correct_version(self):
+        """POST writes the new option-def into the DHCPv4 config."""
+        with _persist_stub(_option_def_config([])) as kea:
+            self.client.post(
+                self._url(),
+                {"name": "my-opt", "code": 200, "type": "string", "space": "dhcp4", "array": False},
+            )
+        written = _written_config(kea)
+        self.assertIn("Dhcp4", written)
+        added = next(d for d in written["Dhcp4"]["option-def"] if d.get("code") == 200)
+        self.assertEqual(added["name"], "my-opt")
+        self.assertEqual(added["type"], "string")
+        self.assertEqual(added["space"], "dhcp4")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_kea_exception_shows_error(self, MockKeaClient):
-        """POST that raises KeaException returns 200 with error (no 500)."""
-        from netbox_kea.kea import KeaException
-
-        MockKeaClient.return_value.option_def_add.side_effect = KeaException(
-            {"result": 1, "text": "duplicate code"}, index=0
-        )
-        response = self.client.post(
-            self._url(),
-            {"name": "my-opt", "code": 200, "type": "string", "space": "dhcp4", "array": False},
-        )
+    def test_post_kea_exception_shows_error(self):
+        """A KeaException from the mutation shows an error (no 500)."""
+        with stub_kea({"config-get": {"result": 1, "text": "duplicate code"}}) as kea:
+            response = self.client.post(
+                self._url(),
+                {"name": "my-opt", "code": 200, "type": "string", "space": "dhcp4", "array": False},
+            )
         self.assertIn(response.status_code, (200, 302))
         msgs = list(django_messages.get_messages(response.wsgi_request))
         self.assertTrue(any(m.level == django_messages.ERROR for m in msgs))
-        MockKeaClient.return_value.option_def_add.assert_called_once()
+        self.assertIn("config-get", kea.commands())
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_invalid_form_returns_200(self, MockKeaClient):
-        """POST with missing required fields returns 200 (form re-render)."""
-        response = self.client.post(self._url(), {"name": "", "code": "", "type": "", "space": ""})
+    def test_post_invalid_form_returns_200(self):
+        """POST with missing required fields returns 200 (form re-render), no Kea call."""
+        with stub_kea({}) as kea:
+            response = self.client.post(self._url(), {"name": "", "code": "", "type": "", "space": ""})
         self.assertEqual(response.status_code, 200)
-        MockKeaClient.return_value.option_def_add.assert_not_called()
+        self.assertEqual(kea.commands(), [])
 
     def test_get_requires_login(self):
         """Unauthenticated GET redirects to login."""
@@ -621,30 +570,25 @@ class TestServerOptionDef6AddView(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_option_def6_add", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_returns_200(self, MockKeaClient):
+    def test_get_returns_200(self):
         """GET renders the add form for v6."""
-        response = self.client.get(self._url())
+        with stub_kea({}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_calls_option_def_add_with_version_6(self, MockKeaClient):
-        """POST calls option_def_add with version=6."""
-        MockKeaClient.return_value.option_def_add.return_value = None
-        self.client.post(
-            self._url(),
-            {"name": "v6-opt", "code": 250, "type": "ipv6-address", "space": "dhcp6", "array": False},
-        )
-        call_args = MockKeaClient.return_value.option_def_add.call_args
-        kwargs = call_args.kwargs or call_args[1]
-        args = call_args.args or call_args[0]
-        version = kwargs.get("version") or (args[0] if args else None)
-        self.assertEqual(version, 6)
-        opt = kwargs.get("option_def") or (call_args.args[1] if len(call_args.args) > 1 else {})
-        self.assertEqual(opt.get("name"), "v6-opt")
-        self.assertEqual(opt.get("code"), 250)
-        self.assertEqual(opt.get("type"), "ipv6-address")
-        self.assertEqual(opt.get("space"), "dhcp6")
+    def test_post_calls_option_def_add_with_version_6(self):
+        """POST writes the new option-def into the DHCPv6 config."""
+        with _persist_stub(_option_def_config([], version=6)) as kea:
+            self.client.post(
+                self._url(),
+                {"name": "v6-opt", "code": 250, "type": "ipv6-address", "space": "dhcp6", "array": False},
+            )
+        written = _written_config(kea)
+        self.assertIn("Dhcp6", written)
+        added = next(d for d in written["Dhcp6"]["option-def"] if d.get("code") == 250)
+        self.assertEqual(added["name"], "v6-opt")
+        self.assertEqual(added["type"], "ipv6-address")
+        self.assertEqual(added["space"], "dhcp6")
 
 
 # ---------------------------------------------------------------------------
@@ -659,51 +603,42 @@ class TestServerOptionDef4DeleteView(_ViewTestBase):
     def _url(self, code=200, space="dhcp4"):
         return reverse("plugins:netbox_kea:server_option_def4_delete", args=[self.server.pk, code, space])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_returns_200_with_confirmation(self, MockKeaClient):
-        """GET renders a confirmation page mentioning code and space."""
-        response = self.client.get(self._url())
+    def test_get_returns_200_with_confirmation(self):
+        """GET renders a confirmation page mentioning code and space (no Kea call)."""
+        with stub_kea({}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "200")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_calls_option_def_del_and_redirects(self, MockKeaClient):
-        """POST calls option_def_del and redirects to option_def4 list."""
-        MockKeaClient.return_value.option_def_del.return_value = None
-        response = self.client.post(self._url())
+    def test_post_calls_option_def_del_and_redirects(self):
+        """POST removes the option-def and redirects to option_def4 list."""
+        with _persist_stub(_option_def_config(_OPTION_DEF_LIST_V4)) as kea:
+            response = self.client.post(self._url())
         self.assertEqual(response.status_code, 302)
         self._assert_no_none_pk_redirect(response)
-        MockKeaClient.return_value.option_def_del.assert_called_once()
+        self.assertIn("config-set", kea.commands())
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_passes_correct_version_code_space(self, MockKeaClient):
-        """POST calls option_def_del with version=4, code=200, space='dhcp4'."""
-        MockKeaClient.return_value.option_def_del.return_value = None
-        self.client.post(self._url(code=200, space="dhcp4"))
-        call_args = MockKeaClient.return_value.option_def_del.call_args
-        kwargs = call_args.kwargs or call_args[1]
-        args = call_args.args or call_args[0]
-        version = kwargs.get("version") or (args[0] if args else None)
-        code = kwargs.get("code") or (args[1] if len(args) > 1 else None)
-        space = kwargs.get("space") or (args[2] if len(args) > 2 else None)
-        self.assertEqual(version, 4)
-        self.assertEqual(code, 200)
-        self.assertEqual(space, "dhcp4")
+    def test_post_passes_correct_version_code_space(self):
+        """POST removes exactly the (code=200, space=dhcp4) entry from the DHCPv4 config."""
+        with _persist_stub(_option_def_config(_OPTION_DEF_LIST_V4)) as kea:
+            self.client.post(self._url(code=200, space="dhcp4"))
+        defs = _written_config(kea)["Dhcp4"]["option-def"]
+        codes = [d.get("code") for d in defs]
+        self.assertNotIn(200, codes)
+        self.assertIn(201, codes)  # the other def is untouched
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_kea_exception_redirects_with_error(self, MockKeaClient):
-        """POST that raises KeaException must not 500."""
-        from netbox_kea.kea import KeaException
+    def test_post_kea_exception_redirects_with_error(self):
+        """A KeaException from the mutation must not 500 (shows error, redirects).
 
-        MockKeaClient.return_value.option_def_del.side_effect = KeaException(
-            {"result": 3, "text": "not found"}, index=0
-        )
-        response = self.client.post(self._url())
+        A config-get result 1 makes the real ``option_def_del`` raise ``KeaException``.
+        """
+        with stub_kea({"config-get": {"result": 1, "text": "not found"}}) as kea:
+            response = self.client.post(self._url())
         self.assertIn(response.status_code, (200, 302))
         self._assert_no_none_pk_redirect(response)
         msgs = list(django_messages.get_messages(response.wsgi_request))
         self.assertTrue(any(m.level == django_messages.ERROR for m in msgs))
-        MockKeaClient.return_value.option_def_del.assert_called_once()
+        self.assertIn("config-get", kea.commands())
 
     def test_get_requires_login(self):
         """Unauthenticated GET redirects to login."""
@@ -725,22 +660,20 @@ class TestServerOptionDef6DeleteView(_ViewTestBase):
     def _url(self, code=250, space="dhcp6"):
         return reverse("plugins:netbox_kea:server_option_def6_delete", args=[self.server.pk, code, space])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_returns_200(self, MockKeaClient):
-        """GET renders the v6 confirmation page."""
-        response = self.client.get(self._url())
+    def test_get_returns_200(self):
+        """GET renders the v6 confirmation page (no Kea call)."""
+        with stub_kea({}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_calls_option_def_del_with_version_6(self, MockKeaClient):
-        """POST calls option_def_del with version=6."""
-        MockKeaClient.return_value.option_def_del.return_value = None
-        self.client.post(self._url(code=250, space="dhcp6"))
-        call_args = MockKeaClient.return_value.option_def_del.call_args
-        kwargs = call_args.kwargs or call_args[1]
-        args = call_args.args or call_args[0]
-        version = kwargs.get("version") or (args[0] if args else None)
-        self.assertEqual(version, 6)
+    def test_post_calls_option_def_del_with_version_6(self):
+        """POST removes the (code=250, space=dhcp6) entry from the DHCPv6 config."""
+        defs = [{"name": "v6-opt", "code": 250, "type": "ipv6-address", "space": "dhcp6"}]
+        with _persist_stub(_option_def_config(defs, version=6)) as kea:
+            self.client.post(self._url(code=250, space="dhcp6"))
+        written = _written_config(kea)
+        self.assertIn("Dhcp6", written)
+        self.assertNotIn(250, [d.get("code") for d in written["Dhcp6"]["option-def"]])
 
 
 # ---------------------------------------------------------------------------
@@ -755,54 +688,46 @@ class TestSubnetOptionsPostInvalid(_ViewTestBase):
     def _url(self, subnet_id=42):
         return reverse("plugins:netbox_kea:server_subnet4_options_edit", args=[self.server.pk, subnet_id])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_invalid_formset_rerenders(self, MockKeaClient):
-        """POST with an invalid formset (missing management form) must re-render 200."""
-        MockKeaClient.return_value.command.return_value = [
+    def test_post_invalid_formset_rerenders(self):
+        """POST with an invalid formset must re-render 200 without mutating."""
+        config = [
             {
                 "result": 0,
                 "arguments": {"Dhcp4": {"subnet4": [{"id": 42, "subnet": "10.0.0.0/24", "option-data": []}]}},
             }
         ]
-        # Post one form entry missing required 'name' field — makes formset invalid
-        response = self.client.post(
-            self._url(),
-            {
-                "form-TOTAL_FORMS": "1",
-                "form-INITIAL_FORMS": "0",
-                "form-MIN_NUM_FORMS": "0",
-                "form-MAX_NUM_FORMS": "1000",
-                "form-0-name": "",
-                "form-0-data": "some-value",
-            },
-        )
-        # Invalid formset can re-render OR redirect depending on validation path
+        with stub_kea({"config-get": config}) as kea:
+            response = self.client.post(
+                self._url(),
+                {
+                    "form-TOTAL_FORMS": "1",
+                    "form-INITIAL_FORMS": "0",
+                    "form-MIN_NUM_FORMS": "0",
+                    "form-MAX_NUM_FORMS": "1000",
+                    "form-0-name": "",
+                    "form-0-data": "some-value",
+                },
+            )
         self.assertEqual(response.status_code, 200)
-        MockKeaClient.return_value.subnet_update_options.assert_not_called()
+        self.assertNotIn("config-set", kea.commands())
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_with_always_send_includes_flag(self, MockKeaClient):
-        """POST with always_send=True must pass always-send=True in options."""
-        MockKeaClient.return_value.subnet_update_options.return_value = None
-        self.client.post(
-            self._url(),
-            {
-                "form-TOTAL_FORMS": "1",
-                "form-INITIAL_FORMS": "0",
-                "form-MIN_NUM_FORMS": "0",
-                "form-MAX_NUM_FORMS": "1000",
-                "form-0-name": "routers",
-                "form-0-data": "10.0.0.1",
-                "form-0-always_send": "on",
-            },
-        )
-        call_kwargs = MockKeaClient.return_value.subnet_update_options.call_args
-        self.assertIsNotNone(call_kwargs, "subnet_update_options was not called")
-        options = (call_kwargs.kwargs or {}).get("options") or (
-            call_kwargs.args[2] if len(call_kwargs.args) > 2 else []
-        )
-        always_send_opts = [o for o in options if o.get("always-send")]
-        self.assertGreaterEqual(len(always_send_opts), 1)
+    def test_post_with_always_send_includes_flag(self):
+        """POST with always_send=True writes always-send=True into the option-data."""
+        with _persist_stub(_OPTIONS_CONFIG_GET) as kea:
+            self.client.post(
+                self._url(),
+                {
+                    "form-TOTAL_FORMS": "1",
+                    "form-INITIAL_FORMS": "0",
+                    "form-MIN_NUM_FORMS": "0",
+                    "form-MAX_NUM_FORMS": "1000",
+                    "form-0-name": "routers",
+                    "form-0-data": "10.0.0.1",
+                    "form-0-always_send": "on",
+                },
+            )
+        opts = _written_config(kea)["Dhcp4"]["subnet4"][0]["option-data"]
+        self.assertGreaterEqual(len([o for o in opts if o.get("always-send")]), 1)
 
 
 # ---------------------------------------------------------------------------
@@ -817,45 +742,40 @@ class TestServerOptionsPostInvalid(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_dhcp4_options_edit", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_invalid_formset_rerenders(self, MockKeaClient):
+    def test_post_invalid_formset_rerenders(self):
         """POST with an invalid formset must re-render (not crash)."""
-        MockKeaClient.return_value.command.return_value = [{"result": 0, "arguments": {"Dhcp4": {"option-data": []}}}]
-        response = self.client.post(
-            self._url(),
-            {
-                "form-TOTAL_FORMS": "1",
-                "form-INITIAL_FORMS": "0",
-                "form-MIN_NUM_FORMS": "0",
-                "form-MAX_NUM_FORMS": "1000",
-                "form-0-name": "",
-                "form-0-data": "val",
-            },
-        )
+        with stub_kea({"config-get": [{"result": 0, "arguments": {"Dhcp4": {"option-data": []}}}]}) as kea:
+            response = self.client.post(
+                self._url(),
+                {
+                    "form-TOTAL_FORMS": "1",
+                    "form-INITIAL_FORMS": "0",
+                    "form-MIN_NUM_FORMS": "0",
+                    "form-MAX_NUM_FORMS": "1000",
+                    "form-0-name": "",
+                    "form-0-data": "val",
+                },
+            )
         self.assertEqual(response.status_code, 200)
-        MockKeaClient.return_value.server_update_options.assert_not_called()
+        self.assertNotIn("config-set", kea.commands())
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_with_always_send_includes_flag(self, MockKeaClient):
-        self.client.post(
-            self._url(),
-            {
-                "form-TOTAL_FORMS": "1",
-                "form-INITIAL_FORMS": "0",
-                "form-MIN_NUM_FORMS": "0",
-                "form-MAX_NUM_FORMS": "1000",
-                "form-0-name": "domain-name-servers",
-                "form-0-data": "8.8.8.8",
-                "form-0-always_send": "on",
-            },
-        )
-        call_kwargs = MockKeaClient.return_value.server_update_options.call_args
-        self.assertIsNotNone(call_kwargs, "server_update_options was not called")
-        options = (call_kwargs.kwargs or {}).get("options") or (
-            call_kwargs.args[1] if len(call_kwargs.args) > 1 else []
-        )
-        always_send_opts = [o for o in options if o.get("always-send")]
-        self.assertGreaterEqual(len(always_send_opts), 1)
+    def test_post_with_always_send_includes_flag(self):
+        """POST with always_send=True writes always-send=True into the server option-data."""
+        with _persist_stub(_SERVER_OPTIONS_CONFIG_GET) as kea:
+            self.client.post(
+                self._url(),
+                {
+                    "form-TOTAL_FORMS": "1",
+                    "form-INITIAL_FORMS": "0",
+                    "form-MIN_NUM_FORMS": "0",
+                    "form-MAX_NUM_FORMS": "1000",
+                    "form-0-name": "domain-name-servers",
+                    "form-0-data": "8.8.8.8",
+                    "form-0-always_send": "on",
+                },
+            )
+        opts = _written_config(kea)["Dhcp4"]["option-data"]
+        self.assertGreaterEqual(len([o for o in opts if o.get("always-send")]), 1)
 
 
 # ---------------------------------------------------------------------------
@@ -870,57 +790,46 @@ class TestOptionDefAddExceptions(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_option_def4_add", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_invalid_form_rerenders(self, MockKeaClient):
-        """POST with invalid form (missing required fields) must return 200."""
-        response = self.client.post(self._url(), {"name": "", "code": "", "type": "", "space": ""})
+    def test_post_invalid_form_rerenders(self):
+        """POST with invalid form (missing required fields) must return 200, no Kea call."""
+        with stub_kea({}) as kea:
+            response = self.client.post(self._url(), {"name": "", "code": "", "type": "", "space": ""})
         self.assertEqual(response.status_code, 200)
-        MockKeaClient.return_value.option_def_add.assert_not_called()
+        self.assertEqual(kea.commands(), [])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_with_array_true_passes_flag(self, MockKeaClient):
-        """POST with array=True must include array=True in the option_def dict."""
-        MockKeaClient.return_value.option_def_add.return_value = None
-        self.client.post(
-            self._url(),
-            {
-                "name": "my-option",
-                "code": "200",
-                "type": "string",
-                "space": "dhcp4",
-                "array": "on",
-            },
-        )
-        call_kwargs = MockKeaClient.return_value.option_def_add.call_args
-        self.assertIsNotNone(call_kwargs, "option_def_add was not called")
-        opt = (call_kwargs.kwargs or {}).get("option_def") or (call_kwargs.args[1] if len(call_kwargs.args) > 1 else {})
-        self.assertIs(opt.get("array"), True)
-        self.assertEqual(opt.get("name"), "my-option")
-        self.assertEqual(opt.get("code"), 200)
-        self.assertEqual(opt.get("type"), "string")
-        self.assertEqual(opt.get("space"), "dhcp4")
+    def test_post_with_array_true_passes_flag(self):
+        """POST with array=True writes array=True into the option-def."""
+        with _persist_stub(_option_def_config([])) as kea:
+            self.client.post(
+                self._url(),
+                {
+                    "name": "my-option",
+                    "code": "200",
+                    "type": "string",
+                    "space": "dhcp4",
+                    "array": "on",
+                },
+            )
+        added = next(d for d in _written_config(kea)["Dhcp4"]["option-def"] if d.get("code") == 200)
+        self.assertIs(added.get("array"), True)
+        self.assertEqual(added["name"], "my-option")
+        self.assertEqual(added["type"], "string")
+        self.assertEqual(added["space"], "dhcp4")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_kea_exception_shows_error_and_redirects(self, MockKeaClient):
-        """KeaException on option_def_add must show error message and redirect."""
-        from netbox_kea.kea import KeaException
-
-        MockKeaClient.return_value.option_def_add.side_effect = KeaException(
-            {"result": 1, "text": "duplicate code"}, index=0
-        )
-        response = self.client.post(
-            self._url(),
-            {"name": "my-opt", "code": "200", "type": "string", "space": "dhcp4"},
-            follow=True,
-        )
+    def test_post_kea_exception_shows_error_and_redirects(self):
+        """KeaException on the mutation must show error message and redirect."""
+        with stub_kea({"config-get": {"result": 1, "text": "duplicate code"}}):
+            response = self.client.post(
+                self._url(),
+                {"name": "my-opt", "code": "200", "type": "string", "space": "dhcp4"},
+                follow=True,
+            )
         msgs = list(response.context["messages"])
         self.assertTrue(any(m.level == django_messages.ERROR for m in msgs))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_generic_exception_propagates(self, MockKeaClient):
-        """Non-KeaException on option_def_add propagates (not swallowed)."""
-        MockKeaClient.return_value.option_def_add.side_effect = RuntimeError("crash")
-        with self.assertRaises(RuntimeError):
+    def test_post_generic_exception_propagates(self):
+        """A non-Kea error (RuntimeError) propagates (not swallowed by the mutation handler)."""
+        with stub_kea({"config-get": RuntimeError("crash")}), self.assertRaises(RuntimeError):
             self.client.post(
                 self._url(),
                 {"name": "my-opt", "code": "200", "type": "string", "space": "dhcp4"},
@@ -939,23 +848,16 @@ class TestOptionDefDeleteExceptions(_ViewTestBase):
     def _url(self, code=200, space="dhcp4"):
         return reverse("plugins:netbox_kea:server_option_def4_delete", args=[self.server.pk, code, space])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_kea_exception_shows_error_and_redirects(self, MockKeaClient):
-        """KeaException on option_def_del must show error message."""
-        from netbox_kea.kea import KeaException
-
-        MockKeaClient.return_value.option_def_del.side_effect = KeaException(
-            {"result": 1, "text": "not found"}, index=0
-        )
-        response = self.client.post(self._url(), follow=True)
+    def test_post_kea_exception_shows_error_and_redirects(self):
+        """KeaException on the mutation must show error message."""
+        with stub_kea({"config-get": {"result": 1, "text": "not found"}}):
+            response = self.client.post(self._url(), follow=True)
         msgs = list(response.context["messages"])
         self.assertTrue(any(m.level == django_messages.ERROR for m in msgs))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_generic_exception_propagates(self, MockKeaClient):
-        """Non-KeaException on option_def_del propagates (not swallowed)."""
-        MockKeaClient.return_value.option_def_del.side_effect = RuntimeError("crash")
-        with self.assertRaises(RuntimeError):
+    def test_post_generic_exception_propagates(self):
+        """A non-Kea error (RuntimeError) propagates (not swallowed)."""
+        with stub_kea({"config-get": RuntimeError("crash")}), self.assertRaises(RuntimeError):
             self.client.post(self._url())
 
 
@@ -966,55 +868,42 @@ class TestOptionDefDeleteExceptions(_ViewTestBase):
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestSubnetOptionsSharedNetwork(_ViewTestBase):
-    """Lines 4706-4708, 4761: subnet in shared-network + POST options handler."""
+    """Subnet found inside a shared-network + invalid-POST re-render."""
 
     def _url(self, subnet_id=99):
         return reverse("plugins:netbox_kea:server_subnet4_options_edit", args=[self.server.pk, subnet_id])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_subnet_in_shared_network(self, MockKeaClient):
-        """Lines 4706-4708: subnet found inside shared-network is returned."""
-        MockKeaClient.return_value.command.return_value = [
-            {
-                "result": 0,
-                "arguments": {
-                    "Dhcp4": {
-                        "subnet4": [],
-                        "shared-networks": [
-                            {
-                                "name": "prod",
-                                "subnet4": [{"id": 99, "subnet": "10.99.0.0/24", "option-data": []}],
-                            }
-                        ],
-                    }
-                },
-            }
-        ]
-        response = self.client.get(self._url())
+    _SHARED_NET_CONFIG = [
+        {
+            "result": 0,
+            "arguments": {
+                "Dhcp4": {
+                    "subnet4": [],
+                    "shared-networks": [
+                        {
+                            "name": "prod",
+                            "subnet4": [{"id": 99, "subnet": "10.99.0.0/24", "option-data": []}],
+                        }
+                    ],
+                }
+            },
+        }
+    ]
+
+    def test_get_subnet_in_shared_network(self):
+        """A subnet found inside a shared-network is located and rendered."""
+        with stub_kea({"config-get": self._SHARED_NET_CONFIG}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "10.99.0.0/24")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_invalid_formset_rerenders(self, MockKeaClient):
-        """Line 4761 (post handler): invalid formset re-renders form (subnet inside shared-networks)."""
-        MockKeaClient.return_value.command.return_value = [
-            {
-                "result": 0,
-                "arguments": {
-                    "Dhcp4": {
-                        "subnet4": [],
-                        "shared-networks": [
-                            {"name": "net1", "subnet4": [{"id": 99, "subnet": "10.99.0.0/24", "option-data": []}]}
-                        ],
-                    }
-                },
-            }
-        ]
-        # Submit invalid formset (missing TOTAL_FORMS)
-        response = self.client.post(self._url(), {"form-0-name": "dns-servers"})
+    def test_post_invalid_formset_rerenders(self):
+        """Invalid formset re-renders the form (subnet inside shared-networks), no mutation."""
+        with stub_kea({"config-get": self._SHARED_NET_CONFIG}) as kea:
+            response = self.client.post(self._url(), {"form-0-name": "dns-servers"})
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "10.99.0.0/24")
-        MockKeaClient.return_value.subnet_update_options.assert_not_called()
+        self.assertNotIn("config-set", kea.commands())
 
 
 # ---------------------------------------------------------------------------
@@ -1024,84 +913,107 @@ class TestSubnetOptionsSharedNetwork(_ViewTestBase):
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestKeaConfigTestErrorHandling(_ViewTestBase):
-    """KeaConfigTestError in mutation handlers must produce a user-facing error message."""
+    """A config-test failure (KeaConfigTestError) must produce a user-facing error message.
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_subnet_options_config_test_error_shows_message(self, MockKeaClient):
-        """POST to subnet options edit must show config-test error message on KeaConfigTestError."""
-        from netbox_kea.kea import KeaConfigTestError, KeaException
+    Driven by registering ``config-test`` → result 1, so the real ``_apply_config``
+    raises ``KeaConfigTestError`` before ``config-set``.
+    """
 
-        cause = KeaException({"result": 1, "text": "config test failed"})
-        MockKeaClient.return_value.subnet_update_options.side_effect = KeaConfigTestError("dhcp4", cause)
-        url = reverse("plugins:netbox_kea:server_subnet4_options_edit", args=[self.server.pk, 1])
-        response = self.client.post(url, {"form-TOTAL_FORMS": "0", "form-INITIAL_FORMS": "0"}, follow=True)
+    _CONFIG_TEST_FAILS = {"config-test": {"result": 1, "text": "config test failed"}}
+
+    def _assert_config_error(self, response):
         self.assertEqual(response.status_code, 200)
         msgs = [str(m) for m in response.context["messages"]]
         self.assertTrue(any("config" in m.lower() and "no changes" in m.lower() for m in msgs))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_server_options_config_test_error_shows_message(self, MockKeaClient):
-        """POST to server options edit must show config-test error message on KeaConfigTestError."""
-        from netbox_kea.kea import KeaConfigTestError, KeaException
+    def test_subnet_options_config_test_error_shows_message(self):
+        """POST to subnet options edit shows the config-test error message."""
+        url = reverse("plugins:netbox_kea:server_subnet4_options_edit", args=[self.server.pk, 42])
+        with _persist_stub(_OPTIONS_CONFIG_GET, **self._CONFIG_TEST_FAILS):
+            response = self.client.post(
+                url,
+                {
+                    "form-TOTAL_FORMS": "1",
+                    "form-INITIAL_FORMS": "0",
+                    "form-MIN_NUM_FORMS": "0",
+                    "form-MAX_NUM_FORMS": "1000",
+                    "form-0-name": "routers",
+                    "form-0-data": "10.0.0.1",
+                    "form-0-always_send": "",
+                    "form-0-DELETE": "",
+                },
+                follow=True,
+            )
+        self._assert_config_error(response)
 
-        cause = KeaException({"result": 1, "text": "config test failed"})
-        MockKeaClient.return_value.server_update_options.side_effect = KeaConfigTestError("dhcp4", cause)
+    def test_server_options_config_test_error_shows_message(self):
+        """POST to server options edit shows the config-test error message."""
         url = reverse("plugins:netbox_kea:server_dhcp4_options_edit", args=[self.server.pk])
-        response = self.client.post(url, {"form-TOTAL_FORMS": "0", "form-INITIAL_FORMS": "0"}, follow=True)
-        self.assertEqual(response.status_code, 200)
-        msgs = [str(m) for m in response.context["messages"]]
-        self.assertTrue(any("config" in m.lower() and "no changes" in m.lower() for m in msgs))
+        with _persist_stub(_SERVER_OPTIONS_CONFIG_GET, **self._CONFIG_TEST_FAILS):
+            response = self.client.post(
+                url,
+                {
+                    "form-TOTAL_FORMS": "1",
+                    "form-INITIAL_FORMS": "0",
+                    "form-MIN_NUM_FORMS": "0",
+                    "form-MAX_NUM_FORMS": "1000",
+                    "form-0-name": "routers",
+                    "form-0-data": "10.0.0.1",
+                    "form-0-always_send": "",
+                    "form-0-DELETE": "",
+                },
+                follow=True,
+            )
+        self._assert_config_error(response)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_option_def_add_config_test_error_shows_message(self, MockKeaClient):
-        """POST to option-def add must show config-test error message on KeaConfigTestError."""
-        from netbox_kea.kea import KeaConfigTestError, KeaException
-
-        cause = KeaException({"result": 1, "text": "config test failed"})
-        MockKeaClient.return_value.option_def_add.side_effect = KeaConfigTestError("dhcp4", cause)
+    def test_option_def_add_config_test_error_shows_message(self):
+        """POST to option-def add shows the config-test error message."""
         url = reverse("plugins:netbox_kea:server_option_def4_add", args=[self.server.pk])
-        response = self.client.post(
-            url,
-            {"name": "my-opt", "code": "200", "type": "string", "space": "dhcp4"},
-            follow=True,
-        )
-        self.assertEqual(response.status_code, 200)
-        msgs = [str(m) for m in response.context["messages"]]
-        self.assertTrue(any("config" in m.lower() and "no changes" in m.lower() for m in msgs))
+        with _persist_stub(_option_def_config([]), **self._CONFIG_TEST_FAILS):
+            response = self.client.post(
+                url,
+                {"name": "my-opt", "code": "200", "type": "string", "space": "dhcp4"},
+                follow=True,
+            )
+        self._assert_config_error(response)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_option_def_del_config_test_error_shows_message(self, MockKeaClient):
-        """POST to option-def delete must show config-test error message on KeaConfigTestError."""
-        from netbox_kea.kea import KeaConfigTestError, KeaException
-
-        cause = KeaException({"result": 1, "text": "config test failed"})
-        MockKeaClient.return_value.option_def_del.side_effect = KeaConfigTestError("dhcp4", cause)
+    def test_option_def_del_config_test_error_shows_message(self):
+        """POST to option-def delete shows the config-test error message."""
         url = reverse("plugins:netbox_kea:server_option_def4_delete", args=[self.server.pk, 200, "dhcp4"])
-        response = self.client.post(url, follow=True)
-        self.assertEqual(response.status_code, 200)
-        msgs = [str(m) for m in response.context["messages"]]
-        self.assertTrue(any("config" in m.lower() and "no changes" in m.lower() for m in msgs))
+        with _persist_stub(_option_def_config(_OPTION_DEF_LIST_V4), **self._CONFIG_TEST_FAILS):
+            response = self.client.post(url, follow=True)
+        self._assert_config_error(response)
 
 
 # ---------------------------------------------------------------------------
 # Subnet options POST: PartialPersistError, TransportError, ValueError
 # ---------------------------------------------------------------------------
 
+_SENTINEL_URL = "https://kea-internal.example.invalid:8443"
+
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestSubnetOptionsPartialPersistError(_ViewTestBase):
-    """POST to subnet options edit raises PartialPersistError → warning message."""
+    """POST to subnet options edit: config-write fails → PartialPersistError → warning."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_partial_persist_error_shows_warning(self, MockKeaClient):
-        """PartialPersistError on subnet_update_options must show a warning about config-write."""
-        from netbox_kea.kea import PartialPersistError
-
-        MockKeaClient.return_value.subnet_update_options.side_effect = PartialPersistError(
-            "dhcp4", Exception("write failed"), subnet_id=1
-        )
-        url = reverse("plugins:netbox_kea:server_subnet4_options_edit", args=[self.server.pk, 1])
-        response = self.client.post(url, {"form-TOTAL_FORMS": "0", "form-INITIAL_FORMS": "0"}, follow=True)
+    def test_partial_persist_error_shows_warning(self):
+        """A config-write failure on a persisting op surfaces a warning (change unpersisted)."""
+        url = reverse("plugins:netbox_kea:server_subnet4_options_edit", args=[self.server.pk, 42])
+        with _persist_stub(_OPTIONS_CONFIG_GET, **{"config-write": {"result": 1, "text": "write failed"}}):
+            response = self.client.post(
+                url,
+                {
+                    "form-TOTAL_FORMS": "1",
+                    "form-INITIAL_FORMS": "0",
+                    "form-MIN_NUM_FORMS": "0",
+                    "form-MAX_NUM_FORMS": "1000",
+                    "form-0-name": "routers",
+                    "form-0-data": "10.0.0.1",
+                    "form-0-always_send": "",
+                    "form-0-DELETE": "",
+                },
+                follow=True,
+            )
         self.assertEqual(response.status_code, 200)
         msgs = list(response.context["messages"])
         self.assertTrue(any(m.level == django_messages.WARNING for m in msgs))
@@ -1109,35 +1021,28 @@ class TestSubnetOptionsPartialPersistError(_ViewTestBase):
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestSubnetOptionsTransportError(_ViewTestBase):
-    """POST to subnet options edit raises ConnectionError → transport error message."""
+    """POST to subnet options edit: config-get raises ConnectionError → transport error message."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_connection_error_shows_transport_message(self, MockKeaClient):
-        """requests.ConnectionError on subnet_update_options must show 'Transport error' message."""
-        import requests
-
-        sentinel_url = "https://kea-internal.example.invalid:8443"
-        MockKeaClient.return_value.subnet_update_options.side_effect = requests.ConnectionError(
-            f"{sentinel_url} refused connection"
-        )
-        url = reverse("plugins:netbox_kea:server_subnet4_options_edit", args=[self.server.pk, 1])
-        response = self.client.post(url, {"form-TOTAL_FORMS": "0", "form-INITIAL_FORMS": "0"}, follow=True)
+    def test_connection_error_shows_transport_message(self):
+        """A transport error surfaces a generic message and never leaks the internal URL."""
+        url = reverse("plugins:netbox_kea:server_subnet4_options_edit", args=[self.server.pk, 42])
+        with stub_kea({"config-get": requests.ConnectionError(f"{_SENTINEL_URL} refused connection")}):
+            response = self.client.post(url, {"form-TOTAL_FORMS": "0", "form-INITIAL_FORMS": "0"}, follow=True)
         self.assertEqual(response.status_code, 200)
         msgs = [str(m) for m in response.context["messages"]]
         self.assertTrue(any("transport error" in m.lower() for m in msgs))
-        self.assertFalse(any(sentinel_url.lower() in m.lower() for m in msgs))
+        self.assertFalse(any(_SENTINEL_URL.lower() in m.lower() for m in msgs))
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestSubnetOptionsValueError(_ViewTestBase):
-    """POST to subnet options edit raises ValueError → invalid config message."""
+    """POST to subnet options edit: config-get raises ValueError → invalid config message."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_value_error_shows_invalid_config_message(self, MockKeaClient):
-        """ValueError on subnet_update_options must show 'Invalid Kea client configuration' message."""
-        MockKeaClient.return_value.subnet_update_options.side_effect = ValueError("bad config")
-        url = reverse("plugins:netbox_kea:server_subnet4_options_edit", args=[self.server.pk, 1])
-        response = self.client.post(url, {"form-TOTAL_FORMS": "0", "form-INITIAL_FORMS": "0"}, follow=True)
+    def test_value_error_shows_invalid_config_message(self):
+        """A ValueError surfaces a generic message and never leaks its detail."""
+        url = reverse("plugins:netbox_kea:server_subnet4_options_edit", args=[self.server.pk, 42])
+        with stub_kea({"config-get": ValueError("bad config")}):
+            response = self.client.post(url, {"form-TOTAL_FORMS": "0", "form-INITIAL_FORMS": "0"}, follow=True)
         self.assertEqual(response.status_code, 200)
         msgs = [str(m) for m in response.context["messages"]]
         self.assertTrue(any("invalid kea client configuration" in m.lower() for m in msgs))
@@ -1151,18 +1056,25 @@ class TestSubnetOptionsValueError(_ViewTestBase):
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestServerOptionsPartialPersistError(_ViewTestBase):
-    """POST to server options edit raises PartialPersistError → warning message."""
+    """POST to server options edit: config-write fails → PartialPersistError → warning."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_partial_persist_error_shows_warning(self, MockKeaClient):
-        """PartialPersistError on server_update_options must show a warning about config-write."""
-        from netbox_kea.kea import PartialPersistError
-
-        MockKeaClient.return_value.server_update_options.side_effect = PartialPersistError(
-            "dhcp4", Exception("write failed"), subnet_id=None
-        )
+    def test_partial_persist_error_shows_warning(self):
         url = reverse("plugins:netbox_kea:server_dhcp4_options_edit", args=[self.server.pk])
-        response = self.client.post(url, {"form-TOTAL_FORMS": "0", "form-INITIAL_FORMS": "0"}, follow=True)
+        with _persist_stub(_SERVER_OPTIONS_CONFIG_GET, **{"config-write": {"result": 1, "text": "write failed"}}):
+            response = self.client.post(
+                url,
+                {
+                    "form-TOTAL_FORMS": "1",
+                    "form-INITIAL_FORMS": "0",
+                    "form-MIN_NUM_FORMS": "0",
+                    "form-MAX_NUM_FORMS": "1000",
+                    "form-0-name": "routers",
+                    "form-0-data": "10.0.0.1",
+                    "form-0-always_send": "",
+                    "form-0-DELETE": "",
+                },
+                follow=True,
+            )
         self.assertEqual(response.status_code, 200)
         msgs = list(response.context["messages"])
         self.assertTrue(any(m.level == django_messages.WARNING for m in msgs))
@@ -1170,35 +1082,26 @@ class TestServerOptionsPartialPersistError(_ViewTestBase):
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestServerOptionsTransportError(_ViewTestBase):
-    """POST to server options edit raises ConnectionError → transport error message."""
+    """POST to server options edit: config-get raises ConnectionError → transport error message."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_connection_error_shows_transport_message(self, MockKeaClient):
-        """requests.ConnectionError on server_update_options must show 'Transport error' message."""
-        import requests
-
-        sentinel_url = "https://kea-internal.example.invalid:8443"
-        MockKeaClient.return_value.server_update_options.side_effect = requests.ConnectionError(
-            f"{sentinel_url} refused connection"
-        )
+    def test_connection_error_shows_transport_message(self):
         url = reverse("plugins:netbox_kea:server_dhcp4_options_edit", args=[self.server.pk])
-        response = self.client.post(url, {"form-TOTAL_FORMS": "0", "form-INITIAL_FORMS": "0"}, follow=True)
+        with stub_kea({"config-get": requests.ConnectionError(f"{_SENTINEL_URL} refused connection")}):
+            response = self.client.post(url, {"form-TOTAL_FORMS": "0", "form-INITIAL_FORMS": "0"}, follow=True)
         self.assertEqual(response.status_code, 200)
         msgs = [str(m) for m in response.context["messages"]]
         self.assertTrue(any("transport error" in m.lower() for m in msgs))
-        self.assertFalse(any(sentinel_url.lower() in m.lower() for m in msgs))
+        self.assertFalse(any(_SENTINEL_URL.lower() in m.lower() for m in msgs))
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestServerOptionsValueError(_ViewTestBase):
-    """POST to server options edit raises ValueError → invalid config message."""
+    """POST to server options edit: config-get raises ValueError → invalid config message."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_value_error_shows_invalid_config_message(self, MockKeaClient):
-        """ValueError on server_update_options must show 'Invalid Kea client configuration' message."""
-        MockKeaClient.return_value.server_update_options.side_effect = ValueError("bad config")
+    def test_value_error_shows_invalid_config_message(self):
         url = reverse("plugins:netbox_kea:server_dhcp4_options_edit", args=[self.server.pk])
-        response = self.client.post(url, {"form-TOTAL_FORMS": "0", "form-INITIAL_FORMS": "0"}, follow=True)
+        with stub_kea({"config-get": ValueError("bad config")}):
+            response = self.client.post(url, {"form-TOTAL_FORMS": "0", "form-INITIAL_FORMS": "0"}, follow=True)
         self.assertEqual(response.status_code, 200)
         msgs = [str(m) for m in response.context["messages"]]
         self.assertTrue(any("invalid kea client configuration" in m.lower() for m in msgs))
@@ -1209,25 +1112,17 @@ class TestServerOptionsValueError(_ViewTestBase):
 # Option-def add POST: PartialPersistError, TransportError, ValueError
 # ---------------------------------------------------------------------------
 
+_OPTION_DEF_ADD_POST = {"name": "my-opt", "code": "200", "type": "string", "space": "dhcp4"}
+
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestOptionDefAddPartialPersistError(_ViewTestBase):
-    """POST to option-def add raises PartialPersistError → warning message."""
+    """POST to option-def add: config-write fails → PartialPersistError → warning."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_partial_persist_error_shows_warning(self, MockKeaClient):
-        """PartialPersistError on option_def_add must show a warning about config-write."""
-        from netbox_kea.kea import PartialPersistError
-
-        MockKeaClient.return_value.option_def_add.side_effect = PartialPersistError(
-            "dhcp4", Exception("write failed"), subnet_id=None
-        )
+    def test_partial_persist_error_shows_warning(self):
         url = reverse("plugins:netbox_kea:server_option_def4_add", args=[self.server.pk])
-        response = self.client.post(
-            url,
-            {"name": "my-opt", "code": "200", "type": "string", "space": "dhcp4"},
-            follow=True,
-        )
+        with _persist_stub(_option_def_config([]), **{"config-write": {"result": 1, "text": "write failed"}}):
+            response = self.client.post(url, _OPTION_DEF_ADD_POST, follow=True)
         self.assertEqual(response.status_code, 200)
         msgs = list(response.context["messages"])
         self.assertTrue(any(m.level == django_messages.WARNING for m in msgs))
@@ -1235,43 +1130,26 @@ class TestOptionDefAddPartialPersistError(_ViewTestBase):
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestOptionDefAddTransportError(_ViewTestBase):
-    """POST to option-def add raises ConnectionError → transport error message."""
+    """POST to option-def add: config-get raises ConnectionError → transport error message."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_connection_error_shows_transport_message(self, MockKeaClient):
-        """requests.ConnectionError on option_def_add must show 'Transport error' message."""
-        import requests
-
-        sentinel_url = "https://kea-internal.example.invalid:8443"
-        MockKeaClient.return_value.option_def_add.side_effect = requests.ConnectionError(
-            f"{sentinel_url} refused connection"
-        )
+    def test_connection_error_shows_transport_message(self):
         url = reverse("plugins:netbox_kea:server_option_def4_add", args=[self.server.pk])
-        response = self.client.post(
-            url,
-            {"name": "my-opt", "code": "200", "type": "string", "space": "dhcp4"},
-            follow=True,
-        )
+        with stub_kea({"config-get": requests.ConnectionError(f"{_SENTINEL_URL} refused connection")}):
+            response = self.client.post(url, _OPTION_DEF_ADD_POST, follow=True)
         self.assertEqual(response.status_code, 200)
         msgs = [str(m) for m in response.context["messages"]]
         self.assertTrue(any("transport error" in m.lower() for m in msgs))
-        self.assertFalse(any(sentinel_url.lower() in m.lower() for m in msgs))
+        self.assertFalse(any(_SENTINEL_URL.lower() in m.lower() for m in msgs))
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestOptionDefAddValueError(_ViewTestBase):
-    """POST to option-def add raises ValueError → invalid config message."""
+    """POST to option-def add: config-get raises ValueError → invalid config message."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_value_error_shows_invalid_config_message(self, MockKeaClient):
-        """ValueError on option_def_add must show 'Invalid Kea client configuration' message."""
-        MockKeaClient.return_value.option_def_add.side_effect = ValueError("bad config")
+    def test_value_error_shows_invalid_config_message(self):
         url = reverse("plugins:netbox_kea:server_option_def4_add", args=[self.server.pk])
-        response = self.client.post(
-            url,
-            {"name": "my-opt", "code": "200", "type": "string", "space": "dhcp4"},
-            follow=True,
-        )
+        with stub_kea({"config-get": ValueError("bad config")}):
+            response = self.client.post(url, _OPTION_DEF_ADD_POST, follow=True)
         self.assertEqual(response.status_code, 200)
         msgs = [str(m) for m in response.context["messages"]]
         self.assertTrue(any("invalid kea client configuration" in m.lower() for m in msgs))
@@ -1285,18 +1163,14 @@ class TestOptionDefAddValueError(_ViewTestBase):
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestOptionDefDeletePartialPersistError(_ViewTestBase):
-    """POST to option-def delete raises PartialPersistError → warning message."""
+    """POST to option-def delete: config-write fails → PartialPersistError → warning."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_partial_persist_error_shows_warning(self, MockKeaClient):
-        """PartialPersistError on option_def_del must show a warning about config-write."""
-        from netbox_kea.kea import PartialPersistError
-
-        MockKeaClient.return_value.option_def_del.side_effect = PartialPersistError(
-            "dhcp4", Exception("write failed"), subnet_id=None
-        )
+    def test_partial_persist_error_shows_warning(self):
         url = reverse("plugins:netbox_kea:server_option_def4_delete", args=[self.server.pk, 200, "dhcp4"])
-        response = self.client.post(url, follow=True)
+        with _persist_stub(
+            _option_def_config(_OPTION_DEF_LIST_V4), **{"config-write": {"result": 1, "text": "write failed"}}
+        ):
+            response = self.client.post(url, follow=True)
         self.assertEqual(response.status_code, 200)
         msgs = list(response.context["messages"])
         self.assertTrue(any(m.level == django_messages.WARNING for m in msgs))
@@ -1304,35 +1178,26 @@ class TestOptionDefDeletePartialPersistError(_ViewTestBase):
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestOptionDefDeleteTransportError(_ViewTestBase):
-    """POST to option-def delete raises ConnectionError → transport error message."""
+    """POST to option-def delete: config-get raises ConnectionError → transport error message."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_connection_error_shows_transport_message(self, MockKeaClient):
-        """requests.ConnectionError on option_def_del must show 'Transport error' message."""
-        import requests
-
-        sentinel_url = "https://kea-internal.example.invalid:8443"
-        MockKeaClient.return_value.option_def_del.side_effect = requests.ConnectionError(
-            f"{sentinel_url} refused connection"
-        )
+    def test_connection_error_shows_transport_message(self):
         url = reverse("plugins:netbox_kea:server_option_def4_delete", args=[self.server.pk, 200, "dhcp4"])
-        response = self.client.post(url, follow=True)
+        with stub_kea({"config-get": requests.ConnectionError(f"{_SENTINEL_URL} refused connection")}):
+            response = self.client.post(url, follow=True)
         self.assertEqual(response.status_code, 200)
         msgs = [str(m) for m in response.context["messages"]]
         self.assertTrue(any("transport error" in m.lower() for m in msgs))
-        self.assertFalse(any(sentinel_url.lower() in m.lower() for m in msgs))
+        self.assertFalse(any(_SENTINEL_URL.lower() in m.lower() for m in msgs))
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestOptionDefDeleteValueError(_ViewTestBase):
-    """POST to option-def delete raises ValueError → invalid config message."""
+    """POST to option-def delete: config-get raises ValueError → invalid config message."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_value_error_shows_invalid_config_message(self, MockKeaClient):
-        """ValueError on option_def_del must show 'Invalid Kea client configuration' message."""
-        MockKeaClient.return_value.option_def_del.side_effect = ValueError("bad config")
+    def test_value_error_shows_invalid_config_message(self):
         url = reverse("plugins:netbox_kea:server_option_def4_delete", args=[self.server.pk, 200, "dhcp4"])
-        response = self.client.post(url, follow=True)
+        with stub_kea({"config-get": ValueError("bad config")}):
+            response = self.client.post(url, follow=True)
         self.assertEqual(response.status_code, 200)
         msgs = [str(m) for m in response.context["messages"]]
         self.assertTrue(any("invalid kea client configuration" in m.lower() for m in msgs))
@@ -1348,32 +1213,30 @@ class TestOptionDefDeleteValueError(_ViewTestBase):
 class TestSubnetOptionsGetClientError(_ViewTestBase):
     """GET to subnet options edit when get_client raises ValueError → redirect with error."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_client_value_error_redirects(self, MockKeaClient):
-        """ValueError from get_client on GET must redirect with error message."""
-        MockKeaClient.side_effect = ValueError("bad TLS config")
-        url = reverse("plugins:netbox_kea:server_subnet4_options_edit", args=[self.server.pk, 1])
-        response = self.client.get(url, follow=True)
+    def test_get_client_value_error_redirects(self):
+        """A get_client ValueError (cert-without-key) redirects with a generic message."""
+        bad = _make_db_server(name="badtls-subnet", client_cert_path="/nonexistent/cert.pem")
+        url = reverse("plugins:netbox_kea:server_subnet4_options_edit", args=[bad.pk, 1])
+        with stub_kea({}):
+            response = self.client.get(url, follow=True)
         self.assertEqual(response.status_code, 200)
         msgs = [str(m) for m in response.context["messages"]]
         self.assertTrue(any("internal error" in m.lower() for m in msgs))
-        self.assertFalse(any("bad tls config" in m.lower() for m in msgs))
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestServerOptionsGetClientError(_ViewTestBase):
     """GET to server options edit when get_client raises ValueError → redirect with error."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_client_value_error_redirects(self, MockKeaClient):
-        """ValueError from get_client on GET must redirect with error message."""
-        MockKeaClient.side_effect = ValueError("bad TLS config")
-        url = reverse("plugins:netbox_kea:server_dhcp4_options_edit", args=[self.server.pk])
-        response = self.client.get(url, follow=True)
+    def test_get_client_value_error_redirects(self):
+        """A get_client ValueError (cert-without-key) redirects with a generic message."""
+        bad = _make_db_server(name="badtls-server", client_cert_path="/nonexistent/cert.pem")
+        url = reverse("plugins:netbox_kea:server_dhcp4_options_edit", args=[bad.pk])
+        with stub_kea({}):
+            response = self.client.get(url, follow=True)
         self.assertEqual(response.status_code, 200)
         msgs = [str(m) for m in response.context["messages"]]
         self.assertTrue(any("internal error" in m.lower() for m in msgs))
-        self.assertFalse(any("bad tls config" in m.lower() for m in msgs))
 
 
 # ---------------------------------------------------------------------------
@@ -1383,16 +1246,13 @@ class TestServerOptionsGetClientError(_ViewTestBase):
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestOptionDefListFetchError(_ViewTestBase):
-    """GET to option-def list when option_def_list raises KeaException → 200 with empty list."""
+    """GET to option-def list when config-get fails → 200 with options_load_error=True."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_kea_exception_returns_200_with_error_flag(self, MockKeaClient):
-        """KeaException on option_def_list must return 200 with options_load_error=True."""
-        from netbox_kea.kea import KeaException
-
-        MockKeaClient.return_value.option_def_list.side_effect = KeaException({"result": 1, "text": "error"}, index=0)
+    def test_kea_exception_returns_200_with_error_flag(self):
+        """A KeaException while fetching the option-def list yields 200 + options_load_error."""
         url = reverse("plugins:netbox_kea:server_option_def4", args=[self.server.pk])
-        response = self.client.get(url)
+        with stub_kea({"config-get": {"result": 1, "text": "error"}}):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.context.get("options_load_error"))
 
@@ -1404,16 +1264,12 @@ class TestOptionDefListFetchError(_ViewTestBase):
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestCombinedStatusBadgeError(_ViewTestBase):
-    """GET to status badge when version-get raises → offline status."""
+    """GET to status badge when version-get fails → offline status."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_kea_exception_returns_200_with_offline(self, MockKeaClient):
-        """KeaException on version-get must return 200 with offline status badges."""
-        from netbox_kea.kea import KeaException
-
-        MockKeaClient.return_value.command.side_effect = KeaException({"result": 1, "text": "error"}, index=0)
+    def test_kea_exception_returns_200_with_offline(self):
+        """A KeaException on version-get yields 200 with offline status badges."""
         url = reverse("plugins:netbox_kea:combined_server_status_badge", args=[self.server.pk])
-        response = self.client.get(url)
+        with stub_kea({"version-get": {"result": 1, "text": "error"}}):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        content = response.content.decode()
-        self.assertIn("offline", content.lower())
+        self.assertIn("offline", response.content.decode().lower())

--- a/netbox_kea/tests/test_views_reservations.py
+++ b/netbox_kea/tests/test_views_reservations.py
@@ -47,7 +47,7 @@ from ipam.models import IPAddress as NbIP
 from netbox_kea.kea import KeaClient
 from netbox_kea.views import _get_reservation_identifier as _extract_identifier
 
-from .kea_stub import stub_kea
+from .kea_stub import _res_get, _res_page, _subnet_get, stub_kea
 from .utils import _PLUGINS_CONFIG, _make_db_server, _ViewTestBase
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -65,32 +65,6 @@ from .utils import _PLUGINS_CONFIG, _make_db_server, _ViewTestBase
 #
 # A POST followed with ``follow=True`` lands on the reservations list, which then
 # issues ``reservation-get-page`` again — so those stubs also register it.
-
-
-def _res_page(hosts, *, next_from=0, next_source=0):
-    """A ``reservation-get-page`` result: *hosts* plus Kea's pagination cursor.
-
-    ``next_from``/``next_source`` both 0 marks the source exhausted, so
-    ``iter_reservations`` stops after this page.
-    """
-    return {"result": 0, "arguments": {"hosts": hosts, "next": {"from": next_from, "source-index": next_source}}}
-
-
-def _res_get(reservation):
-    """A ``reservation-get`` result: the host fields Kea returns directly inside ``arguments``."""
-    return {"result": 0, "arguments": dict(reservation)}
-
-
-def _subnet_get(version, pools=None, subnet_id=1):
-    """A ``subnet{v}-get`` result for the reservation-add pool-overlap probe.
-
-    *pools* is a list of pool range strings; the probe warns only when the
-    reservation IP falls inside one of them.
-    """
-    return {
-        "result": 0,
-        "arguments": {f"subnet{version}": [{"id": subnet_id, "pools": [{"pool": p} for p in (pools or [])]}]},
-    }
 
 
 #: ``reservation-get-page`` with no hosts (source exhausted → empty reservation list).

--- a/netbox_kea/tests/test_views_reservations.py
+++ b/netbox_kea/tests/test_views_reservations.py
@@ -7,7 +7,9 @@ Also contains pure-Python unit tests for helper functions defined in views.py
 because they are tightly coupled to view logic.
 
 These tests verify correct HTTP responses and redirect behaviour for every view.
-All Kea HTTP calls are mocked so no running Kea instance is required.
+They drive a **real** ``KeaClient``; only the HTTP boundary is stubbed via
+``kea_stub.stub_kea``, so the request payloads the views actually send to Kea are
+exercised (and can be asserted on) instead of asserting against a ``MagicMock``.
 
 Test organisation strategy
 --------------------------
@@ -20,10 +22,21 @@ View tests use ``django.test.TestCase`` because they write to the test database
 (user + server fixtures).  Server objects are created via ``Server.objects.create()``
 which does **not** call ``Model.clean()`` and therefore does not trigger live Kea
 connectivity checks.
+
+NOTE — reservation writes never persist
+---------------------------------------
+``KeaClient.reservation_add`` / ``reservation_update`` / ``reservation_del`` each
+issue a *single* Kea command and never ``config-write`` (host_cmds writes to a host
+backend, not the config file).  The ``except PartialPersistError`` branch that
+follows each of those calls in the view is therefore unreachable through the real
+client — it only ever fired when a ``MagicMock`` injected the exception into a
+method that cannot raise it.  Those mock-only tests are omitted here; the
+persisting-write guarantee is covered by the pool/subnet PartialPersist cases in
+``test_reservation_views.py`` (real ``config-write`` result 1).
 """
 
 import unittest as _unittest  # alias to avoid pytest collection confusion
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import requests as req
 from django.contrib import messages as django_messages
@@ -34,7 +47,65 @@ from ipam.models import IPAddress as NbIP
 from netbox_kea.kea import KeaClient
 from netbox_kea.views import _get_reservation_identifier as _extract_identifier
 
+from .kea_stub import stub_kea
 from .utils import _PLUGINS_CONFIG, _make_db_server, _ViewTestBase
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Shared stub responses (real KeaClient + HTTP-boundary stub)
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Command chains issued by the reservation views:
+#   list GET:  ``reservation-get-page`` (drained via ``iter_reservations``) then, if
+#              any reservations are found, ``lease{v}-get-all`` per unique subnet
+#              (lease-status enrichment; NetBox IPAM badges hit the DB, not Kea).
+#   add POST:  ``subnet{v}-get`` (pool-overlap probe, non-fatal) + ``reservation-add``.
+#   edit GET:  ``reservation-get`` (prefill) + ``lease{v}-get`` (hostname diff).
+#   edit POST: ``reservation-get`` (reload existing) + ``reservation-update``.
+#   delete POST: ``reservation-del``.
+#
+# A POST followed with ``follow=True`` lands on the reservations list, which then
+# issues ``reservation-get-page`` again — so those stubs also register it.
+
+
+def _res_page(hosts, *, next_from=0, next_source=0):
+    """A ``reservation-get-page`` result: *hosts* plus Kea's pagination cursor.
+
+    ``next_from``/``next_source`` both 0 marks the source exhausted, so
+    ``iter_reservations`` stops after this page.
+    """
+    return {"result": 0, "arguments": {"hosts": hosts, "next": {"from": next_from, "source-index": next_source}}}
+
+
+def _res_get(reservation):
+    """A ``reservation-get`` result: the host fields Kea returns directly inside ``arguments``."""
+    return {"result": 0, "arguments": dict(reservation)}
+
+
+def _subnet_get(version, pools=None, subnet_id=1):
+    """A ``subnet{v}-get`` result for the reservation-add pool-overlap probe.
+
+    *pools* is a list of pool range strings; the probe warns only when the
+    reservation IP falls inside one of them.
+    """
+    return {
+        "result": 0,
+        "arguments": {f"subnet{version}": [{"id": subnet_id, "pools": [{"pool": p} for p in (pools or [])]}]},
+    }
+
+
+#: ``reservation-get-page`` with no hosts (source exhausted → empty reservation list).
+_RES_EMPTY_PAGE = {"result": 3}
+#: ``reservation-get`` / ``lease{v}-get`` with result 3 = no such record.
+_RES_NOT_FOUND = {"result": 3}
+_LEASE_NOT_FOUND = {"result": 3}
+
+#: Existing-reservation payloads used to seed the edit POST reload.
+_EDIT4_EXISTING = {"hw-address": "aa:bb:cc:dd:ee:ff", "ip-address": "10.0.0.55", "subnet-id": 1}
+_EDIT6_EXISTING = {
+    "ip-addresses": ["2001:db8::1"],
+    "duid": "00:01:00:01:12:34:56:78:aa:bb:cc:dd:ee:ff",
+    "subnet-id": 1,
+}
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
@@ -163,41 +234,30 @@ class TestReservation4ListExceptions(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_reservations4", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_hook_not_available_shows_warning(self, MockKeaClient):
-        """KeaException result=2 sets hook_available=False without crashing."""
-        from netbox_kea.kea import KeaException
-
-        MockKeaClient.return_value.reservation_get_page.side_effect = KeaException(
-            {"result": 2, "text": "hook not loaded"}, index=0
-        )
-        response = self.client.get(self._url())
+    def test_hook_not_available_shows_warning(self):
+        """reservation-get-page result=2 sets hook_available=False without crashing."""
+        with stub_kea({"reservation-get-page": {"result": 2, "text": "unknown command 'reservation-get-page'"}}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         self.assertFalse(response.context.get("hook_available", True))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_network_error_during_fetch_keeps_hook_available(self, MockKeaClient):
-        """requests.RequestException during reservation_get_page keeps hook_available=True.
+    def test_network_error_during_fetch_keeps_hook_available(self):
+        """A transport error during reservation-get-page keeps hook_available=True.
 
         Transport errors do not indicate the hook is missing — only result==2 does.
         """
-        MockKeaClient.return_value.reservation_get_page.side_effect = req.RequestException("connection refused")
-        response = self.client.get(self._url())
+        with stub_kea({"reservation-get-page": req.RequestException("connection refused")}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.context.get("hook_available", False))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_kea_exception_non_result2_keeps_hook_available(self, MockKeaClient):
-        """KeaException with result!=2 keeps hook_available=True.
+    def test_kea_exception_non_result2_keeps_hook_available(self):
+        """A reservation-get-page result!=2 keeps hook_available=True.
 
         Only result==2 (unknown command = hook not loaded) should hide the hook UI.
         """
-        from netbox_kea.kea import KeaException
-
-        MockKeaClient.return_value.reservation_get_page.side_effect = KeaException(
-            {"result": 1, "text": "general error"}, index=0
-        )
-        response = self.client.get(self._url())
+        with stub_kea({"reservation-get-page": {"result": 1, "text": "general error"}}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.context.get("hook_available", False))
 
@@ -209,41 +269,30 @@ class TestReservation6ListExceptions(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_reservations6", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_hook_not_available_shows_warning(self, MockKeaClient):
-        """KeaException result=2 sets hook_available=False without crashing."""
-        from netbox_kea.kea import KeaException
-
-        MockKeaClient.return_value.reservation_get_page.side_effect = KeaException(
-            {"result": 2, "text": "hook not loaded"}, index=0
-        )
-        response = self.client.get(self._url())
+    def test_hook_not_available_shows_warning(self):
+        """reservation-get-page result=2 sets hook_available=False without crashing."""
+        with stub_kea({"reservation-get-page": {"result": 2, "text": "unknown command 'reservation-get-page'"}}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         self.assertFalse(response.context.get("hook_available", True))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_network_error_during_fetch_keeps_hook_available(self, MockKeaClient):
-        """requests.RequestException during reservation_get_page keeps hook_available=True.
+    def test_network_error_during_fetch_keeps_hook_available(self):
+        """A transport error during reservation-get-page keeps hook_available=True.
 
         Transport errors do not indicate the hook is missing — only result==2 does.
         """
-        MockKeaClient.return_value.reservation_get_page.side_effect = req.RequestException("timeout")
-        response = self.client.get(self._url())
+        with stub_kea({"reservation-get-page": req.RequestException("timeout")}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.context.get("hook_available", False))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_kea_exception_non_result2_keeps_hook_available(self, MockKeaClient):
-        """KeaException with result!=2 keeps hook_available=True.
+    def test_kea_exception_non_result2_keeps_hook_available(self):
+        """A reservation-get-page result!=2 keeps hook_available=True.
 
         Only result==2 (unknown command = hook not loaded) should hide the hook UI.
         """
-        from netbox_kea.kea import KeaException
-
-        MockKeaClient.return_value.reservation_get_page.side_effect = KeaException(
-            {"result": 1, "text": "general error"}, index=0
-        )
-        response = self.client.get(self._url())
+        with stub_kea({"reservation-get-page": {"result": 1, "text": "general error"}}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.context.get("hook_available", False))
 
@@ -260,92 +309,50 @@ class TestReservation4AddExceptions(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_reservation4_add", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_partial_persist_error_redirects_with_warning(self, MockKeaClient):
-        """PartialPersistError must redirect with a warning message."""
-        from netbox_kea.kea import PartialPersistError
-
-        MockKeaClient.return_value.reservation_add.side_effect = PartialPersistError("dhcp4", Exception("write"))
-        MockKeaClient.return_value.reservation_get_page.return_value = ([], 0, 0)
-        response = self.client.post(self._url(), _VALID_RESERVATION4_POST, follow=True)
-        self.assertEqual(response.status_code, 200)
-        msgs = list(response.context["messages"])
-        self.assertTrue(any(m.level == django_messages.WARNING for m in msgs))
-
-    @patch("netbox_kea.models.KeaClient")
-    def test_partial_persist_with_sync_to_netbox(self, MockKeaClient):
-        """PartialPersistError with sync_to_netbox=True must attempt IPAM sync."""
-        from netbox_kea.kea import PartialPersistError
-
-        MockKeaClient.return_value.reservation_add.side_effect = PartialPersistError("dhcp4", Exception("write"))
-        MockKeaClient.return_value.reservation_get_page.return_value = ([], 0, 0)
-        post_data = {**_VALID_RESERVATION4_POST, "sync_to_netbox": "on"}
-        with patch("netbox_kea.views.reservations.sync_reservation_to_netbox") as mock_sync:
-            mock_sync.return_value = (MagicMock(spec=NbIP), True, False)
-            response = self.client.post(self._url(), post_data, follow=True)
-        self.assertEqual(response.status_code, 200)
-        mock_sync.assert_called_once()
-
-    @patch("netbox_kea.models.KeaClient")
-    def test_partial_persist_sync_failure_shows_warning(self, MockKeaClient):
-        """PartialPersistError + sync error must show two warnings."""
-        from netbox_kea.kea import PartialPersistError
-
-        MockKeaClient.return_value.reservation_add.side_effect = PartialPersistError("dhcp4", Exception("write"))
-        MockKeaClient.return_value.reservation_get_page.return_value = ([], 0, 0)
-        post_data = {**_VALID_RESERVATION4_POST, "sync_to_netbox": "on"}
-        with patch("netbox_kea.views.reservations.sync_reservation_to_netbox", side_effect=ValueError("sync boom")):
-            response = self.client.post(self._url(), post_data, follow=True)
-        msgs = list(response.context["messages"])
-        self.assertTrue(any("sync failed" in m.message.lower() for m in msgs))
-
-    @patch("netbox_kea.models.KeaClient")
-    def test_kea_exception_rerenders_form(self, MockKeaClient):
-        """KeaException must re-render the form with an error message."""
-        from netbox_kea.kea import KeaException
-
-        MockKeaClient.return_value.reservation_add.side_effect = KeaException(
-            {"result": 1, "text": "already exists"}, index=0
-        )
-        MockKeaClient.return_value.reservation_get_page.return_value = ([], 0, 0)
-        response = self.client.post(self._url(), _VALID_RESERVATION4_POST)
+    def test_kea_exception_rerenders_form(self):
+        """A reservation-add error must re-render the form with an error message."""
+        with stub_kea({"subnet4-get": _subnet_get(4), "reservation-add": {"result": 1, "text": "already exists"}}):
+            response = self.client.post(self._url(), _VALID_RESERVATION4_POST)
         self.assertEqual(response.status_code, 200)
         msgs = list(django_messages.get_messages(response.wsgi_request))
         self.assertTrue(any(m.level == django_messages.ERROR for m in msgs))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_kea_exception_result1_rerenders_form(self, MockKeaClient):
-        """KeaException from reservation_add must re-render the form with an error message."""
-        from netbox_kea.kea import KeaException
-
-        MockKeaClient.return_value.reservation_add.side_effect = KeaException(
-            {"result": 1, "text": "server error"}, index=0
-        )
-        MockKeaClient.return_value.reservation_get_page.return_value = ([], 0, 0)
-        response = self.client.post(self._url(), _VALID_RESERVATION4_POST)
+    def test_kea_exception_result1_rerenders_form(self):
+        """A reservation-add result=1 must re-render the form with an error message."""
+        with stub_kea({"subnet4-get": _subnet_get(4), "reservation-add": {"result": 1, "text": "server error"}}):
+            response = self.client.post(self._url(), _VALID_RESERVATION4_POST)
         self.assertEqual(response.status_code, 200)
         msgs = list(django_messages.get_messages(response.wsgi_request))
         self.assertTrue(any(m.level == django_messages.ERROR for m in msgs))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_success_with_sync_to_netbox(self, MockKeaClient):
-        """Successful add with sync_to_netbox=True must call sync and show info message."""
-        MockKeaClient.return_value.reservation_add.return_value = None
-        MockKeaClient.return_value.reservation_get_page.return_value = ([], 0, 0)
+    def test_success_with_sync_to_netbox(self):
+        """Successful add with sync_to_netbox=True runs the real sync → NetBox IP created."""
         post_data = {**_VALID_RESERVATION4_POST, "sync_to_netbox": "on"}
-        with patch("netbox_kea.views.reservations.sync_reservation_to_netbox") as mock_sync:
-            mock_sync.return_value = (MagicMock(spec=NbIP), True, False)
+        with stub_kea(
+            {"subnet4-get": _subnet_get(4), "reservation-add": {"result": 0}, "reservation-get-page": _RES_EMPTY_PAGE}
+        ) as kea:
             response = self.client.post(self._url(), post_data, follow=True)
         self.assertEqual(response.status_code, 200)
-        mock_sync.assert_called_once()
+        self.assertEqual(kea.commands().count("reservation-add"), 1)
+        self.assertTrue(NbIP.objects.filter(address__startswith="10.0.0.55/").exists())
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_success_sync_failure_shows_warning(self, MockKeaClient):
-        """Successful add where sync raises must show a warning (no 500)."""
-        MockKeaClient.return_value.reservation_add.return_value = None
-        MockKeaClient.return_value.reservation_get_page.return_value = ([], 0, 0)
+    def test_success_sync_failure_shows_warning(self):
+        """Successful add where sync raises must show a warning (no 500).
+
+        The sync boundary (a NetBox-side function tested in test_sync.py) is patched
+        to raise so the view's error handling is exercised; the KeaClient is real.
+        """
         post_data = {**_VALID_RESERVATION4_POST, "sync_to_netbox": "on"}
-        with patch("netbox_kea.views.reservations.sync_reservation_to_netbox", side_effect=ValueError("sync fail")):
+        with (
+            patch("netbox_kea.views.reservations.sync_reservation_to_netbox", side_effect=ValueError("sync fail")),
+            stub_kea(
+                {
+                    "subnet4-get": _subnet_get(4),
+                    "reservation-add": {"result": 0},
+                    "reservation-get-page": _RES_EMPTY_PAGE,
+                }
+            ),
+        ):
             response = self.client.post(self._url(), post_data, follow=True)
         msgs = list(response.context["messages"])
         self.assertTrue(any("sync failed" in m.message.lower() for m in msgs))
@@ -363,68 +370,21 @@ class TestReservation6AddExceptions(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_reservation6_add", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_partial_persist_error_redirects_with_warning(self, MockKeaClient):
-        """PartialPersistError must redirect with a warning message."""
-        from netbox_kea.kea import PartialPersistError
-
-        MockKeaClient.return_value.reservation_add.side_effect = PartialPersistError("dhcp6", Exception("write"))
-        MockKeaClient.return_value.reservation_get_page.return_value = ([], 0, 0)
-        response = self.client.post(self._url(), _VALID_RESERVATION6_POST, follow=True)
-        self.assertEqual(response.status_code, 200)
-        msgs = list(response.context["messages"])
-        self.assertTrue(any(m.level == django_messages.WARNING for m in msgs))
-
-    @patch("netbox_kea.models.KeaClient")
-    def test_partial_persist_with_sync_to_netbox(self, MockKeaClient):
-        """PartialPersistError with sync_to_netbox=True must attempt IPAM sync and show recovery message."""
-        from netbox_kea.kea import PartialPersistError
-
-        MockKeaClient.return_value.reservation_add.side_effect = PartialPersistError("dhcp6", Exception("write"))
-        MockKeaClient.return_value.reservation_get_page.return_value = ([], 0, 0)
-        post_data = {**_VALID_RESERVATION6_POST, "sync_to_netbox": "on"}
-        with patch("netbox_kea.views.reservations.sync_reservation_to_netbox") as mock_sync:
-            mock_sync.return_value = (MagicMock(spec=NbIP), False, False)
-            response = self.client.post(self._url(), post_data, follow=True)
-        self.assertEqual(response.status_code, 200)
-        mock_sync.assert_called_once()
-        msgs = list(response.context["messages"])
-        self.assertTrue(any(m.level == django_messages.WARNING for m in msgs), "Expected warning about partial persist")
-
-    @patch("netbox_kea.models.KeaClient")
-    def test_partial_persist_sync_failure_shows_warning(self, MockKeaClient):
-        """PartialPersistError + sync exception must show warning about sync failure."""
-        from netbox_kea.kea import PartialPersistError
-
-        MockKeaClient.return_value.reservation_add.side_effect = PartialPersistError("dhcp6", Exception("write"))
-        MockKeaClient.return_value.reservation_get_page.return_value = ([], 0, 0)
-        post_data = {**_VALID_RESERVATION6_POST, "sync_to_netbox": "on"}
-        with patch("netbox_kea.views.reservations.sync_reservation_to_netbox", side_effect=ValueError("sync boom")):
-            response = self.client.post(self._url(), post_data, follow=True)
-        msgs = list(response.context["messages"])
-        self.assertTrue(any("sync failed" in m.message.lower() for m in msgs))
-
-    @patch("netbox_kea.models.KeaClient")
-    def test_kea_exception_rerenders_form(self, MockKeaClient):
-        """KeaException must re-render the form with an error message, not leak raw Kea text."""
-        from netbox_kea.kea import KeaException
-
+    def test_kea_exception_rerenders_form(self):
+        """A reservation-add error must re-render the form without leaking raw Kea text."""
         sentinel = "kea-detail-should-not-leak"
-        MockKeaClient.return_value.reservation_add.side_effect = KeaException({"result": 1, "text": sentinel}, index=0)
-        MockKeaClient.return_value.reservation_get_page.return_value = ([], 0, 0)
-        response = self.client.post(self._url(), _VALID_RESERVATION6_POST)
+        with stub_kea({"subnet6-get": _subnet_get(6), "reservation-add": {"result": 1, "text": sentinel}}):
+            response = self.client.post(self._url(), _VALID_RESERVATION6_POST)
         self.assertEqual(response.status_code, 200)
         msgs = list(django_messages.get_messages(response.wsgi_request))
         self.assertTrue(any(m.level == django_messages.ERROR for m in msgs))
         self.assertFalse(any(sentinel in str(m) for m in msgs))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_generic_exception_propagates(self, MockKeaClient):
-        """Unexpected exception must propagate (not be silently caught)."""
-        MockKeaClient.return_value.reservation_add.side_effect = RuntimeError("bang")
-        MockKeaClient.return_value.reservation_get_page.return_value = ([], 0, 0)
-        with self.assertRaises(RuntimeError):
-            self.client.post(self._url(), _VALID_RESERVATION6_POST)
+    def test_generic_exception_propagates(self):
+        """An unexpected transport-layer error must propagate (not be silently caught)."""
+        with stub_kea({"subnet6-get": _subnet_get(6), "reservation-add": RuntimeError("bang")}):
+            with self.assertRaises(RuntimeError):
+                self.client.post(self._url(), _VALID_RESERVATION6_POST)
 
 
 # ---------------------------------------------------------------------------
@@ -439,145 +399,69 @@ class TestReservation4EditExceptions(_ViewTestBase):
     def _url(self, subnet_id=1, ip="10.0.0.55"):
         return reverse("plugins:netbox_kea:server_reservation4_edit", args=[self.server.pk, subnet_id, ip])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_redirects_on_kea_exception(self, MockKeaClient):
-        """GET that raises KeaException during reservation fetch must redirect."""
-        from netbox_kea.kea import KeaException
-
-        MockKeaClient.return_value.reservation_get.side_effect = KeaException(
-            {"result": 1, "text": "server error"}, index=0
-        )
-        response = self.client.get(self._url())
+    def test_get_redirects_on_kea_exception(self):
+        """GET that raises a Kea error during reservation fetch must redirect."""
+        with stub_kea({"reservation-get": {"result": 1, "text": "server error"}}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 302)
         self._assert_no_none_pk_redirect(response)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_redirects_on_transport_error(self, MockKeaClient):
-        """GET that raises RequestException during reservation fetch must redirect."""
-        import requests as _req
-
-        MockKeaClient.return_value.reservation_get.side_effect = _req.ConnectionError("down")
-        response = self.client.get(self._url())
+    def test_get_redirects_on_transport_error(self):
+        """GET that raises a transport error during reservation fetch must redirect."""
+        with stub_kea({"reservation-get": req.ConnectionError("down")}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 302)
         self._assert_no_none_pk_redirect(response)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_404_when_reservation_not_found(self, MockKeaClient):
+    def test_get_404_when_reservation_not_found(self):
         """GET must return 404 when reservation_get returns None."""
-        MockKeaClient.return_value.reservation_get.return_value = None
-        response = self.client.get(self._url())
+        with stub_kea({"reservation-get": _RES_NOT_FOUND}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 404)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_partial_persist_error_redirects(self, MockKeaClient):
-        """PartialPersistError on reservation_update must redirect with warning."""
-        from netbox_kea.kea import PartialPersistError
-
-        MockKeaClient.return_value.reservation_get.return_value = {
-            "hw-address": "aa:bb:cc:dd:ee:ff",
-            "ip-address": "10.0.0.55",
-            "subnet-id": 1,
-        }
-        MockKeaClient.return_value.reservation_update.side_effect = PartialPersistError("dhcp4", Exception("write"))
-        response = self.client.post(self._url(), _VALID_RESERVATION4_EDIT_POST, follow=True)
-        self.assertEqual(response.status_code, 200)
-        msgs = list(response.context["messages"])
-        self.assertTrue(any(m.level == django_messages.WARNING for m in msgs))
-
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_partial_persist_with_sync(self, MockKeaClient):
-        """PartialPersistError with sync_to_netbox attempts sync."""
-        from netbox_kea.kea import PartialPersistError
-
-        MockKeaClient.return_value.reservation_get.return_value = {
-            "hw-address": "aa:bb:cc:dd:ee:ff",
-            "ip-address": "10.0.0.55",
-            "subnet-id": 1,
-        }
-        MockKeaClient.return_value.reservation_update.side_effect = PartialPersistError("dhcp4", Exception("write"))
-        post_data = {**_VALID_RESERVATION4_EDIT_POST, "sync_to_netbox": "on"}
-        with patch("netbox_kea.views.reservations.sync_reservation_to_netbox") as mock_sync:
-            mock_sync.return_value = (MagicMock(spec=NbIP), True, False)
-            response = self.client.post(self._url(), post_data, follow=True)
-        self.assertEqual(response.status_code, 200)
-        mock_sync.assert_called_once()
-
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_partial_persist_sync_failure(self, MockKeaClient):
-        """PartialPersistError + sync failure shows warning."""
-        from netbox_kea.kea import PartialPersistError
-
-        MockKeaClient.return_value.reservation_get.return_value = {
-            "hw-address": "aa:bb:cc:dd:ee:ff",
-            "ip-address": "10.0.0.55",
-            "subnet-id": 1,
-        }
-        MockKeaClient.return_value.reservation_update.side_effect = PartialPersistError("dhcp4", Exception("write"))
-        post_data = {**_VALID_RESERVATION4_EDIT_POST, "sync_to_netbox": "on"}
-        with patch("netbox_kea.views.reservations.sync_reservation_to_netbox", side_effect=ValueError("sync")):
-            response = self.client.post(self._url(), post_data, follow=True)
-        msgs = list(response.context["messages"])
-        self.assertTrue(any("sync failed" in m.message.lower() for m in msgs))
-
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_kea_exception_rerenders_form(self, MockKeaClient):
-        """KeaException on reservation_update must re-render the form with error message."""
-        from netbox_kea.kea import KeaException
-
-        MockKeaClient.return_value.reservation_get.return_value = {
-            "hw-address": "aa:bb:cc:dd:ee:ff",
-            "ip-address": "10.0.0.55",
-            "subnet-id": 1,
-        }
-        MockKeaClient.return_value.reservation_update.side_effect = KeaException(
-            {"result": 1, "text": "not found"}, index=0
-        )
-        response = self.client.post(self._url(), _VALID_RESERVATION4_EDIT_POST)
+    def test_post_kea_exception_rerenders_form(self):
+        """A reservation-update error must re-render the form with an error message."""
+        with stub_kea({"reservation-get": _res_get(_EDIT4_EXISTING), "reservation-update": {"result": 1, "text": "x"}}):
+            response = self.client.post(self._url(), _VALID_RESERVATION4_EDIT_POST)
         self.assertEqual(response.status_code, 200)
         msgs = list(response.context["messages"])
         self.assertTrue(
             any("Kea reported an error" in str(m) for m in msgs), "Expected KeaException hint in flash message"
         )
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_generic_exception_propagates(self, MockKeaClient):
-        """Unexpected exception on reservation_update must propagate."""
-        MockKeaClient.return_value.reservation_get.return_value = {
-            "hw-address": "aa:bb:cc:dd:ee:ff",
-            "ip-address": "10.0.0.55",
-            "subnet-id": 1,
-        }
-        MockKeaClient.return_value.reservation_update.side_effect = RuntimeError("crash")
-        with self.assertRaises(RuntimeError):
-            self.client.post(self._url(), _VALID_RESERVATION4_EDIT_POST)
+    def test_post_generic_exception_propagates(self):
+        """An unexpected transport-layer error on reservation-update must propagate."""
+        with stub_kea({"reservation-get": _res_get(_EDIT4_EXISTING), "reservation-update": RuntimeError("crash")}):
+            with self.assertRaises(RuntimeError):
+                self.client.post(self._url(), _VALID_RESERVATION4_EDIT_POST)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_success_with_sync(self, MockKeaClient):
-        """Successful update with sync_to_netbox calls sync and shows info."""
-        MockKeaClient.return_value.reservation_get.return_value = {
-            "hw-address": "aa:bb:cc:dd:ee:ff",
-            "ip-address": "10.0.0.55",
-            "subnet-id": 1,
-        }
-        MockKeaClient.return_value.reservation_update.return_value = None
+    def test_post_success_with_sync(self):
+        """Successful update with sync_to_netbox runs the real sync → NetBox IP created."""
         post_data = {**_VALID_RESERVATION4_EDIT_POST, "sync_to_netbox": "on"}
-        with patch("netbox_kea.views.reservations.sync_reservation_to_netbox") as mock_sync:
-            mock_sync.return_value = (MagicMock(spec=NbIP), False, False)
+        with stub_kea(
+            {
+                "reservation-get": _res_get(_EDIT4_EXISTING),
+                "reservation-update": {"result": 0},
+                "reservation-get-page": _RES_EMPTY_PAGE,
+            }
+        ):
             response = self.client.post(self._url(), post_data, follow=True)
         self.assertEqual(response.status_code, 200)
-        mock_sync.assert_called_once()
+        self.assertTrue(NbIP.objects.filter(address__startswith="10.0.0.55/").exists())
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_success_sync_failure_shows_warning(self, MockKeaClient):
-        """Successful update where sync raises must show warning."""
-        MockKeaClient.return_value.reservation_get.return_value = {
-            "hw-address": "aa:bb:cc:dd:ee:ff",
-            "ip-address": "10.0.0.55",
-            "subnet-id": 1,
-        }
-        MockKeaClient.return_value.reservation_update.return_value = None
+    def test_post_success_sync_failure_shows_warning(self):
+        """Successful update where sync raises must show a warning."""
         post_data = {**_VALID_RESERVATION4_EDIT_POST, "sync_to_netbox": "on"}
-        with patch("netbox_kea.views.reservations.sync_reservation_to_netbox", side_effect=ValueError("oops")):
+        with (
+            patch("netbox_kea.views.reservations.sync_reservation_to_netbox", side_effect=ValueError("oops")),
+            stub_kea(
+                {
+                    "reservation-get": _res_get(_EDIT4_EXISTING),
+                    "reservation-update": {"result": 0},
+                    "reservation-get-page": _RES_EMPTY_PAGE,
+                }
+            ),
+        ):
             response = self.client.post(self._url(), post_data, follow=True)
         msgs = list(response.context["messages"])
         self.assertTrue(any("sync failed" in m.message.lower() for m in msgs))
@@ -595,73 +479,39 @@ class TestReservation6EditExceptions(_ViewTestBase):
     def _url(self, subnet_id=1, ip="2001:db8::1"):
         return reverse("plugins:netbox_kea:server_reservation6_edit", args=[self.server.pk, subnet_id, ip])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_redirects_on_kea_exception(self, MockKeaClient):
-        """GET that raises KeaException during reservation fetch must redirect."""
-        from netbox_kea.kea import KeaException
-
-        MockKeaClient.return_value.reservation_get.side_effect = KeaException({"result": 1, "text": "error"}, index=0)
-        response = self.client.get(self._url())
+    def test_get_redirects_on_kea_exception(self):
+        """GET that raises a Kea error during reservation fetch must redirect."""
+        with stub_kea({"reservation-get": {"result": 1, "text": "error"}}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 302)
         self._assert_no_none_pk_redirect(response)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_redirects_on_transport_error(self, MockKeaClient):
-        """GET that raises RequestException during reservation fetch must redirect."""
-        import requests as _req
-
-        MockKeaClient.return_value.reservation_get.side_effect = _req.ConnectionError("down")
-        response = self.client.get(self._url())
+    def test_get_redirects_on_transport_error(self):
+        """GET that raises a transport error during reservation fetch must redirect."""
+        with stub_kea({"reservation-get": req.ConnectionError("down")}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 302)
         self._assert_no_none_pk_redirect(response)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_404_when_reservation_not_found(self, MockKeaClient):
+    def test_get_404_when_reservation_not_found(self):
         """GET must return 404 when reservation_get returns None."""
-        MockKeaClient.return_value.reservation_get.return_value = None
-        response = self.client.get(self._url())
+        with stub_kea({"reservation-get": _RES_NOT_FOUND}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 404)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_partial_persist_error_redirects(self, MockKeaClient):
-        """PartialPersistError on reservation_update must redirect with warning."""
-        from netbox_kea.kea import PartialPersistError
-
-        MockKeaClient.return_value.reservation_get.return_value = {
-            "ip-addresses": ["2001:db8::1"],
-            "duid": "00:01:00:01:12:34:56:78:aa:bb:cc:dd:ee:ff",
-        }
-        MockKeaClient.return_value.reservation_update.side_effect = PartialPersistError("dhcp6", Exception("write"))
-        response = self.client.post(self._url(), _VALID_RESERVATION6_EDIT_POST, follow=True)
-        self.assertEqual(response.status_code, 200)
-        msgs = list(response.context["messages"])
-        self.assertTrue(any(m.level == django_messages.WARNING for m in msgs))
-
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_kea_exception_rerenders_form(self, MockKeaClient):
-        """KeaException on reservation_update must re-render the form."""
-        from netbox_kea.kea import KeaException
-
-        MockKeaClient.return_value.reservation_get.return_value = {
-            "ip-addresses": ["2001:db8::1"],
-            "duid": "00:01:00:01:12:34:56:78:aa:bb:cc:dd:ee:ff",
-        }
-        MockKeaClient.return_value.reservation_update.side_effect = KeaException(
-            {"result": 1, "text": "error"}, index=0
-        )
-        response = self.client.post(self._url(), _VALID_RESERVATION6_EDIT_POST)
+    def test_post_kea_exception_rerenders_form(self):
+        """A reservation-update error must re-render the form."""
+        with stub_kea(
+            {"reservation-get": _res_get(_EDIT6_EXISTING), "reservation-update": {"result": 1, "text": "error"}}
+        ):
+            response = self.client.post(self._url(), _VALID_RESERVATION6_EDIT_POST)
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_generic_exception_propagates(self, MockKeaClient):
-        """Unexpected exception on reservation_update must propagate."""
-        MockKeaClient.return_value.reservation_get.return_value = {
-            "ip-addresses": ["2001:db8::1"],
-            "duid": "00:01:00:01:12:34:56:78:aa:bb:cc:dd:ee:ff",
-        }
-        MockKeaClient.return_value.reservation_update.side_effect = RuntimeError("crash")
-        with self.assertRaises(RuntimeError):
-            self.client.post(self._url(), _VALID_RESERVATION6_EDIT_POST)
+    def test_post_generic_exception_propagates(self):
+        """An unexpected transport-layer error on reservation-update must propagate."""
+        with stub_kea({"reservation-get": _res_get(_EDIT6_EXISTING), "reservation-update": RuntimeError("crash")}):
+            with self.assertRaises(RuntimeError):
+                self.client.post(self._url(), _VALID_RESERVATION6_EDIT_POST)
 
 
 # ---------------------------------------------------------------------------
@@ -676,35 +526,18 @@ class TestReservation4DeleteExceptions(_ViewTestBase):
     def _url(self, subnet_id=1, ip="10.0.0.55"):
         return reverse("plugins:netbox_kea:server_reservation4_delete", args=[self.server.pk, subnet_id, ip])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_partial_persist_error_redirects_with_warning(self, MockKeaClient):
-        """PartialPersistError must redirect with warning and still run side effects."""
-        from netbox_kea.kea import PartialPersistError
-
-        MockKeaClient.return_value.reservation_del.side_effect = PartialPersistError("dhcp4", Exception("write"))
-        response = self.client.post(self._url(), follow=True)
-        self.assertEqual(response.status_code, 200)
-        msgs = list(response.context["messages"])
-        self.assertTrue(any(m.level == django_messages.WARNING for m in msgs))
-
-    @patch("netbox_kea.models.KeaClient")
-    def test_kea_exception_shows_error(self, MockKeaClient):
-        """KeaException must show an error message and redirect."""
-        from netbox_kea.kea import KeaException
-
-        MockKeaClient.return_value.reservation_del.side_effect = KeaException(
-            {"result": 1, "text": "not found"}, index=0
-        )
-        response = self.client.post(self._url(), follow=True)
+    def test_kea_exception_shows_error(self):
+        """A reservation-del error must show an error message and redirect."""
+        with stub_kea({"reservation-del": {"result": 1, "text": "not found"}, "reservation-get-page": _RES_EMPTY_PAGE}):
+            response = self.client.post(self._url(), follow=True)
         msgs = list(response.context["messages"])
         self.assertTrue(any(m.level == django_messages.ERROR for m in msgs))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_generic_exception_propagates(self, MockKeaClient):
-        """Unexpected exception must propagate (not show a generic error message)."""
-        MockKeaClient.return_value.reservation_del.side_effect = RuntimeError("crash")
-        with self.assertRaises(RuntimeError):
-            self.client.post(self._url())
+    def test_generic_exception_propagates(self):
+        """An unexpected transport-layer error must propagate (not show a generic error message)."""
+        with stub_kea({"reservation-del": RuntimeError("crash")}):
+            with self.assertRaises(RuntimeError):
+                self.client.post(self._url())
 
 
 # ---------------------------------------------------------------------------
@@ -719,33 +552,18 @@ class TestReservation6DeleteExceptions(_ViewTestBase):
     def _url(self, subnet_id=1, ip="2001:db8::1"):
         return reverse("plugins:netbox_kea:server_reservation6_delete", args=[self.server.pk, subnet_id, ip])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_partial_persist_error_redirects_with_warning(self, MockKeaClient):
-        """PartialPersistError must redirect with warning."""
-        from netbox_kea.kea import PartialPersistError
-
-        MockKeaClient.return_value.reservation_del.side_effect = PartialPersistError("dhcp6", Exception("write"))
-        response = self.client.post(self._url(), follow=True)
-        self.assertEqual(response.status_code, 200)
-        msgs = list(response.context["messages"])
-        self.assertTrue(any(m.level == django_messages.WARNING for m in msgs))
-
-    @patch("netbox_kea.models.KeaClient")
-    def test_kea_exception_shows_error(self, MockKeaClient):
-        """KeaException must show an error message."""
-        from netbox_kea.kea import KeaException
-
-        MockKeaClient.return_value.reservation_del.side_effect = KeaException({"result": 1, "text": "error"}, index=0)
-        response = self.client.post(self._url(), follow=True)
+    def test_kea_exception_shows_error(self):
+        """A reservation-del error must show an error message."""
+        with stub_kea({"reservation-del": {"result": 1, "text": "error"}, "reservation-get-page": _RES_EMPTY_PAGE}):
+            response = self.client.post(self._url(), follow=True)
         msgs = list(response.context["messages"])
         self.assertTrue(any(m.level == django_messages.ERROR for m in msgs))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_generic_exception_propagates(self, MockKeaClient):
-        """Unexpected exception must propagate (not show a generic error message)."""
-        MockKeaClient.return_value.reservation_del.side_effect = RuntimeError("crash")
-        with self.assertRaises(RuntimeError):
-            self.client.post(self._url())
+    def test_generic_exception_propagates(self):
+        """An unexpected transport-layer error must propagate (not show a generic error message)."""
+        with stub_kea({"reservation-del": RuntimeError("crash")}):
+            with self.assertRaises(RuntimeError):
+                self.client.post(self._url())
 
 
 # ---------------------------------------------------------------------------
@@ -775,39 +593,27 @@ class TestGetReservationOptionsFormsetPartial(_ViewTestBase):
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestReservationListEnrichmentExceptions(_ViewTestBase):
-    """_enrich_reservations_with_lease_status: thread pool exception paths."""
+    """_enrich_reservations_with_lease_status: thread pool exception paths (via the list view)."""
 
     def _url(self):
         return reverse("plugins:netbox_kea:server_reservations4", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_no_reservations_skips_enrichment(self, MockKeaClient):
-        """Line 1650: empty reservation list → enrichment returns early."""
-        MockKeaClient.return_value.reservation_get_page.return_value = ([], 0, 0)
-        response = self.client.get(self._url())
+    def test_no_reservations_skips_enrichment(self):
+        """An empty reservation list → enrichment returns early (no lease query issued)."""
+        with stub_kea({"reservation-get-page": _RES_EMPTY_PAGE}) as kea:
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
-        MockKeaClient.return_value.clone.assert_not_called()
+        self.assertNotIn("lease4-get-all", kea.commands())
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_thread_pool_generic_exception_returns_early(self, MockKeaClient):
-        """Line 1662-1663: generic exception in thread pool causes enrichment to return."""
-        MockKeaClient.return_value.reservation_get_page.return_value = (
-            [{"subnet-id": 1, "ip-address": "10.0.0.5", "hw-address": "aa:bb:cc:dd:ee:ff"}],
-            0,
-            0,
-        )
-        # lease4-get-all raises an unexpected error — must set on the cloned client
-        # since _enrich_reservations_with_lease_status calls client.clone()
-        MockKeaClient.return_value.clone.return_value.command.side_effect = RuntimeError("unexpected")
-        MockKeaClient.return_value.clone.return_value.__enter__ = MagicMock(  # mock-ok: CM protocol stub
-            return_value=MockKeaClient.return_value.clone.return_value
-        )
-        MockKeaClient.return_value.clone.return_value.__exit__ = MagicMock(
-            return_value=None
-        )  # mock-ok: CM protocol stub
-        response = self.client.get(self._url())
+    def test_thread_pool_generic_exception_returns_early(self):
+        """A generic error in the lease-enrichment worker causes enrichment to return early."""
+        host = {"subnet-id": 1, "ip-address": "10.0.0.5", "hw-address": "aa:bb:cc:dd:ee:ff"}
+        # lease4-get-all raises an unexpected error in the worker thread; the enrichment
+        # outer except swallows it so the list still renders.
+        with stub_kea({"reservation-get-page": _res_page([host]), "lease4-get-all": RuntimeError("unexpected")}) as kea:
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
-        MockKeaClient.return_value.clone.return_value.command.assert_called()
+        self.assertIn("lease4-get-all", kea.commands())
 
 
 # ---------------------------------------------------------------------------
@@ -815,16 +621,13 @@ class TestReservationListEnrichmentExceptions(_ViewTestBase):
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestReservation6AddOptionDataAndSync(_ViewTestBase):
-    """Lines 2008, 2027-2034: Reservation6 add with option-data and sync."""
+    """Reservation6 add with option-data and sync-to-NetBox."""
 
     def _url(self):
         return reverse("plugins:netbox_kea:server_reservation6_add", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_with_option_data_included(self, MockKeaClient):
-        """option-data is included in reservation payload when formset has entries."""
-        MockKeaClient.return_value.reservation_add.return_value = None
-        MockKeaClient.return_value.reservation_get_page.return_value = ([], 0, 0)
+    def test_post_with_option_data_included(self):
+        """option-data is included in the reservation-add payload when the formset has entries."""
         post_data = {
             **_VALID_RESERVATION6_POST,
             "options-TOTAL_FORMS": "1",
@@ -836,32 +639,25 @@ class TestReservation6AddOptionDataAndSync(_ViewTestBase):
             "options-0-always_send": "",
             "options-0-DELETE": "",
         }
-        response = self.client.post(self._url(), post_data)
+        with stub_kea({"subnet6-get": _subnet_get(6), "reservation-add": {"result": 0}}) as kea:
+            response = self.client.post(self._url(), post_data)
         self.assertIn(response.status_code, (200, 302))
-        self.assertTrue(MockKeaClient.return_value.reservation_add.called)
-        call_args = MockKeaClient.return_value.reservation_add.call_args
-        # Extract the reservation dict (second positional arg to reservation_add)
-        reservation_dict = (
-            call_args[0][1]
-            if call_args[0] and len(call_args[0]) > 1
-            else (call_args.kwargs or {}).get("reservation", {})
-        )
+        self.assertEqual(kea.commands().count("reservation-add"), 1)
+        reservation_dict = kea.bodies("reservation-add")[0]["arguments"]["reservation"]
         option_data = reservation_dict.get("option-data", [])
         dns_entry = next((o for o in option_data if o.get("name") == "dns-servers"), None)
         self.assertIsNotNone(dns_entry, "dns-servers option not found in reservation option-data")
         self.assertEqual(dns_entry["data"], "2001:4860:4860::8888")
 
-    @patch("netbox_kea.views.reservations.sync_reservation_to_netbox")
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_sync_success(self, MockKeaClient, mock_sync):
-        """sync_to_netbox=on → sync called once and success message queued."""
-        MockKeaClient.return_value.reservation_add.return_value = None
-        MockKeaClient.return_value.reservation_get_page.return_value = ([], 0, 0)
-        mock_sync.return_value = (MagicMock(spec=NbIP), True, False)
+    def test_post_sync_success(self):
+        """sync_to_netbox=on runs the real sync → NetBox IP created + info message queued."""
         post_data = {**_VALID_RESERVATION6_POST, "sync_to_netbox": "on"}
-        response = self.client.post(self._url(), post_data, follow=True)
+        with stub_kea(
+            {"subnet6-get": _subnet_get(6), "reservation-add": {"result": 0}, "reservation-get-page": _RES_EMPTY_PAGE}
+        ):
+            response = self.client.post(self._url(), post_data, follow=True)
         self.assertEqual(response.status_code, 200)
-        mock_sync.assert_called_once()
+        self.assertTrue(NbIP.objects.filter(address__startswith="2001:db8::1/").exists())
         msgs = list(response.context["messages"])
         self.assertTrue(
             any(
@@ -873,14 +669,14 @@ class TestReservation6AddOptionDataAndSync(_ViewTestBase):
         )
 
     @patch("netbox_kea.views.reservations.sync_reservation_to_netbox")
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_sync_exception_shows_warning(self, MockKeaClient, mock_sync):
+    def test_post_sync_exception_shows_warning(self, mock_sync):
         """sync raises exception → warning message queued (reservation still created)."""
-        MockKeaClient.return_value.reservation_add.return_value = None
-        MockKeaClient.return_value.reservation_get_page.return_value = ([], 0, 0)
         mock_sync.side_effect = ValueError("sync failed")
         post_data = {**_VALID_RESERVATION6_POST, "sync_to_netbox": "on"}
-        response = self.client.post(self._url(), post_data, follow=True)
+        with stub_kea(
+            {"subnet6-get": _subnet_get(6), "reservation-add": {"result": 0}, "reservation-get-page": _RES_EMPTY_PAGE}
+        ):
+            response = self.client.post(self._url(), post_data, follow=True)
         self.assertEqual(response.status_code, 200)
         mock_sync.assert_called_once()
         msgs = list(response.context["messages"])
@@ -959,7 +755,15 @@ class TestReservationSyncRequiresIpamPermission(_ViewTestBase):
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestReservation6EditOptionDataAndSync(_ViewTestBase):
-    """Lines 2292, 2307-2314, 2327-2334: Reservation6 edit with option-data and sync."""
+    """Reservation6 edit with option-data and sync-to-NetBox."""
+
+    _EXISTING = {
+        "subnet-id": 1,
+        "ip-addresses": ["2001:db8::1", "2001:db8::2"],
+        "duid": "00:01:00:01:12:34:56:78:aa:bb:cc:dd:ee:ff",
+        "hostname": "v6host",
+        "option-data": [],
+    }
 
     def _url(self):
         return reverse(
@@ -967,24 +771,12 @@ class TestReservation6EditOptionDataAndSync(_ViewTestBase):
             args=[self.server.pk, 1, "2001:db8::1"],
         )
 
-    def _mock_get(self, MockKeaClient):
-        MockKeaClient.return_value.reservation_get.return_value = {
-            "subnet-id": 1,
-            "ip-addresses": ["2001:db8::1", "2001:db8::2"],
-            "duid": "00:01:00:01:12:34:56:78:aa:bb:cc:dd:ee:ff",
-            "hostname": "v6host",
-            "option-data": [],
-        }
+    def test_post_with_option_data(self):
+        """option-data is included in the reservation-update payload when the formset has entries.
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_with_option_data(self, MockKeaClient):
-        """option-data is included in reservation_update payload when formset has entries.
-
-        Uses edit-shaped payload (no subnet_id/ip_addresses) and a two-address mock_get
-        to verify the multi-IP preserve path runs and both IPs are preserved.
+        Uses an edit-shaped payload (no subnet_id/ip_addresses) and a two-address existing
+        reservation to verify the multi-IP preserve path runs and both IPs are preserved.
         """
-        self._mock_get(MockKeaClient)
-        MockKeaClient.return_value.reservation_update.return_value = None
         post_data = {
             **_VALID_RESERVATION6_EDIT_POST,
             "options-TOTAL_FORMS": "1",
@@ -996,15 +788,11 @@ class TestReservation6EditOptionDataAndSync(_ViewTestBase):
             "options-0-always_send": "",
             "options-0-DELETE": "",
         }
-        response = self.client.post(self._url(), post_data)
+        with stub_kea({"reservation-get": _res_get(self._EXISTING), "reservation-update": {"result": 0}}) as kea:
+            response = self.client.post(self._url(), post_data)
         self.assertIn(response.status_code, (200, 302))
-        self.assertTrue(MockKeaClient.return_value.reservation_update.called)
-        call_args = MockKeaClient.return_value.reservation_update.call_args
-        reservation_dict = (
-            call_args[0][1]
-            if call_args[0] and len(call_args[0]) > 1
-            else (call_args.kwargs or {}).get("reservation", {})
-        )
+        self.assertEqual(kea.commands().count("reservation-update"), 1)
+        reservation_dict = kea.bodies("reservation-update")[0]["arguments"]["reservation"]
         # Both original IPs must be preserved (not collapsed to one).
         self.assertEqual(
             reservation_dict.get("ip-addresses"),
@@ -1016,17 +804,19 @@ class TestReservation6EditOptionDataAndSync(_ViewTestBase):
         self.assertIsNotNone(ntp_entry, "ntp-servers option not found in reservation option-data")
         self.assertEqual(ntp_entry["data"], "2001:db8::1:1")
 
-    @patch("netbox_kea.views.reservations.sync_reservation_to_netbox")
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_sync_success(self, MockKeaClient, mock_sync):
-        """sync_to_netbox=on → sync called once and info message queued."""
-        self._mock_get(MockKeaClient)
-        MockKeaClient.return_value.reservation_update.return_value = None
-        mock_sync.return_value = (MagicMock(spec=NbIP), False, False)
+    def test_post_sync_success(self):
+        """sync_to_netbox=on runs the real sync → info message queued."""
         post_data = {**_VALID_RESERVATION6_EDIT_POST, "sync_to_netbox": "on"}
-        response = self.client.post(self._url(), post_data, follow=True)
+        with stub_kea(
+            {
+                "reservation-get": _res_get(self._EXISTING),
+                "reservation-update": {"result": 0},
+                "reservation-get-page": _RES_EMPTY_PAGE,
+            }
+        ):
+            response = self.client.post(self._url(), post_data, follow=True)
         self.assertEqual(response.status_code, 200)
-        mock_sync.assert_called_once()
+        self.assertTrue(NbIP.objects.filter(address__startswith="2001:db8::1/").exists())
         msgs = list(response.context["messages"])
         self.assertTrue(
             any(m.level == django_messages.INFO for m in msgs),
@@ -1034,14 +824,18 @@ class TestReservation6EditOptionDataAndSync(_ViewTestBase):
         )
 
     @patch("netbox_kea.views.reservations.sync_reservation_to_netbox")
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_sync_exception(self, MockKeaClient, mock_sync):
+    def test_post_sync_exception(self, mock_sync):
         """sync exception → warning message queued (reservation still updated)."""
-        self._mock_get(MockKeaClient)
-        MockKeaClient.return_value.reservation_update.return_value = None
         mock_sync.side_effect = ValueError("sync fail")
         post_data = {**_VALID_RESERVATION6_EDIT_POST, "sync_to_netbox": "on"}
-        response = self.client.post(self._url(), post_data, follow=True)
+        with stub_kea(
+            {
+                "reservation-get": _res_get(self._EXISTING),
+                "reservation-update": {"result": 0},
+                "reservation-get-page": _RES_EMPTY_PAGE,
+            }
+        ):
+            response = self.client.post(self._url(), post_data, follow=True)
         self.assertEqual(response.status_code, 200)
         mock_sync.assert_called_once()
         msgs = list(response.context["messages"])
@@ -1050,83 +844,40 @@ class TestReservation6EditOptionDataAndSync(_ViewTestBase):
             f"Expected WARNING message on sync failure, got: {[(m.level, m.message) for m in msgs]}",
         )
 
-    @patch("netbox_kea.views.reservations.sync_reservation_to_netbox")
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_partial_persist_with_sync(self, MockKeaClient, mock_sync):
-        """Lines 2327-2334: PartialPersistError + sync success."""
-        from netbox_kea.kea import PartialPersistError
-
-        self._mock_get(MockKeaClient)
-        MockKeaClient.return_value.reservation_update.side_effect = PartialPersistError("dhcp6", Exception("write"))
-        mock_sync.return_value = (MagicMock(spec=NbIP), True, False)
-        post_data = {**_VALID_RESERVATION6_EDIT_POST, "sync_to_netbox": "on"}
-        response = self.client.post(self._url(), post_data, follow=True)
-        self.assertIn(response.status_code, (200, 302))
-        mock_sync.assert_called_once()
-        msgs = list(response.context["messages"])
-        self.assertTrue(
-            any(m.level == django_messages.WARNING for m in msgs),
-            f"Expected WARNING for config-write failure, got: {[(m.level, m.message) for m in msgs]}",
-        )
-
-    @patch("netbox_kea.views.reservations.sync_reservation_to_netbox")
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_partial_persist_with_sync_exception(self, MockKeaClient, mock_sync):
-        """Lines 2332-2334: PartialPersistError + sync exception → warning."""
-        from netbox_kea.kea import PartialPersistError
-
-        self._mock_get(MockKeaClient)
-        MockKeaClient.return_value.reservation_update.side_effect = PartialPersistError("dhcp6", Exception("write"))
-        mock_sync.side_effect = ValueError("db error")
-        post_data = {**_VALID_RESERVATION6_EDIT_POST, "sync_to_netbox": "on"}
-        response = self.client.post(self._url(), post_data, follow=True)
-        self.assertIn(response.status_code, (200, 302))
-        mock_sync.assert_called_once()
-        msgs = list(response.context["messages"])
-        self.assertTrue(
-            any("sync failed" in str(m).lower() for m in msgs),
-            f"Expected 'sync failed' warning, got: {[str(m) for m in msgs]}",
-        )
-
 
 # ---------------------------------------------------------------------------
-# _enrich_reservations_with_lease_status — edge cases (lines 1641, 1645, 1650, 1662-1663)
+# _enrich_reservations_with_lease_status — direct unit tests (real KeaClient)
 # ---------------------------------------------------------------------------
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestEnrichReservationsLeaseStatusCoverage(_ViewTestBase):
-    """_enrich_reservations_with_lease_status: direct unit tests for edge cases."""
+    """_enrich_reservations_with_lease_status: direct unit tests for edge cases.
+
+    These drive a real ``KeaClient`` (no DB needed) with the HTTP boundary stubbed;
+    ``clone()`` builds a fresh session in each worker thread, which the class-level
+    ``requests.Session.post`` patch also covers.
+    """
 
     def test_result3_returns_empty_list(self):
-        """lease-get-all result=3 → _fetch_leases_for_subnet returns [] → active lease not found."""
+        """lease-get-all result=3 → subnet confirmed empty → has_active_lease set False."""
         from netbox_kea.views import _enrich_reservations_with_lease_status
 
-        client = MagicMock(spec=KeaClient)
-        clone_mock = MagicMock(spec=KeaClient)
-        clone_mock.__enter__ = MagicMock(return_value=clone_mock)  # mock-ok: CM protocol stub
-        clone_mock.__exit__ = MagicMock(return_value=None)  # mock-ok: CM protocol stub
-        clone_mock.command.return_value = [{"result": 3, "arguments": {}}]
-        client.clone.return_value = clone_mock
         reservations = [{"ip-address": "10.0.0.1", "subnet-id": 42}]
-        # Should not raise; lease_cmds result=3 → empty list → no has_active_lease set
-        _enrich_reservations_with_lease_status(client, reservations, 4)
+        with stub_kea({"lease4-get-all": {"result": 3}}):
+            client = KeaClient(url="https://kea.example.com")
+            _enrich_reservations_with_lease_status(client, reservations, 4)
         # result=3 means empty — confirmed no active lease, so has_active_lease is set False
         self.assertFalse(reservations[0].get("has_active_lease", True))
 
     def test_kea_exception_non_result2_returns_empty(self):
-        """KeaException with result != 2 → subnet treated as indeterminate → has_active_lease unset."""
-        from netbox_kea.kea import KeaException
+        """A lease-get-all result != 2/3 → subnet treated as indeterminate → has_active_lease unset."""
         from netbox_kea.views import _enrich_reservations_with_lease_status
 
-        client = MagicMock(spec=KeaClient)
-        clone_mock = MagicMock(spec=KeaClient)
-        clone_mock.__enter__ = MagicMock(return_value=clone_mock)  # mock-ok: CM protocol stub
-        clone_mock.__exit__ = MagicMock(return_value=None)  # mock-ok: CM protocol stub
-        clone_mock.command.side_effect = KeaException({"result": 1, "text": "error"}, index=0)
-        client.clone.return_value = clone_mock
         reservations = [{"ip-address": "10.0.0.1", "subnet-id": 42}]
-        _enrich_reservations_with_lease_status(client, reservations, 4)
+        with stub_kea({"lease4-get-all": {"result": 1, "text": "error"}}):
+            client = KeaClient(url="https://kea.example.com")
+            _enrich_reservations_with_lease_status(client, reservations, 4)
         # result != 2 → subnet indeterminate → has_active_lease must remain unset
         self.assertNotIn("has_active_lease", reservations[0])
 
@@ -1134,23 +885,26 @@ class TestEnrichReservationsLeaseStatusCoverage(_ViewTestBase):
         """Reservations without subnet-id → unique_subnet_ids empty → enrichment returns early."""
         from netbox_kea.views import _enrich_reservations_with_lease_status
 
-        client = MagicMock(spec=KeaClient)
         reservations = [{"ip-address": "10.0.0.1"}]  # no subnet-id
-        _enrich_reservations_with_lease_status(client, reservations, 4)
-        # client.clone should never be called when there are no valid subnet-ids
-        client.clone.assert_not_called()
+        with stub_kea({}) as kea:
+            client = KeaClient(url="https://kea.example.com")
+            _enrich_reservations_with_lease_status(client, reservations, 4)
+        # No valid subnet-ids → no Kea traffic at all.
+        self.assertEqual(kea.commands(), [])
 
     def test_as_completed_exception_returns_early(self):
         """Exception from as_completed → outer except swallows it and enrichment returns early."""
         from netbox_kea.views import _enrich_reservations_with_lease_status
 
-        client = MagicMock(spec=KeaClient)
-        client.command.return_value = [{"result": 0, "arguments": {"leases": []}}]
         reservations = [{"ip-address": "10.0.0.1", "subnet-id": 42}]
-        with patch(
-            "netbox_kea.views.reservations.concurrent.futures.as_completed",
-            side_effect=RuntimeError("as_completed failed"),
-        ) as mock_as_completed:
+        with (
+            patch(
+                "netbox_kea.views.reservations.concurrent.futures.as_completed",
+                side_effect=RuntimeError("as_completed failed"),
+            ) as mock_as_completed,
+            stub_kea({"lease4-get-all": {"result": 3}}),
+        ):
+            client = KeaClient(url="https://kea.example.com")
             _enrich_reservations_with_lease_status(client, reservations, 4)
         # as_completed must have been reached (executor submitted tasks)
         mock_as_completed.assert_called_once()
@@ -1171,11 +925,10 @@ class TestWarnPoolReservationOverlapCoverage(_ViewTestBase):
         """Pool string without dash (CIDR notation) → IPNetwork path is taken."""
         from netbox_kea.views import _warn_pool_reservation_overlap
 
-        client = MagicMock(spec=KeaClient)
-        client.reservation_get_page.return_value = ([], 0, 0)
         request = self._make_request()
-        # Should not raise; CIDR pool path
-        _warn_pool_reservation_overlap(request, client, 4, subnet_id=1, pool_str="10.0.0.0/24")
+        with stub_kea({"reservation-get-page": _RES_EMPTY_PAGE}):
+            client = self.server.get_client(version=4)
+            _warn_pool_reservation_overlap(request, client, 4, subnet_id=1, pool_str="10.0.0.0/24")
         msgs = list(django_messages.get_messages(request))
         self.assertEqual(len(msgs), 0)
 
@@ -1183,13 +936,10 @@ class TestWarnPoolReservationOverlapCoverage(_ViewTestBase):
         """Host whose subnet-id doesn't match the requested subnet_id is skipped."""
         from netbox_kea.views import _warn_pool_reservation_overlap
 
-        client = MagicMock(spec=KeaClient)
-        # Return a host with subnet-id=999 (different from requested subnet_id=1)
-        client.reservation_get_page.side_effect = [
-            ([{"subnet-id": 999, "ip-address": "10.0.0.5"}], 0, 0),
-        ]
         request = self._make_request()
-        _warn_pool_reservation_overlap(request, client, 4, subnet_id=1, pool_str="10.0.0.0-10.0.0.100")
+        with stub_kea({"reservation-get-page": _res_page([{"subnet-id": 999, "ip-address": "10.0.0.5"}])}):
+            client = self.server.get_client(version=4)
+            _warn_pool_reservation_overlap(request, client, 4, subnet_id=1, pool_str="10.0.0.0-10.0.0.100")
         # host skipped → no warning
         msgs = list(django_messages.get_messages(request))
         self.assertEqual(len(msgs), 0)
@@ -1198,13 +948,10 @@ class TestWarnPoolReservationOverlapCoverage(_ViewTestBase):
         """Malformed IP address string is silently skipped (inner except path)."""
         from netbox_kea.views import _warn_pool_reservation_overlap
 
-        client = MagicMock(spec=KeaClient)
-        client.reservation_get_page.side_effect = [
-            ([{"subnet-id": 1, "ip-address": "NOT_AN_IP"}], 0, 0),
-        ]
         request = self._make_request()
-        # Should not raise; malformed IP is silently skipped
-        _warn_pool_reservation_overlap(request, client, 4, subnet_id=1, pool_str="10.0.0.0-10.0.0.100")
+        with stub_kea({"reservation-get-page": _res_page([{"subnet-id": 1, "ip-address": "NOT_AN_IP"}])}):
+            client = self.server.get_client(version=4)
+            _warn_pool_reservation_overlap(request, client, 4, subnet_id=1, pool_str="10.0.0.0-10.0.0.100")
         msgs = list(django_messages.get_messages(request))
         self.assertEqual(len(msgs), 0)
 
@@ -1222,46 +969,33 @@ class TestWarnReservationPoolOverlapCoverage(_ViewTestBase):
         """Pool entry with empty pool string is silently skipped."""
         from netbox_kea.views import _warn_reservation_pool_overlap
 
-        client = MagicMock(spec=KeaClient)
-        client.command.return_value = [
-            {
-                "result": 0,
-                "arguments": {"subnet4": [{"id": 1, "subnet": "10.0.0.0/24", "pools": [{"pool": ""}]}]},
-            }
-        ]
         request = self._make_request()
-        # Should not raise; empty pool string is skipped
-        _warn_reservation_pool_overlap(request, client, 4, subnet_id=1, ip_str="10.0.0.5")
+        with stub_kea({"subnet4-get": _subnet_get(4, pools=[""])}):
+            client = self.server.get_client(version=4)
+            _warn_reservation_pool_overlap(request, client, 4, subnet_id=1, ip_str="10.0.0.5")
         msgs = list(django_messages.get_messages(request))
         self.assertEqual(len(msgs), 0)
 
     def test_cidr_pool_creates_ipnetwork(self):
-        """Pool string without dash (CIDR notation) → IPNetwork path is taken."""
+        """Pool string without dash (CIDR notation) → IPNetwork path is taken; IP inside → warning."""
         from netbox_kea.views import _warn_reservation_pool_overlap
 
-        client = MagicMock(spec=KeaClient)
-        client.command.return_value = [
-            {
-                "result": 0,
-                "arguments": {"subnet4": [{"id": 1, "subnet": "10.0.0.0/24", "pools": [{"pool": "10.0.0.0/24"}]}]},
-            }
-        ]
         request = self._make_request()
-        # IP is in pool → warning issued; CIDR pool path (line 2571)
-        _warn_reservation_pool_overlap(request, client, 4, subnet_id=1, ip_str="10.0.0.5")
+        with stub_kea({"subnet4-get": _subnet_get(4, pools=["10.0.0.0/24"])}):
+            client = self.server.get_client(version=4)
+            _warn_reservation_pool_overlap(request, client, 4, subnet_id=1, ip_str="10.0.0.5")
         msgs = list(django_messages.get_messages(request))
         self.assertEqual(len(msgs), 1)
         self.assertEqual(msgs[0].level, django_messages.WARNING)
 
     def test_client_command_exception_swallowed(self):
-        """Exception from client.command is swallowed and no warning is issued."""
+        """A transport error from client.command is swallowed and no warning is issued."""
         from netbox_kea.views import _warn_reservation_pool_overlap
 
-        client = MagicMock(spec=KeaClient)
-        client.command.side_effect = req.RequestException("network failure")
         request = self._make_request()
-        # Should not raise; exception is swallowed
-        _warn_reservation_pool_overlap(request, client, 4, subnet_id=1, ip_str="10.0.0.5")
+        with stub_kea({"subnet4-get": req.RequestException("network failure")}):
+            client = self.server.get_client(version=4)
+            _warn_reservation_pool_overlap(request, client, 4, subnet_id=1, ip_str="10.0.0.5")
         msgs = list(django_messages.get_messages(request))
         self.assertEqual(len(msgs), 0)
 
@@ -1275,26 +1009,19 @@ class TestWarnReservationPoolOverlapCoverage(_ViewTestBase):
 class TestReservationMutationBareExcept(_ViewTestBase):
     """Reservation mutation handlers must not swallow programming errors via bare except Exception."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_attribute_error_from_add_propagates(self, MockKeaClient):
-        """An AttributeError from reservation_add must propagate (not become an error message)."""
-        MockKeaClient.return_value.reservation_add.side_effect = AttributeError("programming bug")
+    def test_attribute_error_from_add_propagates(self):
+        """An AttributeError raised at the Kea boundary during reservation-add must propagate."""
         url = reverse("plugins:netbox_kea:server_reservation4_add", args=[self.server.pk])
-        with self.assertRaises(AttributeError):
-            self.client.post(
-                url,
-                {
-                    **_VALID_RESERVATION4_POST,
-                },
-            )
+        with stub_kea({"subnet4-get": _subnet_get(4), "reservation-add": AttributeError("programming bug")}):
+            with self.assertRaises(AttributeError):
+                self.client.post(url, {**_VALID_RESERVATION4_POST})
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_attribute_error_from_v6_add_propagates(self, MockKeaClient):
-        """An AttributeError from reservation_add (v6) must propagate."""
-        MockKeaClient.return_value.reservation_add.side_effect = AttributeError("programming bug")
+    def test_attribute_error_from_v6_add_propagates(self):
+        """An AttributeError raised at the Kea boundary during reservation-add (v6) must propagate."""
         url = reverse("plugins:netbox_kea:server_reservation6_add", args=[self.server.pk])
-        with self.assertRaises(AttributeError):
-            self.client.post(url, {**_VALID_RESERVATION6_POST})
+        with stub_kea({"subnet6-get": _subnet_get(6), "reservation-add": AttributeError("programming bug")}):
+            with self.assertRaises(AttributeError):
+                self.client.post(url, {**_VALID_RESERVATION6_POST})
 
 
 # ---------------------------------------------------------------------------
@@ -1340,17 +1067,12 @@ class TestReservationAddFormIPCheckWiring(_ViewTestBase):
         self.assertIn("Promise.all", body)
         self.assertNotIn('split(",")[0]', body)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_edit_form_omits_blur_script(self, MockKeaClient):
+    def test_edit_form_omits_blur_script(self):
         """Edit mode disables the IP field, so the advisory script must not attach."""
-        MockKeaClient.return_value.reservation_get.return_value = {
-            "hw-address": "aa:bb:cc:dd:ee:ff",
-            "ip-address": "10.0.0.55",
-            "subnet-id": 1,
-        }
-        MockKeaClient.return_value.lease_get_by_ip.return_value = None
+        existing = {"hw-address": "aa:bb:cc:dd:ee:ff", "ip-address": "10.0.0.55", "subnet-id": 1}
         url = reverse("plugins:netbox_kea:server_reservation4_edit", args=[self.server.pk, 1, "10.0.0.55"])
-        body = self.client.get(url).content.decode()
+        with stub_kea({"reservation-get": _res_get(existing), "lease4-get": _LEASE_NOT_FOUND}):
+            body = self.client.get(url).content.decode()
         check_url = reverse("plugins:netbox_kea:reservation_check_ip", args=[self.server.pk])
         self.assertNotIn('addEventListener("blur"', body)
         self.assertNotIn(check_url, body)

--- a/netbox_kea/tests/test_views_server.py
+++ b/netbox_kea/tests/test_views_server.py
@@ -31,7 +31,43 @@ from django.urls import reverse
 
 from netbox_kea.models import Server
 
-from .utils import _PLUGINS_CONFIG, User, _kea_command_side_effect, _make_db_server, _ViewTestBase
+from .kea_stub import stub_kea
+from .utils import _PLUGINS_CONFIG, User, _make_db_server, _ViewTestBase
+
+# ---------------------------------------------------------------------------
+# Kea response builders (real KeaClient + HTTP-boundary stub)
+# ---------------------------------------------------------------------------
+#
+# Server.clean() runs a live connectivity check (``version-get`` per enabled
+# service), and the status view issues ``status-get`` + ``version-get`` per
+# daemon (CA-level = no service; DHCP = service=["dhcp{v}"]) plus ``config-get``
+# for the global-options block. The stub keys by command name only, so where a
+# test needs CA-vs-service-specific responses it registers a callable
+# ``(body) -> payload`` that branches on ``body.get("service")``.
+
+_VERSION_OK = {"result": 0, "arguments": {"extended": "3.0.3"}}
+
+
+def _ok_status(**args):
+    """A ``status-get`` payload (result 0) with sensible daemon defaults."""
+    base = {"pid": 1234, "uptime": 3600, "reload": 0}
+    base.update(args)
+    return {"result": 0, "arguments": base}
+
+
+def _config_get_empty(body):
+    """A ``config-get`` payload with no global option-data, for the queried service."""
+    svc = (body.get("service") or [""])[0]
+    version = 6 if svc == "dhcp6" else 4
+    key = f"Dhcp{version}"
+    return {"result": 0, "arguments": {key: {"option-data": [], f"subnet{version}": [], "shared-networks": []}}}
+
+
+def _status_stub(**overrides):
+    """Stub the happy-path status view: status-get + version-get + config-get."""
+    base = {"status-get": _ok_status(), "version-get": _VERSION_OK, "config-get": _config_get_empty}
+    base.update(overrides)
+    return stub_kea(base)
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
@@ -119,45 +155,40 @@ class TestServerAddView(_ViewTestBase):
         self._assert_no_none_pk_redirect(response)
         self.assertNotIn(b"servers/None", response.content)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_valid_data_redirects_to_integer_pk(self, MockKeaClient):
+    def test_post_valid_data_redirects_to_integer_pk(self):
         """Successful server creation must redirect to servers/<int:pk>/, never /servers/None/."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.side_effect = _kea_command_side_effect
-
+        # Server.clean() runs a live version-get connectivity check on the enabled service.
         url = reverse("plugins:netbox_kea:server_add")
-        response = self.client.post(
-            url,
-            {
-                "name": "new-valid-server",
-                "ca_url": "https://kea.new.example.com",
-                "dhcp4": True,
-                "dhcp6": False,
-                "ssl_verify": True,
-                "has_control_agent": True,
-            },
-        )
+        with stub_kea({"version-get": _VERSION_OK}):
+            response = self.client.post(
+                url,
+                {
+                    "name": "new-valid-server",
+                    "ca_url": "https://kea.new.example.com",
+                    "dhcp4": True,
+                    "dhcp6": False,
+                    "ssl_verify": True,
+                    "has_control_agent": True,
+                },
+            )
         self.assertEqual(response.status_code, 302)
         self._assert_redirect_to_integer_pk(response)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_valid_server_is_saved_to_db(self, MockKeaClient):
+    def test_post_valid_server_is_saved_to_db(self):
         """After successful add, the Server object must exist in the DB."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.side_effect = _kea_command_side_effect
-
         url = reverse("plugins:netbox_kea:server_add")
-        self.client.post(
-            url,
-            {
-                "name": "saved-server",
-                "ca_url": "https://kea.saved.example.com",
-                "dhcp4": True,
-                "dhcp6": False,
-                "ssl_verify": True,
-                "has_control_agent": True,
-            },
-        )
+        with stub_kea({"version-get": _VERSION_OK}):
+            self.client.post(
+                url,
+                {
+                    "name": "saved-server",
+                    "ca_url": "https://kea.saved.example.com",
+                    "dhcp4": True,
+                    "dhcp6": False,
+                    "ssl_verify": True,
+                    "has_control_agent": True,
+                },
+            )
         self.assertTrue(Server.objects.filter(name="saved-server").exists())
 
 
@@ -187,24 +218,21 @@ class TestServerEditView(_ViewTestBase):
         self.assertEqual(response.status_code, 200)
         self._assert_no_none_pk_redirect(response)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_valid_edit_redirects_to_same_server(self, MockKeaClient):
+    def test_post_valid_edit_redirects_to_same_server(self):
         """Successful edit must redirect to the same server's detail URL."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.side_effect = _kea_command_side_effect
-
         url = reverse("plugins:netbox_kea:server_edit", args=[self.server.pk])
-        response = self.client.post(
-            url,
-            {
-                "name": self.server.name,
-                "ca_url": "https://kea.edited.example.com",
-                "dhcp4": True,
-                "dhcp6": False,
-                "ssl_verify": True,
-                "has_control_agent": True,
-            },
-        )
+        with stub_kea({"version-get": _VERSION_OK}):
+            response = self.client.post(
+                url,
+                {
+                    "name": self.server.name,
+                    "ca_url": "https://kea.edited.example.com",
+                    "dhcp4": True,
+                    "dhcp6": False,
+                    "ssl_verify": True,
+                    "has_control_agent": True,
+                },
+            )
         self.assertEqual(response.status_code, 302)
         self._assert_redirect_to_integer_pk(response)
         # Must redirect to THIS server's pk, not some other.
@@ -244,24 +272,18 @@ class TestServerDeleteView(_ViewTestBase):
 class TestServerStatusView(_ViewTestBase):
     """GET /plugins/kea/servers/<pk>/status/"""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_returns_200(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.command.side_effect = _kea_command_side_effect
-
+    def test_get_returns_200(self):
         url = reverse("plugins:netbox_kea:server_status", args=[self.server.pk])
-        response = self.client.get(url)
+        with _status_stub():
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_without_control_agent_returns_200(self, MockKeaClient):
+    def test_get_without_control_agent_returns_200(self):
         """Status view with has_control_agent=False must still return 200."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.side_effect = _kea_command_side_effect
-
         server = _make_db_server(name="direct-daemon", has_control_agent=False)
         url = reverse("plugins:netbox_kea:server_status", args=[server.pk])
-        response = self.client.get(url)
+        with _status_stub():
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
     def test_get_nonexistent_returns_404(self):
@@ -297,40 +319,38 @@ class TestServerBulkImportView(_ViewTestBase):
         self.assertEqual(response.status_code, 302)
         self.assertIn("login", response.url)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_valid_csv_creates_server(self, MockKeaClient):
+    def test_post_valid_csv_creates_server(self):
         """Valid CSV must create the server and redirect."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.side_effect = _kea_command_side_effect
-
+        # Server.clean() runs a live version-get connectivity check per imported row.
         url = reverse("plugins:netbox_kea:server_bulk_import")
         csv_data = (
             "name,ca_url,dhcp4,dhcp6,ssl_verify,has_control_agent\r\n"
             "import-test-server,https://import.example.com,true,false,true,false\r\n"
         )
-        response = self.client.post(
-            url,
-            {"data": csv_data, "format": "csv", "csv_delimiter": ","},
-        )
+        with stub_kea({"version-get": _VERSION_OK}):
+            response = self.client.post(
+                url,
+                {"data": csv_data, "format": "csv", "csv_delimiter": ","},
+            )
         # Either 200 (results page) or 302 (redirect on success)
         self.assertIn(response.status_code, [200, 302])
         self.assertTrue(Server.objects.filter(name="import-test-server").exists())
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_duplicate_name_returns_error_not_500(self, MockKeaClient):
+    def test_post_duplicate_name_returns_error_not_500(self):
         """Duplicate server name must re-render the form with errors, not 500.
 
-        KeaClient is mocked to guard against future regressions where the unique
-        constraint fires *after* clean() runs (which would attempt a live connection).
+        The real clean() connectivity check (version-get) runs first, then the unique
+        constraint on name fires — this guards against a regression where the constraint
+        error would surface as a 500 instead of a form error.
         """
         url = reverse("plugins:netbox_kea:server_bulk_import")
         # setUp() already created a server named 'test-kea'
         csv_data = "name,ca_url,dhcp4,dhcp6\r\ntest-kea,https://dup.example.com,true,false\r\n"
-        MockKeaClient.return_value.command.side_effect = _kea_command_side_effect
-        response = self.client.post(
-            url,
-            {"data": csv_data, "format": "csv", "csv_delimiter": ","},
-        )
+        with stub_kea({"version-get": _VERSION_OK}):
+            response = self.client.post(
+                url,
+                {"data": csv_data, "format": "csv", "csv_delimiter": ","},
+            )
         self.assertIn(response.status_code, [200, 400])
         # Only one server with this name must exist
         self.assertEqual(Server.objects.filter(name="test-kea").count(), 1)
@@ -360,40 +380,43 @@ _CONFIG_WITH_OPTIONS_V4 = {
 }
 
 
-def _kea_command_with_global_options(cmd, service=None, arguments=None, check=None):
-    """Mock side-effect that includes option-data in config-get."""
-    if cmd == "status-get":
-        return [{"result": 0, "arguments": {"pid": 1, "uptime": 100, "reload": 0}}]
-    if cmd == "version-get":
-        return [{"result": 0, "arguments": {"extended": "2.4.1"}}]
-    if cmd == "config-get":
-        if service and service[0] == "dhcp6":
-            return [
-                {
-                    "result": 0,
-                    "arguments": {
-                        "Dhcp6": {
-                            "option-data": [{"code": 23, "name": "dns-servers", "data": "2001:db8::1"}],
-                            "subnet6": [],
-                            "shared-networks": [],
-                        }
-                    },
+def _config_get_with_options(body):
+    """A ``config-get`` payload carrying global option-data for the queried service."""
+    svc = (body.get("service") or [""])[0]
+    if svc == "dhcp6":
+        return {
+            "result": 0,
+            "arguments": {
+                "Dhcp6": {
+                    "option-data": [{"code": 23, "name": "dns-servers", "data": "2001:db8::1"}],
+                    "subnet6": [],
+                    "shared-networks": [],
                 }
-            ]
-        return [{"result": 0, "arguments": {"Dhcp4": _CONFIG_WITH_OPTIONS_V4}}]
-    return [{"result": 0, "arguments": {}}]
+            },
+        }
+    return {"result": 0, "arguments": {"Dhcp4": _CONFIG_WITH_OPTIONS_V4}}
+
+
+def _global_options_stub(**overrides):
+    """Status view stub whose config-get exposes global option-data (v2.4.1 daemon)."""
+    base = {
+        "status-get": {"result": 0, "arguments": {"pid": 1, "uptime": 100, "reload": 0}},
+        "version-get": {"result": 0, "arguments": {"extended": "2.4.1"}},
+        "config-get": _config_get_with_options,
+    }
+    base.update(overrides)
+    return stub_kea(base)
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestServerStatusGlobalOptions(_ViewTestBase):
     """Status view must render global DHCP options extracted from ``config-get``."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_global_options_present_in_context(self, MockKeaClient):
+    def test_global_options_present_in_context(self):
         """``global_options`` context key must exist and contain parsed option dicts."""
-        MockKeaClient.return_value.command.side_effect = _kea_command_with_global_options
         url = reverse("plugins:netbox_kea:server_status", args=[self.server.pk])
-        response = self.client.get(url)
+        with _global_options_stub():
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertIn("global_options", response.context)
         opts = response.context["global_options"]
@@ -403,35 +426,26 @@ class TestServerStatusGlobalOptions(_ViewTestBase):
         self.assertIn("Dns Servers", opts.get("DHCPv4", {}))
         self.assertEqual(opts.get("DHCPv4", {}).get("Dns Servers"), "8.8.8.8, 8.8.4.4")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_global_options_dns_rendered_in_html(self, MockKeaClient):
+    def test_global_options_dns_rendered_in_html(self):
         """DNS server IP must appear somewhere in the rendered status page."""
-        MockKeaClient.return_value.command.side_effect = _kea_command_with_global_options
         url = reverse("plugins:netbox_kea:server_status", args=[self.server.pk])
-        response = self.client.get(url)
+        with _global_options_stub():
+            response = self.client.get(url)
         self.assertContains(response, "8.8.8.8")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_global_options_domain_name_rendered(self, MockKeaClient):
+    def test_global_options_domain_name_rendered(self):
         """Domain name option must also appear in the status page HTML."""
-        MockKeaClient.return_value.command.side_effect = _kea_command_with_global_options
         url = reverse("plugins:netbox_kea:server_status", args=[self.server.pk])
-        response = self.client.get(url)
+        with _global_options_stub():
+            response = self.client.get(url)
         self.assertContains(response, "example.com")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_status_still_200_when_config_get_fails(self, MockKeaClient):
+    def test_status_still_200_when_config_get_fails(self):
         """If ``config-get`` raises, the status page must still return 200 (graceful degradation)."""
-        from netbox_kea.kea import KeaException
-
-        def side_effect(cmd, service=None, arguments=None, check=None):
-            if cmd == "config-get":
-                raise KeaException({"result": 1, "text": "internal error"}, index=0)
-            return _kea_command_with_global_options(cmd, service=service)
-
-        MockKeaClient.return_value.command.side_effect = side_effect
+        # config-get result 1 → real KeaException → _get_global_options swallows it → {}.
         url = reverse("plugins:netbox_kea:server_status", args=[self.server.pk])
-        response = self.client.get(url)
+        with _global_options_stub(**{"config-get": {"result": 1, "text": "internal error"}}):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["global_options"], {})
 
@@ -593,44 +607,36 @@ class TestStatusViewNullArgs(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_status", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_ca_status_empty_args_degrades_gracefully(self, MockKeaClient):
+    def test_get_ca_status_empty_args_degrades_gracefully(self):
         """_get_ca_status degrades gracefully when arguments is empty."""
 
-        def _side(cmd, service=None, **kwargs):
-            if cmd == "status-get" and (not service or "dhcp" not in service[0]):
-                return [{"result": 0, "arguments": {}}]  # empty → falsy
-            if cmd == "version-get" and (not service or "dhcp" not in service[0]):
-                return [{"result": 0, "arguments": {"extended": "2.0"}}]
-            if cmd == "status-get":
-                return [{"result": 0, "arguments": {"pid": 1, "uptime": 0, "reload": 0}}]
-            if cmd == "version-get":
-                return [{"result": 0, "arguments": {"extended": "2.0"}}]
-            return [{"result": 0, "arguments": {}}]
+        def _status(body):
+            svc = body.get("service")
+            if not svc or "dhcp" not in svc[0]:
+                return {"result": 0, "arguments": {}}  # CA → empty → RuntimeError
+            return {"result": 0, "arguments": {"pid": 1, "uptime": 0, "reload": 0}}
 
-        MockKeaClient.return_value.command.side_effect = _side
+        stub = {"status-get": _status, "version-get": {"result": 0, "arguments": {"extended": "2.0"}}}
         # The view catches exceptions from _get_ca_status; page still renders with empty statuses
-        response = self.client.get(self._url())
+        with _status_stub(**stub):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         services_by_name = {s["name"]: s for s in response.context["services"]}
         if "Control Agent" in services_by_name:
             self.assertEqual(services_by_name["Control Agent"]["status_data"], {})
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_dhcp_status_null_args_degrades_gracefully(self, MockKeaClient):
+    def test_get_dhcp_status_null_args_degrades_gracefully(self):
         """_get_dhcp_status degrades gracefully when arguments is None."""
 
-        def _side(cmd, service=None, **kwargs):
-            if cmd == "status-get" and service and "dhcp" in service[0]:
-                return [{"result": 0, "arguments": None}]
-            if cmd == "status-get":
-                return [{"result": 0, "arguments": {"pid": 1, "uptime": 0, "reload": 0}}]
-            if cmd == "version-get":
-                return [{"result": 0, "arguments": {"extended": "2.0"}}]
-            return [{"result": 0, "arguments": {}}]
+        def _status(body):
+            svc = body.get("service")
+            if svc and "dhcp" in svc[0]:
+                return {"result": 0, "arguments": None}  # dhcp → None → RuntimeError
+            return {"result": 0, "arguments": {"pid": 1, "uptime": 0, "reload": 0}}
 
-        MockKeaClient.return_value.command.side_effect = _side
-        response = self.client.get(self._url())
+        stub = {"status-get": _status, "version-get": {"result": 0, "arguments": {"extended": "2.0"}}}
+        with _status_stub(**stub):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         # When arguments is None, _get_dhcp_status raises RuntimeError and the view
         # falls back to empty status_data — the service entry must still exist.
@@ -642,39 +648,34 @@ class TestStatusViewNullArgs(_ViewTestBase):
             "DHCPv4 status_data must be empty/degraded when arguments is None",
         )
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_dhcp_status_ha_fields_included(self, MockKeaClient):
-        """Lines 370-373: HA fields are present when high-availability in status-get."""
+    def test_get_dhcp_status_ha_fields_included(self):
+        """HA fields are present when high-availability is in status-get."""
 
-        def _side(cmd, service=None, **kwargs):
-            if cmd == "status-get" and service and "dhcp" in service[0]:
-                return [
-                    {
-                        "result": 0,
-                        "arguments": {
-                            "pid": 1,
-                            "uptime": 100,
-                            "reload": 0,
-                            "high-availability": [
-                                {
-                                    "ha-mode": "load-balancing",
-                                    "ha-servers": {
-                                        "local": {"role": "primary", "state": "active"},
-                                        "remote": {"connection-interrupted": False, "age": 10, "role": "secondary"},
-                                    },
-                                }
-                            ],
-                        },
-                    }
-                ]
-            if cmd == "status-get":
-                return [{"result": 0, "arguments": {"pid": 1, "uptime": 100, "reload": 0}}]
-            if cmd == "version-get":
-                return [{"result": 0, "arguments": {"extended": "2.4.1"}}]
-            return [{"result": 0, "arguments": {}}]
+        def _status(body):
+            svc = body.get("service")
+            if svc and "dhcp" in svc[0]:
+                return {
+                    "result": 0,
+                    "arguments": {
+                        "pid": 1,
+                        "uptime": 100,
+                        "reload": 0,
+                        "high-availability": [
+                            {
+                                "ha-mode": "load-balancing",
+                                "ha-servers": {
+                                    "local": {"role": "primary", "state": "active"},
+                                    "remote": {"connection-interrupted": False, "age": 10, "role": "secondary"},
+                                },
+                            }
+                        ],
+                    },
+                }
+            return {"result": 0, "arguments": {"pid": 1, "uptime": 100, "reload": 0}}
 
-        MockKeaClient.return_value.command.side_effect = _side
-        response = self.client.get(self._url())
+        stub = {"status-get": _status, "version-get": {"result": 0, "arguments": {"extended": "2.4.1"}}}
+        with _status_stub(**stub):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "HA")
 
@@ -691,21 +692,16 @@ class TestGetGlobalOptionsGenericException(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_status", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_generic_exception_swallowed(self, MockKeaClient):
-        """Generic exception in config-get for global options is swallowed and the page renders normally."""
-
-        def _side(cmd, service=None, **kwargs):
-            if cmd == "config-get":
-                raise requests.RequestException("unexpected crash")
-            if cmd == "status-get":
-                return [{"result": 0, "arguments": {"pid": 1, "uptime": 0, "reload": 0}}]
-            if cmd == "version-get":
-                return [{"result": 0, "arguments": {"extended": "2.0"}}]
-            return [{"result": 0, "arguments": {}}]
-
-        MockKeaClient.return_value.command.side_effect = _side
-        response = self.client.get(self._url())
+    def test_generic_exception_swallowed(self):
+        """A transport error in config-get for global options is swallowed; the page renders normally."""
+        # config-get raises a transport error at the boundary → _get_global_options swallows it → {}.
+        stub = {
+            "status-get": {"result": 0, "arguments": {"pid": 1, "uptime": 0, "reload": 0}},
+            "version-get": {"result": 0, "arguments": {"extended": "2.0"}},
+            "config-get": requests.RequestException("unexpected crash"),
+        }
+        with stub_kea(stub):
+            response = self.client.get(self._url())
         # Exception in get_extra_context() is caught by the outer try/except in get_extra_context;
         # the page must still render as 200 (degraded state, not 500).
         self.assertEqual(response.status_code, 200)
@@ -721,8 +717,7 @@ class TestGetGlobalOptionsGenericException(_ViewTestBase):
 class TestBulkDeletePermission(_ViewTestBase):
     """Line 800: POST without bulk_delete_lease_from_server permission returns 403."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_user_without_bulk_delete_perm_gets_403(self, MockKeaClient):
+    def test_user_without_bulk_delete_perm_gets_403(self):
         from users.models import ObjectPermission
 
         # Grant view-only ObjectPermission so get_object() succeeds
@@ -734,9 +729,11 @@ class TestBulkDeletePermission(_ViewTestBase):
         view_op.object_types.add(ct)
         self.client.force_login(viewer)
         url = reverse("plugins:netbox_kea:server_leases4_delete", args=[self.server.pk])
-        # User can view the server but has no bulk_delete_lease_from_server perm
-        response = self.client.post(url, {"pk": ["10.0.0.1"], "confirm": "1"})
+        # Permission check returns 403 before any Kea traffic.
+        with stub_kea({}) as kea:
+            response = self.client.post(url, {"pk": ["10.0.0.1"], "confirm": "1"})
         self.assertEqual(response.status_code, 403)
+        self.assertEqual(kea.commands(), [])
 
 
 # ---------------------------------------------------------------------------
@@ -779,39 +776,20 @@ class TestKeaChangeMixinNoPk(_ViewTestBase):
 class TestStatusViewNullVersionArgs(_ViewTestBase):
     """Lines 323, 357: version-get returns None arguments → RuntimeError caught internally."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_ca_version_get_null_args_returns_200(self, MockKeaClient):
-        """Line 323: CA version-get returns None args → RuntimeError caught in get_extra_context."""
-        mock_client = MockKeaClient.return_value
-
-        def _side_effect(cmd, service=None, arguments=None, check=None):
-            if cmd == "status-get":
-                return [{"result": 0, "arguments": {"pid": 1, "uptime": 60, "reload": 0}}]
-            if cmd == "version-get":
-                return [{"result": 0, "arguments": None}]
-            return [{"result": 0, "arguments": {}}]
-
-        mock_client.command.side_effect = _side_effect
+    def test_ca_version_get_null_args_returns_200(self):
+        """CA version-get returns None args → RuntimeError caught in get_extra_context."""
+        stub = {"status-get": _ok_status(uptime=60), "version-get": {"result": 0, "arguments": None}}
         url = reverse("plugins:netbox_kea:server_status", args=[self.server.pk])
-        response = self.client.get(url)
+        with _status_stub(**stub):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         services_by_name = {s["name"]: s for s in response.context["services"]}
         if "Control Agent" in services_by_name:
             self.assertEqual(services_by_name["Control Agent"]["status_data"], {})
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_dhcp_version_get_null_args_returns_200(self, MockKeaClient):
-        """Line 357: DHCP service version-get returns None args → RuntimeError caught."""
-        mock_client = MockKeaClient.return_value
-
-        def _side_effect(cmd, service=None, arguments=None, check=None):
-            if cmd == "status-get":
-                return [{"result": 0, "arguments": {"pid": 1, "uptime": 60, "reload": 0}}]
-            if cmd == "version-get":
-                return [{"result": 0, "arguments": None}]
-            return [{"result": 0, "arguments": {}}]
-
-        mock_client.command.side_effect = _side_effect
+    def test_dhcp_version_get_null_args_returns_200(self):
+        """DHCP service version-get returns None args → RuntimeError caught."""
+        stub = {"status-get": _ok_status(uptime=60), "version-get": {"result": 0, "arguments": None}}
         server_dhcp_only = _make_db_server(
             name="dhcp-only-sv",
             has_control_agent=False,
@@ -819,5 +797,6 @@ class TestStatusViewNullVersionArgs(_ViewTestBase):
             dhcp6=False,
         )
         url = reverse("plugins:netbox_kea:server_status", args=[server_dhcp_only.pk])
-        response = self.client.get(url)
+        with _status_stub(**stub):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)

--- a/netbox_kea/tests/test_views_shared_networks.py
+++ b/netbox_kea/tests/test_views_shared_networks.py
@@ -1,49 +1,53 @@
 # SPDX-FileCopyrightText: 2025 Marcin Zieba <marcinpsk@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
-"""View tests for netbox_kea plugin.
+"""Shared-network view tests for the netbox_kea plugin.
 
-Also contains pure-Python unit tests for helper functions defined in views.py
-(e.g. ``_extract_identifier``), which do not require a database but live here
-because they are tightly coupled to view logic.
+Covers the views in ``netbox_kea/views/shared_networks.py`` (the read-only
+shared-networks list tabs plus the add / delete / edit views).
 
-These tests verify correct HTTP responses and redirect behaviour for every view.
-All Kea HTTP calls are mocked so no running Kea instance is required.
+These tests drive the **real** ``KeaClient``; only the HTTP boundary is stubbed
+via ``kea_stub.stub_kea``, so the request payloads the views actually send to Kea
+are exercised and can be asserted on.
 
-Test organisation strategy
---------------------------
-Each view class gets its own ``TestCase`` subclass so failures are isolated and
-clearly named.  Every test that triggers a redirect asserts that the redirect URL
-contains an *integer* pk (never the string "None"), which is the pattern that
-revealed the original ``POST /plugins/kea/servers/None`` 404 bug.
+Command chains (all issued through the real client):
 
-View tests use ``django.test.TestCase`` because they write to the test database
-(user + server fixtures).  Server objects are created via ``Server.objects.create()``
-which does **not** call ``Model.clean()`` and therefore does not trigger live Kea
-connectivity checks.
+* **list** (``ServerSharedNetworks{4,6}View``): a single ``config-get`` per GET.
+* **add** (``network_add``): ``network{v}-add`` then ``_persist_config``
+  (``config-get`` → ``config-test`` → ``config-write``; ``persist_config``
+  defaults True).
+* **delete** (``network_del``): ``network{v}-del`` then the same persist chain.
+* **edit** (``network_update``): the POST first reloads the network via
+  ``config-get`` (``_fetch_network``), then ``network_update`` runs a
+  read-modify-write cycle ``config-get`` → ``config-test`` → ``config-set`` →
+  ``config-write``. There is no free ``network{v}-update`` hook, so the option
+  payload is asserted on the **config-set body** (``_written_sn``), which proves
+  the version, network, and option-data end to end.
+
+Error paths are driven through the real client:
+
+* ``KeaException`` ← a mutation command returns ``{"result": 1}``;
+* ``KeaConfigTestError`` (a ``KeaException`` subclass) ← ``config-test`` returns
+  result 1 during ``network_update``;
+* ``PartialPersistError`` ← ``config-write`` returns result 1 on a persisting op;
+* transport error ← the failing command is registered as a
+  ``requests.RequestException`` instance (raised at the HTTP boundary).
 """
 
-from unittest.mock import patch
+import copy
 
+import requests
 from django.contrib import messages as django_messages
 from django.test import override_settings
 from django.urls import reverse
 
-from .utils import _PLUGINS_CONFIG, _kea_command_side_effect, _make_db_server, _ViewTestBase
+from .kea_stub import queued, stub_kea
+from .utils import _PLUGINS_CONFIG, _make_db_server, _ViewTestBase
 
-_CONFIG4_WITH_PROD_NET = [
-    {
-        "result": 0,
-        "arguments": {"Dhcp4": {"shared-networks": [{"name": "prod-net", "option-data": [], "subnet4": []}]}},
-    }
-]
+_CONFIG_OK = {"result": 0}
 
-# Config-get response with "prod-net6" shared-network (for SharedNetworkEditView v6 POST tests)
-_CONFIG6_WITH_PROD_NET = [
-    {
-        "result": 0,
-        "arguments": {"Dhcp6": {"shared-networks": [{"name": "prod-net6", "option-data": [], "subnet6": []}]}},
-    }
-]
+# ---------------------------------------------------------------------------
+# config-get fixtures for the shared-networks LIST views
+# ---------------------------------------------------------------------------
 
 _SHARED_NETWORKS_CONFIG_V4 = [
     {
@@ -86,6 +90,68 @@ _SHARED_NETWORKS_CONFIG_V6 = [
     }
 ]
 
+# A config with an empty shared-networks list (used by not-found / abort paths).
+_EMPTY_SN_CONFIG_V4 = [{"result": 0, "arguments": {"Dhcp4": {"subnet4": [], "shared-networks": []}}}]
+
+
+# ---------------------------------------------------------------------------
+# Stub builders (real KeaClient + HTTP-boundary stub)
+# ---------------------------------------------------------------------------
+
+
+def _sn_config(version=4, name="prod-net", description="", option_data=None, subnets=None):
+    """config-get payload exposing a single shared network under ``Dhcp{version}``."""
+    subnet_key = f"subnet{version}"
+    network: dict = {"name": name, "description": description, subnet_key: list(subnets or [])}
+    if option_data is not None:
+        network["option-data"] = option_data
+    return [{"result": 0, "arguments": {f"Dhcp{version}": {"shared-networks": [network], subnet_key: []}}}]
+
+
+def _mutate_stub(command, response=_CONFIG_OK, **overrides):
+    """Stub a ``network{v}-add``/``-del`` mutation plus its ``_persist_config`` chain.
+
+    ``network_add``/``network_del`` issue the mutation command then
+    ``_persist_config`` (``config-get`` → ``config-test`` → ``config-write``,
+    because ``persist_config`` defaults True). When *response* carries an error
+    (or is an exception), the mutation raises before persistence, so the persist
+    registrations simply go unused.
+    """
+    base = {
+        command: response,
+        "config-get": [{"result": 0, "arguments": {}}],
+        "config-test": _CONFIG_OK,
+        "config-write": _CONFIG_OK,
+    }
+    base.update(overrides)
+    return stub_kea(base)
+
+
+def _edit_stub(config_get, **overrides):
+    """Stub the shared-network edit read-modify-write chain.
+
+    The edit POST reloads the network via ``_fetch_network`` (``config-get``),
+    then ``network_update`` runs ``config-get`` → ``config-test`` → ``config-set``
+    → ``config-write``. *config_get* is deep-copied because ``network_update``
+    mutates the fetched config in place; assert on the resulting config-set body
+    via :func:`_written_sn`.
+    """
+    base = {
+        "config-get": copy.deepcopy(config_get),
+        "config-test": _CONFIG_OK,
+        "config-set": _CONFIG_OK,
+        "config-write": _CONFIG_OK,
+    }
+    base.update(overrides)
+    return stub_kea(base)
+
+
+def _written_sn(kea, version=4):
+    """Return the shared-network dict ``network_update`` pushed back via config-set."""
+    bodies = kea.bodies("config-set")
+    assert bodies, "config-set was never issued (network_update did not complete)"
+    return bodies[0]["arguments"][f"Dhcp{version}"]["shared-networks"][0]
+
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestServerSharedNetworks4View(_ViewTestBase):
@@ -94,52 +160,44 @@ class TestServerSharedNetworks4View(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_shared_networks4", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_returns_200(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = _SHARED_NETWORKS_CONFIG_V4
-        response = self.client.get(self._url())
+    def test_get_returns_200(self):
+        with stub_kea({"config-get": _SHARED_NETWORKS_CONFIG_V4}) as kea:
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(kea.commands(), ["config-get"])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_shows_shared_network_name(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = _SHARED_NETWORKS_CONFIG_V4
-        response = self.client.get(self._url())
+    def test_shows_shared_network_name(self):
+        with stub_kea({"config-get": _SHARED_NETWORKS_CONFIG_V4}):
+            response = self.client.get(self._url())
         self.assertContains(response, "net-alpha")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_shows_subnet_count(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = _SHARED_NETWORKS_CONFIG_V4
-        response = self.client.get(self._url())
+    def test_shows_subnet_count(self):
+        with stub_kea({"config-get": _SHARED_NETWORKS_CONFIG_V4}):
+            response = self.client.get(self._url())
         # 2 subnets in net-alpha — check the Subnets column header is present
         self.assertContains(response, "Subnets")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_shows_subnet_cidrs(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = _SHARED_NETWORKS_CONFIG_V4
-        response = self.client.get(self._url())
+    def test_shows_subnet_cidrs(self):
+        with stub_kea({"config-get": _SHARED_NETWORKS_CONFIG_V4}):
+            response = self.client.get(self._url())
         self.assertContains(response, "10.0.0.0/24")
         self.assertContains(response, "10.0.1.0/24")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_empty_table_when_no_shared_networks(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = [
-            {"result": 0, "arguments": {"Dhcp4": {"subnet4": [], "shared-networks": []}}}
-        ]
-        response = self.client.get(self._url())
+    def test_empty_table_when_no_shared_networks(self):
+        with stub_kea({"config-get": _EMPTY_SN_CONFIG_V4}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, "net-alpha")
 
     def test_get_with_dhcp4_disabled_redirects(self):
         v6_only = _make_db_server(name="v6-only-sn", dhcp4=False, dhcp6=True)
         url = reverse("plugins:netbox_kea:server_shared_networks4", args=[v6_only.pk])
-        response = self.client.get(url)
+        # v4→v6 redirect happens before any client is built, so no Kea traffic.
+        with stub_kea({}) as kea:
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 302)
         self._assert_no_none_pk_redirect(response)
+        self.assertEqual(kea.commands(), [])
         # Merged-tab contract: a v6-only server's v4 shared-networks URL redirects to
         # the v6 route (not the server detail page), mirroring leases4/subnets4.
         self.assertEqual(
@@ -147,13 +205,12 @@ class TestServerSharedNetworks4View(_ViewTestBase):
             reverse("plugins:netbox_kea:server_shared_networks6", args=[v6_only.pk]),
         )
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_sets_tab_in_context(self, MockKeaClient):
+    def test_get_sets_tab_in_context(self):
         """F2: shared networks render under the shared 'Subnets' tab."""
         from netbox_kea.views.subnets import _SUBNETS_TAB
 
-        MockKeaClient.return_value.command.return_value = _SHARED_NETWORKS_CONFIG_V4
-        response = self.client.get(self._url())
+        with stub_kea({"config-get": _SHARED_NETWORKS_CONFIG_V4}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         self.assertIs(response.context["tab"], _SUBNETS_TAB)
 
@@ -165,40 +222,34 @@ class TestServerSharedNetworks6View(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_shared_networks6", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_returns_200(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = _SHARED_NETWORKS_CONFIG_V6
-        response = self.client.get(self._url())
+    def test_get_returns_200(self):
+        with stub_kea({"config-get": _SHARED_NETWORKS_CONFIG_V6}) as kea:
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(kea.commands(), ["config-get"])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_shows_shared_network_name(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = _SHARED_NETWORKS_CONFIG_V6
-        response = self.client.get(self._url())
+    def test_shows_shared_network_name(self):
+        with stub_kea({"config-get": _SHARED_NETWORKS_CONFIG_V6}):
+            response = self.client.get(self._url())
         self.assertContains(response, "net-beta")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_shows_subnet_cidrs(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = _SHARED_NETWORKS_CONFIG_V6
-        response = self.client.get(self._url())
+    def test_shows_subnet_cidrs(self):
+        with stub_kea({"config-get": _SHARED_NETWORKS_CONFIG_V6}):
+            response = self.client.get(self._url())
         self.assertContains(response, "2001:db8::/48")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_sets_tab_in_context(self, MockKeaClient):
+    def test_get_sets_tab_in_context(self):
         """F2: shared networks render under the shared 'Subnets' tab."""
         from netbox_kea.views.subnets import _SUBNETS_TAB
 
-        MockKeaClient.return_value.command.return_value = _SHARED_NETWORKS_CONFIG_V6
-        response = self.client.get(self._url())
+        with stub_kea({"config-get": _SHARED_NETWORKS_CONFIG_V6}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         self.assertIs(response.context["tab"], _SUBNETS_TAB)
 
 
 # ---------------------------------------------------------------------------
-# Shared Network Add / Delete views (TDD — RED until views + URLs implemented)
+# Shared Network Add / Delete views
 # ---------------------------------------------------------------------------
 
 
@@ -209,46 +260,40 @@ class TestServerSharedNetwork4AddView(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_shared_network4_add", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_returns_200_with_form(self, MockKeaClient):
-        """GET must render the add-network form with status 200."""
-        response = self.client.get(self._url())
+    def test_get_returns_200_with_form(self):
+        """GET must render the add-network form with status 200 (no Kea traffic)."""
+        with stub_kea({}) as kea:
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(kea.commands(), [])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_valid_creates_network(self, MockKeaClient):
-        """POST with valid name must call network_add and redirect."""
-        MockKeaClient.return_value.network_add.return_value = None
-        response = self.client.post(self._url(), {"name": "net-prod"})
+    def test_post_valid_creates_network(self):
+        """POST with valid name issues network4-add and redirects."""
+        with _mutate_stub("network4-add") as kea:
+            response = self.client.post(self._url(), {"name": "net-prod"})
         self.assertEqual(response.status_code, 302)
         self._assert_no_none_pk_redirect(response)
-        MockKeaClient.return_value.network_add.assert_called_once()
+        self.assertIn("network4-add", kea.commands())
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_calls_network_add_with_correct_version(self, MockKeaClient):
-        """POST must call network_add with version=4."""
-        MockKeaClient.return_value.network_add.return_value = None
-        self.client.post(self._url(), {"name": "net-prod"})
-        call_args = MockKeaClient.return_value.network_add.call_args
-        version = self._call_version(call_args)
-        self.assertEqual(version, 4)
+    def test_post_calls_network_add_with_correct_version(self):
+        """POST must send network4-add to the dhcp4 service with the network name."""
+        with _mutate_stub("network4-add") as kea:
+            self.client.post(self._url(), {"name": "net-prod"})
+        body = kea.bodies("network4-add")[0]
+        self.assertEqual(body["service"], ["dhcp4"])
+        self.assertEqual(body["arguments"]["shared-networks"][0]["name"], "net-prod")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_empty_name_shows_form_errors(self, MockKeaClient):
+    def test_post_empty_name_shows_form_errors(self):
         """POST with empty name must re-render form (no Kea call)."""
-        response = self.client.post(self._url(), {"name": ""})
+        with stub_kea({}) as kea:
+            response = self.client.post(self._url(), {"name": ""})
         self.assertEqual(response.status_code, 200)
-        MockKeaClient.return_value.network_add.assert_not_called()
+        self.assertEqual(kea.commands(), [])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_kea_exception_shows_error_and_redirects(self, MockKeaClient):
+    def test_post_kea_exception_shows_error_and_redirects(self):
         """POST that raises KeaException must redirect with an error (no 500)."""
-        from netbox_kea.kea import KeaException
-
-        MockKeaClient.return_value.network_add.side_effect = KeaException(
-            {"result": 1, "text": "subnet_cmds not loaded"}, index=0
-        )
-        response = self.client.post(self._url(), {"name": "net-prod"})
+        with _mutate_stub("network4-add", response={"result": 1, "text": "subnet_cmds not loaded"}):
+            response = self.client.post(self._url(), {"name": "net-prod"})
         self.assertEqual(response.status_code, 302)
         self._assert_no_none_pk_redirect(response)
 
@@ -267,25 +312,23 @@ class TestServerSharedNetwork4AddView(_ViewTestBase):
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestServerSharedNetwork6AddView(_ViewTestBase):
-    """Tests for ServerSharedNetwork6AddView — verifies v6 variant uses version=6."""
+    """Tests for ServerSharedNetwork6AddView — verifies v6 variant uses the dhcp6 service."""
 
     def _url(self):
         return reverse("plugins:netbox_kea:server_shared_network6_add", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_returns_200(self, MockKeaClient):
+    def test_get_returns_200(self):
         """GET must render the add-network form with status 200."""
-        response = self.client.get(self._url())
+        with stub_kea({}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_calls_network_add_with_version_6(self, MockKeaClient):
-        """POST must call network_add with version=6."""
-        MockKeaClient.return_value.network_add.return_value = None
-        self.client.post(self._url(), {"name": "net6-prod"})
-        call_args = MockKeaClient.return_value.network_add.call_args
-        version = self._call_version(call_args)
-        self.assertEqual(version, 6)
+    def test_post_calls_network_add_with_version_6(self):
+        """POST must send network6-add to the dhcp6 service."""
+        with _mutate_stub("network6-add") as kea:
+            self.client.post(self._url(), {"name": "net6-prod"})
+        body = kea.bodies("network6-add")[0]
+        self.assertEqual(body["service"], ["dhcp6"])
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
@@ -295,44 +338,34 @@ class TestServerSharedNetwork4DeleteView(_ViewTestBase):
     def _url(self, name="net-alpha"):
         return reverse("plugins:netbox_kea:server_shared_network4_delete", args=[self.server.pk, name])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_returns_200_with_confirmation_page(self, MockKeaClient):
-        """GET must render a confirmation page mentioning the network name."""
-        response = self.client.get(self._url())
+    def test_get_returns_200_with_confirmation_page(self):
+        """GET must render a confirmation page mentioning the network name (no Kea)."""
+        with stub_kea({}) as kea:
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "net-alpha")
+        self.assertEqual(kea.commands(), [])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_calls_network_del_and_redirects(self, MockKeaClient):
-        """POST must call network_del and redirect to the shared networks tab."""
-        MockKeaClient.return_value.network_del.return_value = None
-        response = self.client.post(self._url())
+    def test_post_calls_network_del_and_redirects(self):
+        """POST must issue network4-del and redirect to the shared networks tab."""
+        with _mutate_stub("network4-del") as kea:
+            response = self.client.post(self._url())
         self.assertEqual(response.status_code, 302)
         self._assert_no_none_pk_redirect(response)
-        MockKeaClient.return_value.network_del.assert_called_once()
+        self.assertIn("network4-del", kea.commands())
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_passes_correct_version_and_name(self, MockKeaClient):
-        """POST must call network_del with version=4 and the correct network name."""
-        MockKeaClient.return_value.network_del.return_value = None
-        self.client.post(self._url(name="net-alpha"))
-        call_args = MockKeaClient.return_value.network_del.call_args
-        kwargs = call_args.kwargs or call_args[1]
-        args = call_args.args or call_args[0]
-        version = self._call_version(call_args)
-        name = kwargs.get("name") or (args[1] if len(args) > 1 else None)
-        self.assertEqual(version, 4)
-        self.assertEqual(name, "net-alpha")
+    def test_post_passes_correct_version_and_name(self):
+        """POST must send network4-del to dhcp4 with the correct network name."""
+        with _mutate_stub("network4-del") as kea:
+            self.client.post(self._url(name="net-alpha"))
+        body = kea.bodies("network4-del")[0]
+        self.assertEqual(body["service"], ["dhcp4"])
+        self.assertEqual(body["arguments"], {"name": "net-alpha"})
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_kea_exception_redirects_with_error(self, MockKeaClient):
+    def test_post_kea_exception_redirects_with_error(self):
         """POST that raises KeaException must redirect with an error (no 500)."""
-        from netbox_kea.kea import KeaException
-
-        MockKeaClient.return_value.network_del.side_effect = KeaException(
-            {"result": 1, "text": "network not found"}, index=0
-        )
-        response = self.client.post(self._url())
+        with _mutate_stub("network4-del", response={"result": 1, "text": "network not found"}):
+            response = self.client.post(self._url())
         self.assertEqual(response.status_code, 302)
         self._assert_no_none_pk_redirect(response)
 
@@ -351,25 +384,23 @@ class TestServerSharedNetwork4DeleteView(_ViewTestBase):
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestServerSharedNetwork6DeleteView(_ViewTestBase):
-    """Tests for ServerSharedNetwork6DeleteView — verifies v6 variant uses version=6."""
+    """Tests for ServerSharedNetwork6DeleteView — verifies v6 variant uses the dhcp6 service."""
 
     def _url(self, name="net-beta"):
         return reverse("plugins:netbox_kea:server_shared_network6_delete", args=[self.server.pk, name])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_returns_200(self, MockKeaClient):
+    def test_get_returns_200(self):
         """GET must render confirmation page with status 200."""
-        response = self.client.get(self._url())
+        with stub_kea({}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_calls_network_del_with_version_6(self, MockKeaClient):
-        """POST must call network_del with version=6."""
-        MockKeaClient.return_value.network_del.return_value = None
-        self.client.post(self._url(name="net-beta"))
-        call_args = MockKeaClient.return_value.network_del.call_args
-        version = self._call_version(call_args)
-        self.assertEqual(version, 6)
+    def test_post_calls_network_del_with_version_6(self):
+        """POST must send network6-del to the dhcp6 service."""
+        with _mutate_stub("network6-del") as kea:
+            self.client.post(self._url(name="net-beta"))
+        body = kea.bodies("network6-del")[0]
+        self.assertEqual(body["service"], ["dhcp6"])
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -384,86 +415,44 @@ class TestServerSharedNetwork4EditView(_ViewTestBase):
     def _url(self, name="prod-net"):
         return reverse("plugins:netbox_kea:server_shared_network4_edit", args=[self.server.pk, name])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_returns_200(self, MockKeaClient):
+    def _post_data(self, **overrides):
+        data = {
+            "name": "prod-net",
+            "description": "x",
+            "interface": "",
+            "relay_addresses": "",
+            "dns_servers": "",
+            "ntp_servers": "",
+        }
+        data.update(overrides)
+        return data
+
+    def test_get_returns_200(self):
         """GET renders the edit form with status 200."""
-        MockKeaClient.return_value.command.return_value = [
-            {
-                "result": 0,
-                "arguments": {
-                    "Dhcp4": {
-                        "shared-networks": [
-                            {"name": "prod-net", "description": "Old", "option-data": [], "subnet4": []}
-                        ],
-                        "subnet4": [],
-                    }
-                },
-            }
-        ]
-        response = self.client.get(self._url())
+        with stub_kea({"config-get": _sn_config(4, "prod-net", description="Old", option_data=[])}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_valid_calls_network_update_and_redirects(self, MockKeaClient):
-        """POST with valid data calls network_update and redirects."""
-        MockKeaClient.return_value.network_update.return_value = None
-        MockKeaClient.return_value.command.return_value = _CONFIG4_WITH_PROD_NET
-        response = self.client.post(
-            self._url(),
-            {
-                "name": "prod-net",
-                "description": "Updated description",
-                "interface": "",
-                "relay_addresses": "",
-                "dns_servers": "",
-                "ntp_servers": "",
-            },
-        )
+    def test_post_valid_calls_network_update_and_redirects(self):
+        """POST with valid data runs the read-modify-write cycle and redirects."""
+        with _edit_stub(_sn_config(4, "prod-net")) as kea:
+            response = self.client.post(self._url(), self._post_data(description="Updated description"))
         self.assertEqual(response.status_code, 302)
         self._assert_no_none_pk_redirect(response)
-        MockKeaClient.return_value.network_update.assert_called_once()
+        # config-set proves network_update completed the read-modify-write cycle.
+        self.assertIn("config-set", kea.commands())
+        self.assertEqual(_written_sn(kea, 4)["description"], "Updated description")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_passes_version_4_to_network_update(self, MockKeaClient):
-        """POST must call network_update with version=4."""
-        MockKeaClient.return_value.network_update.return_value = None
-        MockKeaClient.return_value.command.return_value = _CONFIG4_WITH_PROD_NET
-        self.client.post(
-            self._url(),
-            {
-                "name": "prod-net",
-                "description": "x",
-                "interface": "",
-                "relay_addresses": "",
-                "dns_servers": "",
-                "ntp_servers": "",
-            },
-        )
-        call_args = MockKeaClient.return_value.network_update.call_args
-        version = self._call_version(call_args)
-        self.assertEqual(version, 4)
+    def test_post_passes_version_4_to_network_update(self):
+        """POST must issue the config-set to the dhcp4 service."""
+        with _edit_stub(_sn_config(4, "prod-net")) as kea:
+            self.client.post(self._url(), self._post_data())
+        self.assertEqual(kea.bodies("config-set")[0]["service"], ["dhcp4"])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_kea_exception_shows_error_and_redirects(self, MockKeaClient):
-        """POST that raises KeaException must redirect, show a generic error, and not leak raw Kea text."""
-        from netbox_kea.kea import KeaException
-
-        MockKeaClient.return_value.network_update.side_effect = KeaException(
-            {"result": 1, "text": "config error"}, index=0
-        )
-        MockKeaClient.return_value.command.return_value = _CONFIG4_WITH_PROD_NET
-        response = self.client.post(
-            self._url(),
-            {
-                "name": "prod-net",
-                "description": "x",
-                "interface": "",
-                "relay_addresses": "",
-                "dns_servers": "",
-                "ntp_servers": "",
-            },
-            follow=True,
-        )
+    def test_post_kea_exception_shows_error_and_redirects(self):
+        """config-test failure surfaces a generic error and must not leak raw Kea text."""
+        with _edit_stub(_sn_config(4, "prod-net"), **{"config-test": {"result": 1, "text": "config error"}}):
+            response = self.client.post(self._url(), self._post_data(), follow=True)
         self.assertEqual(response.status_code, 200)
         self._assert_no_none_pk_redirect(response)
         messages_list = list(response.context["messages"])
@@ -476,25 +465,10 @@ class TestServerSharedNetwork4EditView(_ViewTestBase):
         for m in messages_list:
             self.assertNotIn("config error", m.message, f"Raw Kea error text leaked into message: {m.message}")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_partial_persist_error_shows_warning(self, MockKeaClient):
-        """POST that raises PartialPersistError redirects with a warning (no 500)."""
-        from netbox_kea.kea import PartialPersistError
-
-        MockKeaClient.return_value.network_update.side_effect = PartialPersistError("dhcp4", Exception("write failed"))
-        MockKeaClient.return_value.command.return_value = _CONFIG4_WITH_PROD_NET
-        response = self.client.post(
-            self._url(),
-            {
-                "name": "prod-net",
-                "description": "x",
-                "interface": "",
-                "relay_addresses": "",
-                "dns_servers": "",
-                "ntp_servers": "",
-            },
-            follow=True,
-        )
+    def test_post_partial_persist_error_shows_warning(self):
+        """config-write failure (PartialPersistError) redirects with a warning (no 500)."""
+        with _edit_stub(_sn_config(4, "prod-net"), **{"config-write": {"result": 1, "text": "write failed"}}):
+            response = self.client.post(self._url(), self._post_data(), follow=True)
         self.assertEqual(response.status_code, 200)
         messages_list = list(response.context["messages"])
         self.assertTrue(
@@ -517,47 +491,32 @@ class TestServerSharedNetwork4EditView(_ViewTestBase):
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestServerSharedNetwork6EditView(_ViewTestBase):
-    """Tests for ServerSharedNetwork6EditView — verifies version=6."""
+    """Tests for ServerSharedNetwork6EditView — verifies the dhcp6 service."""
 
     def _url(self, name="prod-net6"):
         return reverse("plugins:netbox_kea:server_shared_network6_edit", args=[self.server.pk, name])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_returns_200(self, MockKeaClient):
+    def test_get_returns_200(self):
         """GET returns 200 for DHCPv6 edit view."""
-        MockKeaClient.return_value.command.return_value = [
-            {
-                "result": 0,
-                "arguments": {
-                    "Dhcp6": {
-                        "shared-networks": [{"name": "prod-net6", "description": "", "option-data": [], "subnet6": []}],
-                        "subnet6": [],
-                    }
-                },
-            }
-        ]
-        response = self.client.get(self._url())
+        with stub_kea({"config-get": _sn_config(6, "prod-net6", option_data=[])}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_calls_network_update_with_version_6(self, MockKeaClient):
-        """POST must call network_update with version=6."""
-        MockKeaClient.return_value.network_update.return_value = None
-        MockKeaClient.return_value.command.return_value = _CONFIG6_WITH_PROD_NET
-        self.client.post(
-            self._url(),
-            {
-                "name": "prod-net6",
-                "description": "v6 net",
-                "interface": "",
-                "relay_addresses": "",
-                "dns_servers": "",
-                "ntp_servers": "",
-            },
-        )
-        call_args = MockKeaClient.return_value.network_update.call_args
-        version = self._call_version(call_args)
-        self.assertEqual(version, 6)
+    def test_post_calls_network_update_with_version_6(self):
+        """POST must issue the config-set to the dhcp6 service."""
+        with _edit_stub(_sn_config(6, "prod-net6")) as kea:
+            self.client.post(
+                self._url(),
+                {
+                    "name": "prod-net6",
+                    "description": "v6 net",
+                    "interface": "",
+                    "relay_addresses": "",
+                    "dns_servers": "",
+                    "ntp_servers": "",
+                },
+            )
+        self.assertEqual(kea.bodies("config-set")[0]["service"], ["dhcp6"])
 
 
 # ---------------------------------------------------------------------------
@@ -572,86 +531,49 @@ class TestSharedNetworkOptionDataPreservation(_ViewTestBase):
     def _url(self, name="prod-net"):
         return reverse("plugins:netbox_kea:server_shared_network4_edit", args=[self.server.pk, name])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_preserves_non_dns_options(self, MockKeaClient):
-        """network_update receives non-DNS/NTP option-data that was fetched from Kea."""
+    def test_post_preserves_non_dns_options(self):
+        """config-set receives non-DNS/NTP option-data that was fetched from Kea."""
         custom_option = {"name": "vendor-specific", "data": "deadbeef"}
-        MockKeaClient.return_value.command.return_value = [
-            {
-                "result": 0,
-                "arguments": {
-                    "Dhcp4": {
-                        "shared-networks": [
-                            {
-                                "name": "prod-net",
-                                "option-data": [
-                                    {"name": "domain-name-servers", "data": "8.8.8.8"},
-                                    custom_option,
-                                ],
-                                "subnet4": [],
-                            }
-                        ],
-                        "subnet4": [],
-                    }
-                },
-            }
-        ]
-        MockKeaClient.return_value.network_update.return_value = None
-        self.client.post(
-            self._url(),
-            {
-                "name": "prod-net",
-                "description": "",
-                "interface": "",
-                "relay_addresses": "",
-                "dns_servers": "1.1.1.1",
-                "ntp_servers": "",
-            },
+        config = _sn_config(
+            4,
+            "prod-net",
+            option_data=[{"name": "domain-name-servers", "data": "8.8.8.8"}, custom_option],
         )
-        call_kwargs = MockKeaClient.return_value.network_update.call_args
-        kwargs = call_kwargs.kwargs or call_kwargs[1]
-        options = kwargs.get("options", [])
+        with _edit_stub(config) as kea:
+            self.client.post(
+                self._url(),
+                {
+                    "name": "prod-net",
+                    "description": "",
+                    "interface": "",
+                    "relay_addresses": "",
+                    "dns_servers": "1.1.1.1",
+                    "ntp_servers": "",
+                },
+            )
+        options = _written_sn(kea, 4)["option-data"]
         option_names = [o["name"] for o in options]
         # The custom non-DNS option must be preserved.
         self.assertIn("vendor-specific", option_names)
         # The new DNS from the form must also be present.
         self.assertIn("domain-name-servers", option_names)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_replaces_dns_servers_not_duplicates(self, MockKeaClient):
+    def test_post_replaces_dns_servers_not_duplicates(self):
         """Old DNS option from Kea is dropped; only the form-supplied DNS value is written."""
-        MockKeaClient.return_value.command.return_value = [
-            {
-                "result": 0,
-                "arguments": {
-                    "Dhcp4": {
-                        "shared-networks": [
-                            {
-                                "name": "prod-net",
-                                "option-data": [{"name": "domain-name-servers", "data": "8.8.8.8"}],
-                                "subnet4": [],
-                            }
-                        ],
-                        "subnet4": [],
-                    }
+        config = _sn_config(4, "prod-net", option_data=[{"name": "domain-name-servers", "data": "8.8.8.8"}])
+        with _edit_stub(config) as kea:
+            self.client.post(
+                self._url(),
+                {
+                    "name": "prod-net",
+                    "description": "",
+                    "interface": "",
+                    "relay_addresses": "",
+                    "dns_servers": "1.1.1.1",
+                    "ntp_servers": "",
                 },
-            }
-        ]
-        MockKeaClient.return_value.network_update.return_value = None
-        self.client.post(
-            self._url(),
-            {
-                "name": "prod-net",
-                "description": "",
-                "interface": "",
-                "relay_addresses": "",
-                "dns_servers": "1.1.1.1",
-                "ntp_servers": "",
-            },
-        )
-        call_kwargs = MockKeaClient.return_value.network_update.call_args
-        kwargs = call_kwargs.kwargs or call_kwargs[1]
-        options = kwargs.get("options", [])
+            )
+        options = _written_sn(kea, 4)["option-data"]
         dns_opts = [o for o in options if o["name"] == "domain-name-servers"]
         # Only one DNS entry must be present (the new value, not the old one).
         self.assertEqual(len(dns_opts), 1)
@@ -670,95 +592,75 @@ class TestSharedNetworkEditFetchFailures(_ViewTestBase):
     def _url(self, name="prod-net"):
         return reverse("plugins:netbox_kea:server_shared_network4_edit", args=[self.server.pk, name])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_redirects_when_network_not_found(self, MockKeaClient):
+    def _post_data(self, **overrides):
+        data = {
+            "name": "prod-net",
+            "description": "x",
+            "interface": "",
+            "relay_addresses": "",
+            "dns_servers": "",
+            "ntp_servers": "",
+        }
+        data.update(overrides)
+        return data
+
+    def test_get_redirects_when_network_not_found(self):
         """GET must redirect when config-get returns a config with no matching network."""
-        MockKeaClient.return_value.command.return_value = [
-            {"result": 0, "arguments": {"Dhcp4": {"shared-networks": [], "subnet4": []}}}
-        ]
-        response = self.client.get(self._url())
+        with stub_kea({"config-get": _EMPTY_SN_CONFIG_V4}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 302)
         self._assert_no_none_pk_redirect(response)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_redirects_when_fetch_raises_kea_exception(self, MockKeaClient):
-        """GET must redirect when config-get raises KeaException."""
-        from netbox_kea.kea import KeaException
-
-        MockKeaClient.return_value.command.side_effect = KeaException({"result": 1, "text": "err"}, index=0)
-        response = self.client.get(self._url())
+    def test_get_redirects_when_fetch_raises_kea_exception(self):
+        """GET must redirect when config-get returns a KeaException (result 1)."""
+        with stub_kea({"config-get": {"result": 1, "text": "err"}}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 302)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_aborts_when_reload_returns_empty(self, MockKeaClient):
+    def test_post_aborts_when_reload_returns_empty(self):
         """POST aborts with error when _fetch_network (reload before write) returns empty."""
-        # POST path has only ONE _fetch_network call (for reload). Make it return empty
-        # (prod-net not in shared-networks) to trigger the abort path.
-        MockKeaClient.return_value.command.return_value = [
-            {"result": 0, "arguments": {"Dhcp4": {"shared-networks": [], "subnet4": []}}}
-        ]
-        response = self.client.post(
-            self._url(),
-            {
-                "name": "prod-net",
-                "description": "x",
-                "interface": "",
-                "relay_addresses": "",
-                "dns_servers": "",
-                "ntp_servers": "",
-            },
-        )
+        # POST path reloads via _fetch_network; an empty shared-networks list (prod-net
+        # absent) triggers the abort path before any mutation.
+        with stub_kea({"config-get": _EMPTY_SN_CONFIG_V4}):
+            response = self.client.post(self._url(), self._post_data())
         # Must re-render (not crash) with error message
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Could not reload")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_sets_ntp_servers_option(self, MockKeaClient):
-        """POST with ntp_servers populates option-data with ntp-servers entry."""
-        MockKeaClient.return_value.command.return_value = _CONFIG4_WITH_PROD_NET
-        MockKeaClient.return_value.network_update.return_value = None
-        self.client.post(
-            self._url(),
-            {
-                "name": "prod-net",
-                "description": "",
-                "interface": "",
-                "relay_addresses": "",
-                "dns_servers": "",
-                "ntp_servers": "10.0.0.1",
-            },
-        )
-        call_kwargs = MockKeaClient.return_value.network_update.call_args.kwargs or {}
-        options = call_kwargs.get("options", [])
+    def test_post_sets_ntp_servers_option(self):
+        """POST with ntp_servers populates option-data with an ntp-servers entry."""
+        with _edit_stub(_sn_config(4, "prod-net", option_data=[])) as kea:
+            self.client.post(
+                self._url(),
+                {
+                    "name": "prod-net",
+                    "description": "",
+                    "interface": "",
+                    "relay_addresses": "",
+                    "dns_servers": "",
+                    "ntp_servers": "10.0.0.1",
+                },
+            )
+        options = _written_sn(kea, 4)["option-data"]
         ntp_opts = [o for o in options if o.get("name") == "ntp-servers"]
         self.assertEqual(len(ntp_opts), 1)
         self.assertEqual(ntp_opts[0]["data"], "10.0.0.1")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_generic_exception_rerenders(self, MockKeaClient):
-        """POST that raises generic Exception must not crash (no 500)."""
-        import requests as _requests
-
-        MockKeaClient.return_value.command.return_value = _CONFIG4_WITH_PROD_NET
-        MockKeaClient.return_value.network_update.side_effect = _requests.RequestException("unexpected")
-        response = self.client.post(
-            self._url(),
-            {
-                "name": "prod-net",
-                "description": "x",
-                "interface": "",
-                "relay_addresses": "",
-                "dns_servers": "",
-                "ntp_servers": "",
-            },
-        )
+    def test_post_generic_exception_rerenders(self):
+        """A transport error during network_update must not crash (no 500)."""
+        # _fetch_network's config-get succeeds; network_update's config-get then raises a
+        # transport error, exercising the view's (RequestException, ValueError) branch.
+        stub = {"config-get": queued(_sn_config(4, "prod-net"), requests.ConnectionError("boom"))}
+        with stub_kea(stub):
+            response = self.client.post(self._url(), self._post_data())
         self.assertIn(response.status_code, (200, 302))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_invalid_form_rerenders(self, MockKeaClient):
-        """POST with missing required field must re-render the form (200)."""
-        response = self.client.post(self._url(), {"description": "x"})
+    def test_post_invalid_form_rerenders(self):
+        """POST with missing required field must re-render the form (200, no Kea)."""
+        with stub_kea({}) as kea:
+            response = self.client.post(self._url(), {"description": "x"})
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(kea.commands(), [])
 
 
 # ---------------------------------------------------------------------------
@@ -768,24 +670,22 @@ class TestSharedNetworkEditFetchFailures(_ViewTestBase):
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestSharedNetworkListEdgeCases(_ViewTestBase):
-    """Lines 1237, 1241: shared network list when dhcp disabled or null config."""
+    """Shared network list when dhcp disabled or config-get returns null arguments."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_dhcp4_disabled_redirects(self, MockKeaClient):
-        """Line 1278: when dhcp4 disabled, get() returns redirect (302)."""
+    def test_dhcp4_disabled_redirects(self):
+        """When dhcp4 disabled, the v4 list view redirects to the v6 route (no Kea)."""
         server_no4 = _make_db_server(name="no-dhcp4", ca_url="https://kea.example.com", dhcp4=False, dhcp6=True)
         url = reverse("plugins:netbox_kea:server_shared_networks4", args=[server_no4.pk])
-        MockKeaClient.return_value.command.side_effect = _kea_command_side_effect
-        response = self.client.get(url)
-        # check_dhcp_enabled returns redirect when dhcp4=False
+        with stub_kea({}) as kea:
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 302)
+        self.assertEqual(kea.commands(), [])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_null_config_returns_empty(self, MockKeaClient):
-        """Line 1241: get_children returns [] when config-get returns null args."""
-        MockKeaClient.return_value.command.return_value = [{"result": 0, "arguments": None}]
+    def test_null_config_returns_empty(self):
+        """get_children returns [] when config-get returns null arguments."""
         url = reverse("plugins:netbox_kea:server_shared_networks4", args=[self.server.pk])
-        response = self.client.get(url)
+        with stub_kea({"config-get": [{"result": 0, "arguments": None}]}):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
 
@@ -796,27 +696,29 @@ class TestSharedNetworkListEdgeCases(_ViewTestBase):
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestSharedNetworkCRUDGenericException(_ViewTestBase):
-    """Lines 1371-1373, 1426-1428: generic exception on add/delete shows error."""
+    """A transport error on add/delete shows a generic internal-error message."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_add_generic_exception_shows_error(self, MockKeaClient):
-        """Lines 1371-1373: transport exception on network_add redirects with error."""
-        import requests as _requests
-
-        MockKeaClient.return_value.network_add.side_effect = _requests.RequestException("connection reset")
+    def test_add_generic_exception_shows_error(self):
+        """Transport exception on network4-add redirects with a generic error."""
         url = reverse("plugins:netbox_kea:server_shared_network4_add", args=[self.server.pk])
-        response = self.client.post(url, {"name": "new-net"}, follow=True)
+        stub = {
+            "network4-add": requests.ConnectionError("connection reset"),
+            "config-get": _EMPTY_SN_CONFIG_V4,  # follow=True lands on the list view
+        }
+        with stub_kea(stub):
+            response = self.client.post(url, {"name": "new-net"}, follow=True)
         msgs = [m.message for m in response.context["messages"]]
         self.assertTrue(any("internal error" in m.lower() for m in msgs))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_delete_generic_exception_shows_error(self, MockKeaClient):
-        """Lines 1426-1428: transport exception on network_del redirects with error."""
-        import requests as _requests
-
-        MockKeaClient.return_value.network_del.side_effect = _requests.RequestException("timeout")
+    def test_delete_generic_exception_shows_error(self):
+        """Transport exception on network4-del redirects with a generic error."""
         url = reverse("plugins:netbox_kea:server_shared_network4_delete", args=[self.server.pk, "old-net"])
-        response = self.client.post(url, {}, follow=True)
+        stub = {
+            "network4-del": requests.ConnectionError("timeout"),
+            "config-get": _EMPTY_SN_CONFIG_V4,  # follow=True lands on the list view
+        }
+        with stub_kea(stub):
+            response = self.client.post(url, {}, follow=True)
         msgs = [m.message for m in response.context["messages"]]
         self.assertTrue(any("internal error" in m.lower() for m in msgs))
 
@@ -828,47 +730,36 @@ class TestSharedNetworkCRUDGenericException(_ViewTestBase):
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestSharedNetworkEditOptionParsing(_ViewTestBase):
-    """Lines 1488-1492: GET populates dns_servers/ntp_servers from option-data."""
+    """GET populates dns_servers/ntp_servers from the fetched option-data."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_populates_dns_and_ntp_from_option_data(self, MockKeaClient):
-        MockKeaClient.return_value.command.return_value = [
-            {
-                "result": 0,
-                "arguments": {
-                    "Dhcp4": {
-                        "shared-networks": [
-                            {
-                                "name": "prod-net",
-                                "option-data": [
-                                    {"name": "domain-name-servers", "data": "8.8.8.8"},
-                                    {"name": "ntp-servers", "data": "192.0.2.1"},
-                                ],
-                                "subnet4": [],
-                            }
-                        ]
-                    }
-                },
-            }
-        ]
+    def test_get_populates_dns_and_ntp_from_option_data(self):
+        config = _sn_config(
+            4,
+            "prod-net",
+            option_data=[
+                {"name": "domain-name-servers", "data": "8.8.8.8"},
+                {"name": "ntp-servers", "data": "192.0.2.1"},
+            ],
+        )
         url = reverse("plugins:netbox_kea:server_shared_network4_edit", args=[self.server.pk, "prod-net"])
-        response = self.client.get(url)
+        with stub_kea({"config-get": config}):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "8.8.8.8")
         self.assertContains(response, "192.0.2.1")
 
 
 # ---------------------------------------------------------------------------
-# Shared networks tab disabled (line 1237)
+# Shared networks tab disabled — defensive get_children guard
 # ---------------------------------------------------------------------------
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestSharedNetworksTabDisabled(_ViewTestBase):
-    """Line 1237: server.dhcp4=False → get_children returns [] immediately."""
+    """server.dhcp4=False → get_children returns [] immediately (before any client)."""
 
     def test_dhcp4_disabled_returns_empty_children(self):
-        """Line 1237: dhcp4=False → get_children returns [] immediately (defensive guard)."""
+        """dhcp4=False → get_children returns [] immediately (defensive guard, no Kea)."""
         from django.test import RequestFactory
 
         from netbox_kea.views import ServerSharedNetworks4View

--- a/netbox_kea/tests/test_views_subnets.py
+++ b/netbox_kea/tests/test_views_subnets.py
@@ -7,7 +7,9 @@ Also contains pure-Python unit tests for helper functions defined in views.py
 because they are tightly coupled to view logic.
 
 These tests verify correct HTTP responses and redirect behaviour for every view.
-All Kea HTTP calls are mocked so no running Kea instance is required.
+They drive a **real** ``KeaClient`` and stub only the HTTP boundary via
+``kea_stub.stub_kea`` (see that module), so the actual request payloads Kea would
+receive are exercised and can be asserted on; no running Kea instance is required.
 
 Test organisation strategy
 --------------------------
@@ -22,15 +24,13 @@ which does **not** call ``Model.clean()`` and therefore does not trigger live Ke
 connectivity checks.
 """
 
-from unittest.mock import patch
-
 import requests
 from django.contrib import messages as django_messages
 from django.test import override_settings
 from django.urls import reverse
 
 from .kea_stub import queued, stub_kea
-from .utils import _PLUGINS_CONFIG, _kea_command_side_effect, _make_db_server, _ViewTestBase
+from .utils import _PLUGINS_CONFIG, _make_db_server, _ViewTestBase
 
 # Shared stub responses for the subnet list/table views, which issue config-get
 # (subnets + shared-networks) then stat-lease{v}-get (utilisation; degrades if the
@@ -2714,25 +2714,19 @@ class TestSubnetViewCoverageGaps(_ViewTestBase):
 class TestPersistConfigBanner(_ViewTestBase):
     """Tests that the persist_config warning banner appears when disabled."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_banner_absent_when_persist_config_true(self, MockKeaClient):
+    def test_banner_absent_when_persist_config_true(self):
         """No warning banner on subnet add when persist_config=True (default)."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.side_effect = _kea_command_side_effect
-
         url = reverse("plugins:netbox_kea:server_subnet4_add", args=[self.server.pk])
-        response = self.client.get(url)
+        with stub_kea({"config-get": _EMPTY_CONFIG4}):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, "Configuration persistence is disabled.")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_banner_present_when_persist_config_false(self, MockKeaClient):
+    def test_banner_present_when_persist_config_false(self):
         """Warning banner appears on subnet add page when persist_config=False."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.side_effect = _kea_command_side_effect
-
         server = _make_db_server(name="no-persist", persist_config=False)
         url = reverse("plugins:netbox_kea:server_subnet4_add", args=[server.pk])
-        response = self.client.get(url)
+        with stub_kea({"config-get": _EMPTY_CONFIG4}):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Configuration persistence is disabled.")

--- a/netbox_kea/tests/test_views_subnets.py
+++ b/netbox_kea/tests/test_views_subnets.py
@@ -1484,25 +1484,22 @@ class TestSubnetListViewEdgeCases(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_subnets4", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_null_config_arguments_raises(self, MockKeaClient):
+    def test_null_config_arguments_raises(self):
         """Null config-get arguments returns an empty table (degraded 200 state)."""
-        MockKeaClient.return_value.command.return_value = [{"result": 0, "arguments": None}]
-        response = self.client.get(self._url())
+        with stub_kea({"config-get": {"result": 0, "arguments": None}, "stat-lease4-get": _STAT_ABSENT4}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_export_returns_csv(self, MockKeaClient):
-        """Line 1173: ?export=csv returns a CSV file response."""
-        MockKeaClient.return_value.command.side_effect = _kea_command_side_effect
-        response = self.client.get(self._url() + "?export=csv")
+    def test_export_returns_csv(self):
+        """?export=csv returns a CSV file response."""
+        with stub_kea({"config-get": _EMPTY_CONFIG4, "stat-lease4-get": _STAT_ABSENT4}):
+            response = self.client.get(self._url() + "?export=csv")
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_htmx_partial_returns_table_fragment(self, MockKeaClient):
-        """Line 1181: HTMX request to subnet view returns partial table."""
-        MockKeaClient.return_value.command.side_effect = _kea_command_side_effect
-        response = self.client.get(self._url(), HTTP_HX_REQUEST="true")
+    def test_htmx_partial_returns_table_fragment(self):
+        """HTMX request to the subnet view returns a partial table fragment."""
+        with stub_kea({"config-get": _EMPTY_CONFIG4, "stat-lease4-get": _STAT_ABSENT4}):
+            response = self.client.get(self._url(), HTTP_HX_REQUEST="true")
         self.assertEqual(response.status_code, 200)
 
 
@@ -1518,22 +1515,17 @@ class TestSubnetDeleteExceptionPaths(_ViewTestBase):
     def _url(self, subnet_id=42):
         return reverse("plugins:netbox_kea:server_subnet4_delete", args=[self.server.pk, subnet_id])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_exception_still_renders(self, MockKeaClient):
-        """Lines 3177-3178: exception in GET (subnet-get) → still renders confirm page."""
-        from netbox_kea.kea import KeaException
-
-        MockKeaClient.return_value.command.side_effect = KeaException(
-            {"result": 1, "text": "subnet-get failed"}, index=0
-        )
-        response = self.client.get(self._url())
+    def test_get_exception_still_renders(self):
+        """A subnet-get failure (result 1 → KeaException) in GET must still render the confirm page."""
+        with stub_kea({"subnet4-get": {"result": 1, "text": "subnet-get failed"}}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_generic_exception_shows_error(self, MockKeaClient):
-        """Lines 3203-3205: generic exception on subnet_del redirects with error."""
-        MockKeaClient.return_value.subnet_del.side_effect = ValueError("crash")
-        response = self.client.post(self._url())
+    def test_post_generic_exception_shows_error(self):
+        """A generic (ValueError) failure on subnet_del must redirect with an error, no 500."""
+        # subnet4-del raises ValueError at the boundary → view's generic-error branch redirects.
+        with stub_kea({"subnet4-del": ValueError("crash")}):
+            response = self.client.post(self._url())
         self.assertEqual(response.status_code, 302)
 
 
@@ -1546,105 +1538,59 @@ class TestSubnetDeleteExceptionPaths(_ViewTestBase):
 class TestFetchSubnetsFromServer(_ViewTestBase):
     """Lines 3807-3855: _fetch_subnets_from_server edge cases."""
 
-    def _run(self, side_effect=None, return_value=None):
+    def _run(self, responses):
+        """Call _fetch_subnets_from_server against a real client with the given stubbed responses."""
         from netbox_kea.views import _fetch_subnets_from_server
 
-        with patch("netbox_kea.models.KeaClient") as MockKea:
-            if side_effect is not None:
-                MockKea.return_value.command.side_effect = side_effect
-            elif return_value is not None:
-                MockKea.return_value.command.return_value = return_value
+        with stub_kea(responses):
             return _fetch_subnets_from_server(self.server, version=4)
 
     def test_null_arguments_raises(self):
-        """Line 3808: null arguments raises RuntimeError."""
+        """Null config-get arguments raises RuntimeError."""
         with self.assertRaises(RuntimeError):
-            self._run(return_value=[{"result": 0, "arguments": None}])
+            self._run({"config-get": {"result": 0, "arguments": None}})
 
     def test_subnets_in_shared_network_included(self):
-        """Line 3827: subnets nested inside shared-networks are included."""
-        config = [
-            {
-                "result": 0,
-                "arguments": {
-                    "Dhcp4": {
-                        "subnet4": [],
-                        "shared-networks": [
-                            {
-                                "name": "prod",
-                                "subnet4": [
-                                    {"id": 10, "subnet": "192.168.0.0/24"},
-                                ],
-                            }
-                        ],
-                    }
-                },
-            }
-        ]
-
-        # stat-lease4-get raises to simulate missing hook
-        def _side(cmd, **kwargs):
-            if cmd == "stat-lease4-get":
-                raise RuntimeError("no stat_cmds")
-            return config  # return the list, not config[0]
-
-        result = self._run(side_effect=_side)
+        """Subnets nested inside shared-networks are included."""
+        config = {
+            "result": 0,
+            "arguments": {
+                "Dhcp4": {
+                    "subnet4": [],
+                    "shared-networks": [{"name": "prod", "subnet4": [{"id": 10, "subnet": "192.168.0.0/24"}]}],
+                }
+            },
+        }
+        # stat-lease4-get result 2 → KeaException, exactly as a missing stat_cmds hook behaves.
+        result = self._run({"config-get": config, "stat-lease4-get": _STAT_ABSENT4})
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["subnet"], "192.168.0.0/24")
 
     def test_stat_cmds_exception_swallowed(self):
-        """Lines 3853-3855: stat_cmds exception is swallowed."""
-        config_resp = [
-            {
-                "result": 0,
-                "arguments": {
-                    "Dhcp4": {
-                        "subnet4": [{"id": 1, "subnet": "10.0.0.0/24"}],
-                        "shared-networks": [],
-                    }
-                },
-            }
-        ]
-
-        def _side(cmd, **kwargs):
-            if cmd == "stat-lease4-get":
-                raise RuntimeError("stat_cmds not loaded")
-            return config_resp  # return the list, not config_resp[0]
-
-        result = self._run(side_effect=_side)
+        """A stat_cmds failure (missing hook) is swallowed; subnets are still returned."""
+        config_resp = {
+            "result": 0,
+            "arguments": {"Dhcp4": {"subnet4": [{"id": 1, "subnet": "10.0.0.0/24"}], "shared-networks": []}},
+        }
+        result = self._run({"config-get": config_resp, "stat-lease4-get": _STAT_ABSENT4})
         self.assertEqual(len(result), 1)
 
     def test_stat_cmds_success_updates_subnet(self):
-        """Line 3853: s.update(stats[s['id']]) called when stat-lease4-get returns valid data."""
-        config_resp = [
-            {
-                "result": 0,
-                "arguments": {
-                    "Dhcp4": {
-                        "subnet4": [{"id": 1, "subnet": "10.0.0.0/24"}],
-                        "shared-networks": [],
-                    }
-                },
-            }
-        ]
-        stat_resp = [
-            {
-                "result": 0,
-                "arguments": {
-                    "result-set": {
-                        "columns": ["subnet-id", "total-addresses", "assigned-addresses"],
-                        "rows": [[1, 100, 25]],
-                    }
-                },
-            }
-        ]
-
-        def _side(cmd, **kwargs):
-            if cmd == "stat-lease4-get":
-                return stat_resp
-            return config_resp
-
-        result = self._run(side_effect=_side)
+        """Valid stat-lease4-get data is merged into the subnet dict."""
+        config_resp = {
+            "result": 0,
+            "arguments": {"Dhcp4": {"subnet4": [{"id": 1, "subnet": "10.0.0.0/24"}], "shared-networks": []}},
+        }
+        stat_resp = {
+            "result": 0,
+            "arguments": {
+                "result-set": {
+                    "columns": ["subnet-id", "total-addresses", "assigned-addresses"],
+                    "rows": [[1, 100, 25]],
+                }
+            },
+        }
+        result = self._run({"config-get": config_resp, "stat-lease4-get": stat_resp})
         self.assertEqual(len(result), 1)
         # stat data was merged into the subnet dict
         self.assertEqual(result[0].get("total"), 100)

--- a/netbox_kea/tests/test_views_subnets.py
+++ b/netbox_kea/tests/test_views_subnets.py
@@ -996,56 +996,56 @@ class TestSubnetEditNetworkChoicesNoneArguments(_ViewTestBase):
     def _url(self, subnet_id=42):
         return reverse("plugins:netbox_kea:server_subnet4_edit", args=[self.server.pk, subnet_id])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_falls_back_when_config_returns_none_arguments(self, MockKeaClient):
+    # subnet the GET prefill (subnet{v}-get) returns before config-get is consulted.
+    _SUBNET4_GET = {"result": 0, "arguments": {"subnet4": [{"id": 42, "subnet": "10.0.0.0/24"}]}}
+
+    def test_get_falls_back_when_config_returns_none_arguments(self):
         """GET must not crash and must show form when config-get returns arguments=None."""
-        _subnet4_get = [{"result": 0, "arguments": {"subnet4": [{"id": 42, "subnet": "10.0.0.0/24"}]}}]
-        _config_none_args = [{"result": 0, "arguments": None, "text": "no config"}]
-        mock_client = MockKeaClient.return_value
-        mock_client.command.side_effect = [_subnet4_get, _config_none_args]
-        response = self.client.get(self._url())
+        config_none_args = {"result": 0, "arguments": None, "text": "no config"}
+        with stub_kea({"subnet4-get": self._SUBNET4_GET, "config-get": config_none_args}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_falls_back_when_config_raises_kea_exception(self, MockKeaClient):
-        """GET must not crash when config-get raises KeaException."""
-        from netbox_kea.kea import KeaException
-
-        _subnet4_get = [{"result": 0, "arguments": {"subnet4": [{"id": 42, "subnet": "10.0.0.0/24"}]}}]
-        mock_client = MockKeaClient.return_value
-        mock_client.command.side_effect = [
-            _subnet4_get,
-            KeaException({"result": 1, "text": "error"}, index=0),
-        ]
-        response = self.client.get(self._url())
+    def test_get_falls_back_when_config_raises_kea_exception(self):
+        """GET must not crash when config-get fails (result 1 → real KeaException)."""
+        # result=1 on config-get makes the real client raise KeaException, which
+        # _get_network_data catches and degrades to fallback choices.
+        with stub_kea({"subnet4-get": self._SUBNET4_GET, "config-get": {"result": 1, "text": "error"}}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_subnet_update_fails_does_not_move_network(self, MockKeaClient):
-        """POST where subnet_update raises KeaException must NOT call network_subnet_add/del."""
-        from netbox_kea.kea import KeaException
-
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = _CONFIG4_NO_NETWORKS
-        mock_client.subnet_update.side_effect = KeaException({"result": 1, "text": "update failed"}, index=0)
-
-        response = self.client.post(
-            self._url(),
-            {
-                "subnet_cidr": "10.0.0.0/24",
-                "pools": "",
-                "gateway": "",
-                "dns_servers": "",
-                "ntp_servers": "",
-                "shared_network": "net-alpha",
-                "current_network": "",
+    def test_post_subnet_update_fails_does_not_move_network(self):
+        """POST where subnet_update fails (result 1 → KeaException) must NOT issue a network move."""
+        # config-get places subnet 42 in NO network; subnet4-update returns result 1 so the
+        # real subnet_update raises KeaException before the network-move block is reached.
+        stub = {
+            "config-get": _CONFIG4_NO_NETWORKS[0],
+            "subnet4-get": {
+                "result": 0,
+                "arguments": {"subnet4": [{"id": 42, "subnet": "10.0.0.0/24", "pools": [], "option-data": []}]},
             },
-        )
-        # View should return to form (200) or redirect, but NOT call network methods.
+            "subnet4-update": {"result": 1, "text": "update failed"},
+            "network4-subnet-add": {"result": 0},
+            "network4-subnet-del": {"result": 0},
+        }
+        with stub_kea(stub) as kea:
+            response = self.client.post(
+                self._url(),
+                {
+                    "subnet_cidr": "10.0.0.0/24",
+                    "pools": "",
+                    "gateway": "",
+                    "dns_servers": "",
+                    "ntp_servers": "",
+                    "shared_network": "net-alpha",
+                    "current_network": "",
+                },
+            )
+        # View should return to form (200) or redirect, but NOT issue a network move.
         self.assertIn(response.status_code, (200, 302))
-        mock_client.subnet_update.assert_called()
-        mock_client.network_subnet_add.assert_not_called()
-        mock_client.network_subnet_del.assert_not_called()
+        self.assertIn("subnet4-update", kea.commands())
+        self.assertNotIn("network4-subnet-add", kea.commands())
+        self.assertNotIn("network4-subnet-del", kea.commands())
 
 
 # ---------------------------------------------------------------------------
@@ -1080,33 +1080,23 @@ class TestSubnetEditZeroTimers(_ViewTestBase):
     def _url(self, subnet_id=42):
         return reverse("plugins:netbox_kea:server_subnet4_edit", args=[self.server.pk, subnet_id])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_includes_zero_renew_timer_in_initial(self, MockKeaClient):
+    def _stub(self):
+        """GET chain: subnet4-get (zero timers) then config-get (network data)."""
+        return stub_kea({"subnet4-get": _SUBNET4_GET_ZERO_TIMERS[0], "config-get": _CONFIG4_NO_NETWORKS_RESP[0]})
+
+    def test_get_includes_zero_renew_timer_in_initial(self):
         """GET for a subnet with renew-timer=0 must populate the form field with 0."""
-
-        def _cmd_side_effect(command, **_kwargs):
-            if "subnet4-get" in command:
-                return _SUBNET4_GET_ZERO_TIMERS
-            return _CONFIG4_NO_NETWORKS_RESP
-
-        MockKeaClient.return_value.command.side_effect = _cmd_side_effect
-        response = self.client.get(self._url())
+        with self._stub():
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         form = response.context.get("form")
         self.assertIsNotNone(form, "Expected a form in context but got None")
         self.assertEqual(form.initial.get("renew_timer"), 0)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_includes_zero_rebind_timer_in_initial(self, MockKeaClient):
+    def test_get_includes_zero_rebind_timer_in_initial(self):
         """GET for a subnet with rebind-timer=0 must populate the form field with 0."""
-
-        def _cmd_side_effect(command, **_kwargs):
-            if "subnet4-get" in command:
-                return _SUBNET4_GET_ZERO_TIMERS
-            return _CONFIG4_NO_NETWORKS_RESP
-
-        MockKeaClient.return_value.command.side_effect = _cmd_side_effect
-        response = self.client.get(self._url())
+        with self._stub():
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         form = response.context.get("form")
         self.assertIsNotNone(form, "Expected a form in context but got None")
@@ -1125,23 +1115,40 @@ class TestPoolAddExceptions(_ViewTestBase):
     def _url(self, subnet_id=42):
         return reverse("plugins:netbox_kea:server_subnet4_pool_add", args=[self.server.pk, subnet_id])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_partial_persist_error_redirects_with_warning(self, MockKeaClient):
-        """PartialPersistError on pool_add must redirect with warning."""
-        from netbox_kea.kea import PartialPersistError
-
-        MockKeaClient.return_value.pool_add.side_effect = PartialPersistError("dhcp4", Exception("write"))
-        MockKeaClient.return_value.reservation_get_page.return_value = ([], 0, 0)
-        response = self.client.post(self._url(), {"pool": "10.0.0.100-10.0.0.200"}, follow=True)
+    def test_partial_persist_error_redirects_with_warning(self):
+        """A real config-write failure (PartialPersistError) on pool_add must warn."""
+        # pool_add: reservation-get-page (overlap probe) → list-commands → subnet4-pool-add →
+        # persist (config-get/test/write). config-write result 1 → real PartialPersistError.
+        # follow=True lands on the subnets list, which issues config-get + stat-lease4-get.
+        stub = {
+            "reservation-get-page": {"result": 3},  # no reservations → no overlap warning
+            "list-commands": {
+                "result": 0,
+                "arguments": ["subnet4-pool-add", "config-get", "config-test", "config-write"],
+            },
+            "subnet4-pool-add": {"result": 0},
+            "config-get": _EMPTY_CONFIG4,
+            "config-test": {"result": 0},
+            "config-write": {"result": 1, "text": "disk full"},
+            "stat-lease4-get": _STAT_ABSENT4,
+        }
+        with stub_kea(stub):
+            response = self.client.post(self._url(), {"pool": "10.0.0.100-10.0.0.200"}, follow=True)
         msgs = list(response.context["messages"])
         self.assertTrue(any(m.level == django_messages.WARNING for m in msgs))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_generic_exception_shows_error(self, MockKeaClient):
-        """Generic exception on pool_add must show error message."""
-        MockKeaClient.return_value.pool_add.side_effect = ValueError("crash")
-        MockKeaClient.return_value.reservation_get_page.return_value = ([], 0, 0)
-        response = self.client.post(self._url(), {"pool": "10.0.0.100-10.0.0.200"}, follow=True)
+    def test_generic_exception_shows_error(self):
+        """A generic (ValueError) failure at the HTTP boundary during pool_add must show an error."""
+        # list-commands raises ValueError at the boundary; the real client surfaces it as a
+        # ValueError out of pool_add, hitting the view's generic-error branch.
+        stub = {
+            "reservation-get-page": {"result": 3},
+            "list-commands": ValueError("crash"),
+            "config-get": _EMPTY_CONFIG4,
+            "stat-lease4-get": _STAT_ABSENT4,
+        }
+        with stub_kea(stub):
+            response = self.client.post(self._url(), {"pool": "10.0.0.100-10.0.0.200"}, follow=True)
         msgs = list(response.context["messages"])
         self.assertTrue(any(m.level == django_messages.ERROR for m in msgs))
 
@@ -1153,16 +1160,34 @@ class TestPoolDeleteExceptions(_ViewTestBase):
     def _url(self, subnet_id=42, pool="10.0.0.100-10.0.0.200"):
         return reverse("plugins:netbox_kea:server_subnet4_pool_delete", args=[self.server.pk, subnet_id, pool])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_invalid_pool_format_returns_400(self, MockKeaClient):
-        """GET with invalid pool string must return 400."""
+    def _pool_del_stub(self, **overrides):
+        """pool_del chain (list-commands → subnet4-pool-del → persist) + the followed subnets list.
+
+        config-write defaults to success; override it (or list-commands) to drive error paths.
+        """
+        base = {
+            "list-commands": {
+                "result": 0,
+                "arguments": ["subnet4-pool-del", "config-get", "config-test", "config-write"],
+            },
+            "subnet4-pool-del": {"result": 0},
+            "config-get": _EMPTY_CONFIG4,
+            "config-test": {"result": 0},
+            "config-write": {"result": 0},
+            "stat-lease4-get": _STAT_ABSENT4,
+        }
+        base.update(overrides)
+        return stub_kea(base)
+
+    def test_get_invalid_pool_format_returns_400(self):
+        """GET with invalid pool string must return 400 (before any Kea call)."""
         url = reverse("plugins:netbox_kea:server_subnet4_pool_delete", args=[self.server.pk, 42, "not_a_pool_format!!"])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 400)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_range_pool_with_spaces_returns_200(self, MockKeaClient):
+    def test_get_range_pool_with_spaces_returns_200(self):
         """GET with a Kea range pool string like '192.0.2.10 - 192.0.2.20' must not return 400."""
+        # The delete-confirm GET renders without contacting Kea, so no stub is needed.
         url = reverse(
             "plugins:netbox_kea:server_subnet4_pool_delete",
             args=[self.server.pk, 42, "192.0.2.10 - 192.0.2.20"],
@@ -1170,41 +1195,33 @@ class TestPoolDeleteExceptions(_ViewTestBase):
         response = self.client.get(url)
         self.assertNotEqual(response.status_code, 400)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_invalid_pool_format_returns_400(self, MockKeaClient):
-        """POST with invalid pool string must return 400."""
+    def test_post_invalid_pool_format_returns_400(self):
+        """POST with invalid pool string must return 400 (before any Kea call)."""
         url = reverse("plugins:netbox_kea:server_subnet4_pool_delete", args=[self.server.pk, 42, "not_a_pool_format!!"])
         response = self.client.post(url)
         self.assertEqual(response.status_code, 400)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_range_pool_with_spaces_accepted(self, MockKeaClient):
+    def test_post_range_pool_with_spaces_accepted(self):
         """POST with a Kea range pool string like '192.0.2.10 - 192.0.2.20' must not return 400."""
-        from netbox_kea.kea import PartialPersistError
-
-        MockKeaClient.return_value.pool_del.side_effect = PartialPersistError("dhcp4", Exception("write"))
         url = reverse(
             "plugins:netbox_kea:server_subnet4_pool_delete",
             args=[self.server.pk, 42, "192.0.2.10 - 192.0.2.20"],
         )
-        response = self.client.post(url, follow=True)
+        with self._pool_del_stub():
+            response = self.client.post(url, follow=True)
         self.assertNotEqual(response.status_code, 400)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_partial_persist_error_redirects_with_warning(self, MockKeaClient):
-        """PartialPersistError on pool_del must redirect with warning."""
-        from netbox_kea.kea import PartialPersistError
-
-        MockKeaClient.return_value.pool_del.side_effect = PartialPersistError("dhcp4", Exception("write"))
-        response = self.client.post(self._url(), follow=True)
+    def test_partial_persist_error_redirects_with_warning(self):
+        """A real config-write failure (PartialPersistError) on pool_del must warn."""
+        with self._pool_del_stub(**{"config-write": {"result": 1, "text": "disk full"}}):
+            response = self.client.post(self._url(), follow=True)
         msgs = list(response.context["messages"])
         self.assertTrue(any(m.level == django_messages.WARNING for m in msgs))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_generic_exception_shows_error(self, MockKeaClient):
-        """Generic exception on pool_del must show error message."""
-        MockKeaClient.return_value.pool_del.side_effect = ValueError("crash")
-        response = self.client.post(self._url(), follow=True)
+    def test_generic_exception_shows_error(self):
+        """A generic (ValueError) failure at the HTTP boundary during pool_del must show an error."""
+        with self._pool_del_stub(**{"list-commands": ValueError("crash")}):
+            response = self.client.post(self._url(), follow=True)
         msgs = list(response.context["messages"])
         self.assertTrue(any(m.level == django_messages.ERROR for m in msgs))
 

--- a/netbox_kea/tests/test_views_subnets.py
+++ b/netbox_kea/tests/test_views_subnets.py
@@ -1609,41 +1609,38 @@ class TestSubnetEditFormInitialFields(_ViewTestBase):
     def _url(self, subnet_id=42):
         return reverse("plugins:netbox_kea:server_subnet4_edit", args=[self.server.pk, subnet_id])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_populates_ntp_and_lease_times(self, MockKeaClient):
+    def test_get_populates_ntp_and_lease_times(self):
         """_form_initial picks up ntp-servers, min-valid-lft, max-valid-lft, renew/rebind-timer."""
-        subnet_resp = [
-            {
-                "result": 0,
-                "arguments": {
-                    "subnet4": [
-                        {
-                            "id": 42,
-                            "subnet": "10.0.0.0/24",
-                            "pools": [],
-                            "option-data": [
-                                {"name": "ntp-servers", "data": "10.0.0.1"},
-                            ],
-                            "valid-lft": 3600,
-                            "min-valid-lft": 1800,
-                            "max-valid-lft": 7200,
-                            "renew-timer": 900,
-                            "rebind-timer": 1500,
-                        }
-                    ]
-                },
-            }
-        ]
-        config_resp = [
-            {
-                "result": 0,
-                "arguments": {"Dhcp4": {"subnet4": [{"id": 42, "subnet": "10.0.0.0/24"}], "shared-networks": []}},
-            }
-        ]
-        # command() is called twice: subnet4-get first, then config-get
-        MockKeaClient.return_value.command.side_effect = [subnet_resp, config_resp]
-        response = self.client.get(self._url())
+        subnet_resp = {
+            "result": 0,
+            "arguments": {
+                "subnet4": [
+                    {
+                        "id": 42,
+                        "subnet": "10.0.0.0/24",
+                        "pools": [],
+                        "option-data": [{"name": "ntp-servers", "data": "10.0.0.1"}],
+                        "valid-lft": 3600,
+                        "min-valid-lft": 1800,
+                        "max-valid-lft": 7200,
+                        "renew-timer": 900,
+                        "rebind-timer": 1500,
+                    }
+                ]
+            },
+        }
+        config_resp = {
+            "result": 0,
+            "arguments": {"Dhcp4": {"subnet4": [{"id": 42, "subnet": "10.0.0.0/24"}], "shared-networks": []}},
+        }
+        with stub_kea({"subnet4-get": subnet_resp, "config-get": config_resp}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
+        initial = response.context["form"].initial
+        self.assertEqual(initial.get("min_valid_lft"), 1800)
+        self.assertEqual(initial.get("max_valid_lft"), 7200)
+        self.assertEqual(initial.get("renew_timer"), 900)
+        self.assertEqual(initial.get("rebind_timer"), 1500)
 
 
 # ---------------------------------------------------------------------------
@@ -1655,33 +1652,29 @@ class TestSubnetEditFormInitialFields(_ViewTestBase):
 class TestGetNetworkDataUnnamedNetwork(_ViewTestBase):
     """Line 2913: shared-network without a name key is skipped."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_unnamed_network_skipped_in_choices(self, MockKeaClient):
-        """Network with no 'name' key is not added to choices."""
-        config_resp = [
-            {
-                "result": 0,
-                "arguments": {
-                    "Dhcp4": {
-                        "subnet4": [{"id": 42, "subnet": "10.0.0.0/24"}],
-                        "shared-networks": [
-                            {"subnet4": []},  # no 'name' key → skipped
-                            {"name": "valid-net", "subnet4": []},
-                        ],
-                    }
-                },
-            }
-        ]
-        subnet_resp = [
-            {
-                "result": 0,
-                "arguments": {"subnet4": [{"id": 42, "subnet": "10.0.0.0/24", "pools": [], "option-data": []}]},
-            }
-        ]
-        MockKeaClient.return_value.command.side_effect = [subnet_resp, config_resp]
+    def test_unnamed_network_skipped_in_choices(self):
+        """Network with no 'name' key is not added to choices; the named one still appears."""
+        config_resp = {
+            "result": 0,
+            "arguments": {
+                "Dhcp4": {
+                    "subnet4": [{"id": 42, "subnet": "10.0.0.0/24"}],
+                    "shared-networks": [
+                        {"subnet4": []},  # no 'name' key → skipped
+                        {"name": "valid-net", "subnet4": []},
+                    ],
+                }
+            },
+        }
+        subnet_resp = {
+            "result": 0,
+            "arguments": {"subnet4": [{"id": 42, "subnet": "10.0.0.0/24", "pools": [], "option-data": []}]},
+        }
         url = reverse("plugins:netbox_kea:server_subnet4_edit", args=[self.server.pk, 42])
-        response = self.client.get(url)
+        with stub_kea({"subnet4-get": subnet_resp, "config-get": config_resp}):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "valid-net")
 
 
 # ---------------------------------------------------------------------------
@@ -1693,16 +1686,14 @@ class TestGetNetworkDataUnnamedNetwork(_ViewTestBase):
 class TestFetchNetworkNonDictArgs(_ViewTestBase):
     """Lines 1462-1463: config-get returns non-dict args → log warning + return {}."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_non_dict_args_redirects(self, MockKeaClient):
-        """config-get returns arguments=None → _fetch_network returns {} → redirect."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = [{"result": 0, "arguments": None}]
+    def test_get_non_dict_args_redirects(self):
+        """config-get returning arguments=None → _fetch_network returns {} → redirect."""
         url = reverse(
             "plugins:netbox_kea:server_shared_network4_edit",
             args=[self.server.pk, "test-net"],
         )
-        response = self.client.get(url)
+        with stub_kea({"config-get": {"result": 0, "arguments": None}}):
+            response = self.client.get(url)
         # network not found → redirects back to shared_networks4
         self.assertEqual(response.status_code, 302)
         self.assertIn(f"/servers/{self.server.pk}/", response.url)
@@ -1717,15 +1708,11 @@ class TestFetchNetworkNonDictArgs(_ViewTestBase):
 class TestGetNetworkChoicesKeaException(_ViewTestBase):
     """Lines 2737-2738: KeaException in _get_network_choices → returns default choice."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_kea_exception_returns_global_pool_only(self, MockKeaClient):
-        """config-get raises KeaException → returns [('', '— (global pool) —')]."""
-        from netbox_kea.kea import KeaException
-
-        mock_client = MockKeaClient.return_value
-        mock_client.command.side_effect = KeaException({"result": 1, "text": "error"}, index=0)
+    def test_kea_exception_returns_global_pool_only(self):
+        """config-get failing (result 1 → KeaException) → the add form falls back to global-pool only."""
         url = reverse("plugins:netbox_kea:server_subnet4_add", args=[self.server.pk])
-        response = self.client.get(url)
+        with stub_kea({"config-get": {"result": 1, "text": "error"}}):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
 
@@ -1738,39 +1725,31 @@ class TestGetNetworkChoicesKeaException(_ViewTestBase):
 class TestGetInheritedOptionsParseOpts(_ViewTestBase):
     """Lines 2974, 2977-2978: _parse_opts handles 'routers' and 'ntp-servers' entries."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_global_options_routers_and_ntp_servers_inherited(self, MockKeaClient):
+    def test_global_options_routers_and_ntp_servers_inherited(self):
         """GET subnet4_edit with global routers + ntp-servers → inherited_options populated."""
-        mock_client = MockKeaClient.return_value
-
-        subnet_resp = [
-            {
-                "result": 0,
-                "arguments": {"subnet4": [{"id": 42, "subnet": "10.0.0.0/24", "pools": [], "option-data": []}]},
-            }
-        ]
-        config_resp = [
-            {
-                "result": 0,
-                "arguments": {
-                    "Dhcp4": {
-                        "subnet4": [],
-                        "shared-networks": [],
-                        "option-data": [
-                            {"name": "routers", "data": "10.0.0.1"},
-                            {"name": "ntp-servers", "data": "10.0.0.2"},
-                        ],
-                    }
-                },
-            }
-        ]
-        mock_client.command.side_effect = [subnet_resp, config_resp]
+        subnet_resp = {
+            "result": 0,
+            "arguments": {"subnet4": [{"id": 42, "subnet": "10.0.0.0/24", "pools": [], "option-data": []}]},
+        }
+        config_resp = {
+            "result": 0,
+            "arguments": {
+                "Dhcp4": {
+                    "subnet4": [],
+                    "shared-networks": [],
+                    "option-data": [
+                        {"name": "routers", "data": "10.0.0.1"},
+                        {"name": "ntp-servers", "data": "10.0.0.2"},
+                    ],
+                }
+            },
+        }
         url = reverse("plugins:netbox_kea:server_subnet4_edit", args=[self.server.pk, 42])
-        response = self.client.get(url)
+        with stub_kea({"subnet4-get": subnet_resp, "config-get": config_resp}):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         # inherited_options should have gateway and ntp_servers from global config
-        ctx = response.context
-        inherited = ctx.get("inherited_options", {})
+        inherited = response.context.get("inherited_options", {})
         self.assertIn("gateway", inherited)
         self.assertIn("ntp_servers", inherited)
 

--- a/netbox_kea/tests/test_views_subnets.py
+++ b/netbox_kea/tests/test_views_subnets.py
@@ -1763,105 +1763,68 @@ class TestGetInheritedOptionsParseOpts(_ViewTestBase):
 class TestSubnetEditNetworkRollback(_ViewTestBase):
     """Lines 3122-3133, 3137-3139: network_subnet_del fails → rollback + outer except."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_network_subnet_del_fails_triggers_rollback_and_outer_except(self, MockKeaClient):
-        """old→new network change: del(old) raises KeaException → rollback del(new) also fails.
-
-        Covers the rollback path where Kea definitively rejects the del and
-        a rollback of the add is attempted.
-        """
-        from netbox_kea.kea import KeaException
-
-        mock_client = MockKeaClient.return_value
-
-        # config-get returns subnet 42 in "net-old", with "net-new" also available
-        config_resp = [
-            {
-                "result": 0,
-                "arguments": {
-                    "Dhcp4": {
-                        "subnet4": [],
-                        "shared-networks": [
-                            {"name": "net-old", "subnet4": [{"id": 42}]},
-                            {"name": "net-new", "subnet4": []},
-                        ],
-                        "option-data": [],
-                    }
-                },
+    # config-get returns subnet 42 in "net-old", with "net-new" also available.
+    _CONFIG_OLD_NEW = {
+        "result": 0,
+        "arguments": {
+            "Dhcp4": {
+                "subnet4": [],
+                "shared-networks": [
+                    {"name": "net-old", "subnet4": [{"id": 42}]},
+                    {"name": "net-new", "subnet4": []},
+                ],
+                "option-data": [],
             }
-        ]
-        mock_client.command.return_value = config_resp
-        mock_client.subnet_update.return_value = None
-        mock_client.network_subnet_add.return_value = None
-        # del(old) raises KeaException (definitive rejection) → rollback del(new) also fails
-        mock_client.network_subnet_del.side_effect = [
-            KeaException({"result": 1, "text": "del old failed"}),
-            KeaException({"result": 1, "text": "rollback del new also failed"}),
-        ]
+        },
+    }
 
-        url = reverse("plugins:netbox_kea:server_subnet4_edit", args=[self.server.pk, 42])
-        response = self.client.post(
-            url,
-            {
-                "subnet_cidr": "10.0.0.0/24",
-                "shared_network": "net-new",
-                "current_network": "net-old",
-                "pools": "",
-                "gateway": "",
-                "dns_servers": "",
-                "ntp_servers": "",
-            },
-        )
-        # Redirects after error message
-        self.assertEqual(response.status_code, 302)
-        # Both del calls were made (old + rollback of new)
-        self.assertEqual(mock_client.network_subnet_del.call_count, 2)
-
-    @patch("netbox_kea.models.KeaClient")
-    def test_network_subnet_del_transport_error_skips_rollback(self, MockKeaClient):
-        """old→new network change: del(old) raises transport error → NO rollback attempted.
-
-        Transport errors (RequestException) leave state ambiguous, so rollback is skipped.
-        """
-        mock_client = MockKeaClient.return_value
-
-        config_resp = [
-            {
+    def _post_stub(self, **overrides):
+        """Edit POST chain moving subnet 42 net-old→net-new: subnet_update + network add/del + persists."""
+        base = {
+            "config-get": self._CONFIG_OLD_NEW,
+            "subnet4-get": {
                 "result": 0,
-                "arguments": {
-                    "Dhcp4": {
-                        "subnet4": [],
-                        "shared-networks": [
-                            {"name": "net-old", "subnet4": [{"id": 42}]},
-                            {"name": "net-new", "subnet4": []},
-                        ],
-                        "option-data": [],
-                    }
-                },
-            }
-        ]
-        mock_client.command.return_value = config_resp
-        mock_client.subnet_update.return_value = None
-        mock_client.network_subnet_add.return_value = None
-        # del(old) raises transport error — state is ambiguous
-        mock_client.network_subnet_del.side_effect = requests.ConnectionError("network unreachable")
-
-        url = reverse("plugins:netbox_kea:server_subnet4_edit", args=[self.server.pk, 42])
-        response = self.client.post(
-            url,
-            {
-                "subnet_cidr": "10.0.0.0/24",
-                "shared_network": "net-new",
-                "current_network": "net-old",
-                "pools": "",
-                "gateway": "",
-                "dns_servers": "",
-                "ntp_servers": "",
+                "arguments": {"subnet4": [{"id": 42, "subnet": "10.0.0.0/24", "pools": [], "option-data": []}]},
             },
-        )
+            "subnet4-update": {"result": 0},
+            "config-test": {"result": 0},
+            "config-write": {"result": 0},
+            "network4-subnet-add": {"result": 0},
+            "network4-subnet-del": {"result": 0},
+        }
+        base.update(overrides)
+        return stub_kea(base)
+
+    def _post_data(self):
+        return {
+            "subnet_cidr": "10.0.0.0/24",
+            "shared_network": "net-new",
+            "current_network": "net-old",
+            "pools": "",
+            "gateway": "",
+            "dns_servers": "",
+            "ntp_servers": "",
+        }
+
+    def test_network_subnet_del_fails_triggers_rollback_and_outer_except(self):
+        """del(old) rejected by Kea (result 1 → KeaException) must trigger a rollback del(new)."""
+        # add(net-new) succeeds; del(net-old) returns result 1 → KeaException → the view rolls back
+        # by deleting net-new (which also returns result 1). So network4-subnet-del is issued twice.
+        url = reverse("plugins:netbox_kea:server_subnet4_edit", args=[self.server.pk, 42])
+        with self._post_stub(**{"network4-subnet-del": {"result": 1, "text": "del failed"}}) as kea:
+            response = self.client.post(url, self._post_data())
         self.assertEqual(response.status_code, 302)
-        # Only 1 del call (old) — no rollback attempted for transport errors
-        self.assertEqual(mock_client.network_subnet_del.call_count, 1)
+        # both del calls were made (old + rollback of new)
+        self.assertEqual(kea.commands().count("network4-subnet-del"), 2)
+
+    def test_network_subnet_del_transport_error_skips_rollback(self):
+        """del(old) raising a transport error leaves state ambiguous → NO rollback attempted."""
+        url = reverse("plugins:netbox_kea:server_subnet4_edit", args=[self.server.pk, 42])
+        with self._post_stub(**{"network4-subnet-del": requests.ConnectionError("network unreachable")}) as kea:
+            response = self.client.post(url, self._post_data())
+        self.assertEqual(response.status_code, 302)
+        # only 1 del call (old) — no rollback attempted for transport errors
+        self.assertEqual(kea.commands().count("network4-subnet-del"), 1)
 
 
 # ---------------------------------------------------------------------------
@@ -1876,40 +1839,30 @@ class TestSubnetAddNetworkChoicesError(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_subnet4_add", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_shows_warning_when_network_choices_fail(self, MockKeaClient):
-        """GET must render 200 with a warning message when config-get fails."""
-        from netbox_kea.kea import KeaException
-
-        MockKeaClient.return_value.command.side_effect = KeaException(
-            {"result": 1, "text": "config-get failed", "arguments": None}, index=0
-        )
-        response = self.client.get(self._url(), follow=True)
+    def test_get_shows_warning_when_network_choices_fail(self):
+        """GET must render 200 with a warning message when config-get fails (result 1 → KeaException)."""
+        with stub_kea({"config-get": {"result": 1, "text": "config-get failed"}}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         msgs = [str(m) for m in response.context["messages"]]
         self.assertTrue(any("shared network" in m.lower() for m in msgs))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_rejects_submission_when_network_choices_fail(self, MockKeaClient):
-        """POST must show a form error and NOT call subnet_add when config-get fails."""
-        from netbox_kea.kea import KeaException
-
-        MockKeaClient.return_value.command.side_effect = KeaException(
-            {"result": 1, "text": "config-get failed", "arguments": None}, index=0
-        )
-        response = self.client.post(
-            self._url(),
-            {
-                "subnet": "10.99.0.0/24",
-                "pools": "",
-                "gateway": "",
-                "dns_servers": "",
-                "ntp_servers": "",
-                "shared_network": "",
-            },
-        )
+    def test_post_rejects_submission_when_network_choices_fail(self):
+        """POST must show a form error and NOT issue subnet4-add when config-get fails."""
+        with stub_kea({"config-get": {"result": 1, "text": "config-get failed"}}) as kea:
+            response = self.client.post(
+                self._url(),
+                {
+                    "subnet": "10.99.0.0/24",
+                    "pools": "",
+                    "gateway": "",
+                    "dns_servers": "",
+                    "ntp_servers": "",
+                    "shared_network": "",
+                },
+            )
         self.assertEqual(response.status_code, 200)
-        MockKeaClient.return_value.subnet_add.assert_not_called()
+        self.assertNotIn("subnet4-add", kea.commands())
 
 
 # ---------------------------------------------------------------------------
@@ -1921,46 +1874,23 @@ class TestSubnetAddNetworkChoicesError(_ViewTestBase):
 class TestSubnetEditNetworkDataErrors(_ViewTestBase):
     """_get_network_data must degrade gracefully on transport and parse errors."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_transport_error_returns_200(self, MockKeaClient):
+    _LIVE_SUBNET = {
+        "result": 0,
+        "arguments": {"subnet4": [{"id": 1, "subnet": "10.0.0.0/24", "pools": [], "option-data": []}]},
+    }
+
+    def test_transport_error_returns_200(self):
         """A requests.RequestException on config-get must not cause a 500 in the edit view."""
-
-        def command_side_effect(cmd, service=None, arguments=None, check=None):
-            if cmd == "subnet4-get":
-                return [
-                    {
-                        "result": 0,
-                        "arguments": {"subnet4": [{"id": 1, "subnet": "10.0.0.0/24", "pools": [], "option-data": []}]},
-                    }
-                ]
-            if cmd == "config-get":
-                raise requests.ConnectionError("down")
-            return [{"result": 0, "arguments": {}}]
-
-        MockKeaClient.return_value.command.side_effect = command_side_effect
         url = reverse("plugins:netbox_kea:server_subnet4_edit", args=[self.server.pk, 1])
-        response = self.client.get(url)
+        with stub_kea({"subnet4-get": self._LIVE_SUBNET, "config-get": requests.ConnectionError("down")}):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_value_error_returns_200(self, MockKeaClient):
+    def test_value_error_returns_200(self):
         """A ValueError on config-get must not cause a 500 in the edit view."""
-
-        def command_side_effect(cmd, service=None, arguments=None, check=None):
-            if cmd == "subnet4-get":
-                return [
-                    {
-                        "result": 0,
-                        "arguments": {"subnet4": [{"id": 1, "subnet": "10.0.0.0/24", "pools": [], "option-data": []}]},
-                    }
-                ]
-            if cmd == "config-get":
-                raise ValueError("bad response")
-            return [{"result": 0, "arguments": {}}]
-
-        MockKeaClient.return_value.command.side_effect = command_side_effect
         url = reverse("plugins:netbox_kea:server_subnet4_edit", args=[self.server.pk, 1])
-        response = self.client.get(url)
+        with stub_kea({"subnet4-get": self._LIVE_SUBNET, "config-get": ValueError("bad response")}):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
 
@@ -1973,53 +1903,45 @@ class TestSubnetEditNetworkDataErrors(_ViewTestBase):
 class TestSubnetAddPartialPersistNetworkAssign(_ViewTestBase):
     """network_subnet_add PartialPersistError must show warning not 'could not assign' error."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_partial_persist_from_network_assign_shows_warning_not_error(self, MockKeaClient):
-        """When network_subnet_add raises PartialPersistError, show warning (subnet assigned but config-write failed)."""
-        from netbox_kea.kea import PartialPersistError
-
-        mock_client = MockKeaClient.return_value
-
-        # subnet_add raises PartialPersistError (subnet added but config-write failed, id=99)
-        mock_client.subnet_add.side_effect = PartialPersistError(
-            "dhcp4", Exception("config-write failed"), subnet_id=99
-        )
-        # network_subnet_add also raises PartialPersistError (network attached but config-write failed)
-        mock_client.network_subnet_add.side_effect = PartialPersistError(
-            "dhcp4", Exception("config-write failed"), subnet_id=99
-        )
-        # Mock shared network choices via command
-        mock_client.command.return_value = [
-            {
-                "result": 0,
-                "arguments": {
-                    "Dhcp4": {
-                        "shared-networks": [{"name": "my-net"}],
-                        "subnet4": [],
-                    }
-                },
-            }
-        ]
-
+    def test_partial_persist_from_network_assign_shows_warning_not_error(self):
+        """A config-write failure during network assignment must warn, not say 'could not assign'."""
+        # subnet4-add echoes id 99; config-write fails so both subnet_add and the follow-up
+        # network_subnet_add raise PartialPersistError — the subnet IS live, so the message is a
+        # config-write warning, not the "could not assign" transport-failure error.
+        config_mynet = {
+            "result": 0,
+            "arguments": {"Dhcp4": {"shared-networks": [{"name": "my-net"}], "subnet4": []}},
+        }
+        stub = {
+            "config-get": config_mynet,
+            "subnet4-list": {"result": 0, "arguments": {"subnets": []}},
+            "subnet4-add": {"result": 0, "arguments": {"subnets": [{"id": 99}]}},
+            "config-test": {"result": 0},
+            "config-write": {"result": 1, "text": "disk full"},
+            "network4-subnet-add": {"result": 0},
+            "stat-lease4-get": _STAT_ABSENT4,
+        }
         url = reverse("plugins:netbox_kea:server_subnet4_add", args=[self.server.pk])
-        response = self.client.post(
-            url,
-            {
-                "subnet": "10.99.0.0/24",
-                "shared_network": "my-net",
-                "pools": "",
-                "gateway": "",
-                "dns_servers": "",
-                "ntp_servers": "",
-            },
-            follow=True,
-        )
+        with stub_kea(stub) as kea:
+            response = self.client.post(
+                url,
+                {
+                    "subnet": "10.99.0.0/24",
+                    "shared_network": "my-net",
+                    "pools": "",
+                    "gateway": "",
+                    "dns_servers": "",
+                    "ntp_servers": "",
+                },
+                follow=True,
+            )
         self.assertEqual(response.status_code, 200)
         msgs = [str(m) for m in response.context["messages"]]
-        # Must NOT see the failure message
+        # must NOT see the transport-failure message
         self.assertFalse(any("could not assign" in m.lower() for m in msgs))
-        # network_subnet_add was called (subnet IS live)
-        mock_client.network_subnet_add.assert_called_once()
+        # network4-subnet-add was issued for the partial subnet id (subnet IS live)
+        self.assertEqual(kea.commands().count("network4-subnet-add"), 1)
+        self.assertEqual(kea.bodies("network4-subnet-add")[0]["arguments"]["id"], 99)
 
 
 # ---------------------------------------------------------------------------
@@ -2031,50 +1953,46 @@ class TestSubnetAddPartialPersistNetworkAssign(_ViewTestBase):
 class TestSubnetAddNoIdWarning(_ViewTestBase):
     """When subnet_add returns None and shared_network requested, show a warning."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_warning_shown_when_no_id_returned(self, MockKeaClient):
-        """subnet_add returning None with shared_network requested must show warning."""
-        mock_client = MockKeaClient.return_value
-        # subnet_add returns None (no ID)
-        mock_client.subnet_add.return_value = None
-        # Mock shared network choices from config-get
-        mock_client.command.return_value = [
-            {
-                "result": 0,
-                "arguments": {
-                    "Dhcp4": {
-                        "shared-networks": [{"name": "my-net"}],
-                        "subnet4": [],
-                    }
-                },
-            }
-        ]
-
+    def test_warning_shown_when_no_id_returned(self):
+        """subnet_add returning no id (with shared_network requested) must warn and skip assignment."""
+        # subnet4-list fails and subnet4-add echoes no id, so subnet_add returns None even though
+        # persist succeeds. The view warns about the missing id and never issues network4-subnet-add.
+        config_mynet = {
+            "result": 0,
+            "arguments": {"Dhcp4": {"shared-networks": [{"name": "my-net"}], "subnet4": []}},
+        }
+        stub = {
+            "config-get": config_mynet,
+            "subnet4-list": {"result": 1, "text": "not loaded"},
+            "subnet4-add": {"result": 0},
+            "config-test": {"result": 0},
+            "config-write": {"result": 0},
+            "network4-subnet-add": {"result": 0},
+            "stat-lease4-get": _STAT_ABSENT4,
+        }
         url = reverse("plugins:netbox_kea:server_subnet4_add", args=[self.server.pk])
-        response = self.client.post(
-            url,
-            {
-                "subnet": "10.99.0.0/24",
-                "shared_network": "my-net",
-                "pools": "",
-                "gateway": "",
-                "dns_servers": "",
-                "ntp_servers": "",
-            },
-            follow=True,
-        )
+        with stub_kea(stub) as kea:
+            response = self.client.post(
+                url,
+                {
+                    "subnet": "10.99.0.0/24",
+                    "shared_network": "my-net",
+                    "pools": "",
+                    "gateway": "",
+                    "dns_servers": "",
+                    "ntp_servers": "",
+                },
+                follow=True,
+            )
         self.assertEqual(response.status_code, 200)
         msgs = [str(m) for m in response.context["messages"]]
-        # Must see a warning about missing ID / network assignment skipped
+        # must see a warning about the missing id / skipped network assignment
         self.assertTrue(
-            any(
-                "no id" in m.lower() or "could not assign" in m.lower() or "no id was returned" in m.lower()
-                for m in msgs
-            ),
+            any("no id" in m.lower() or "could not assign" in m.lower() for m in msgs),
             f"Expected warning about missing ID but got: {msgs}",
         )
-        # network_subnet_add must NOT have been called (we have no ID)
-        mock_client.network_subnet_add.assert_not_called()
+        # network4-subnet-add must NOT have been issued (we have no id)
+        self.assertNotIn("network4-subnet-add", kea.commands())
 
 
 # ---------------------------------------------------------------------------

--- a/netbox_kea/tests/test_views_subnets.py
+++ b/netbox_kea/tests/test_views_subnets.py
@@ -2205,106 +2205,66 @@ class TestPoolDeletePostErrors(_ViewTestBase):
 class TestSubnetAddPostNetworkErrors(_ViewTestBase):
     """Cover subnet add POST network assignment errors."""
 
+    _CONFIG4_MYNET = {
+        "result": 0,
+        "arguments": {"Dhcp4": {"shared-networks": [{"name": "my-net"}], "subnet4": []}},
+    }
+
     def _url(self):
         return reverse("plugins:netbox_kea:server_subnet4_add", args=[self.server.pk])
 
-    def _setup_client(self, MockKeaClient, subnet_add_effect=None, network_add_effect=None):
-        """Set up common mock for subnet_add + network flow."""
-        mock_client = MockKeaClient.return_value
-        # config-get for shared networks (used by _get_network_choices)
-        mock_client.command.return_value = [
-            {"result": 0, "arguments": {"Dhcp4": {"shared-networks": [{"name": "my-net"}], "subnet4": []}}}
-        ]
-        if subnet_add_effect:
-            mock_client.subnet_add.side_effect = subnet_add_effect
-        else:
-            mock_client.subnet_add.return_value = 99  # returns new subnet ID
-        if network_add_effect:
-            mock_client.network_subnet_add.side_effect = network_add_effect
-        return mock_client
+    def _add_stub(self, config, **overrides):
+        """subnet_add chain (config-get choices → subnet4-list → subnet4-add → persist) + network move."""
+        base = {
+            "config-get": config,
+            "subnet4-list": {"result": 0, "arguments": {"subnets": []}},
+            "subnet4-add": {"result": 0, "arguments": {"subnets": [{"id": 99}]}},
+            "config-test": {"result": 0},
+            "config-write": {"result": 0},
+            "network4-subnet-add": {"result": 0},
+            "stat-lease4-get": _STAT_ABSENT4,
+        }
+        base.update(overrides)
+        return stub_kea(base)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_network_assign_kea_exception_shows_warning(self, MockKeaClient):
-        """KeaException from network_subnet_add shows warning (subnet already created)."""
-        from netbox_kea.kea import KeaException
+    def _post_data(self, shared_network=""):
+        return {
+            "subnet": "10.99.0.0/24",
+            "shared_network": shared_network,
+            "pools": "",
+            "gateway": "",
+            "dns_servers": "",
+            "ntp_servers": "",
+        }
 
-        self._setup_client(
-            MockKeaClient,
-            network_add_effect=KeaException({"result": 1, "text": "network error"}, index=0),
-        )
-        response = self.client.post(
-            self._url(),
-            {
-                "subnet": "10.99.0.0/24",
-                "shared_network": "my-net",
-                "pools": "",
-                "gateway": "",
-                "dns_servers": "",
-                "ntp_servers": "",
-            },
-            follow=True,
-        )
+    def test_network_assign_kea_exception_shows_warning(self):
+        """A KeaException from network_subnet_add (subnet already created) shows a warning, no 500."""
+        with self._add_stub(self._CONFIG4_MYNET, **{"network4-subnet-add": {"result": 1, "text": "network error"}}):
+            response = self.client.post(self._url(), self._post_data(shared_network="my-net"), follow=True)
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_subnet_add_request_exception_rerenders(self, MockKeaClient):
-        """RequestException from subnet_add re-renders form."""
-        self._setup_client(
-            MockKeaClient,
-            subnet_add_effect=requests.ConnectionError("down"),
-        )
-        response = self.client.post(
-            self._url(),
-            {
-                "subnet": "10.99.0.0/24",
-                "shared_network": "",
-                "pools": "",
-                "gateway": "",
-                "dns_servers": "",
-                "ntp_servers": "",
-            },
-        )
+    def test_subnet_add_request_exception_rerenders(self):
+        """A transport error from subnet_add re-renders the form."""
+        with self._add_stub(_EMPTY_CONFIG4, **{"subnet4-add": requests.ConnectionError("down")}):
+            response = self.client.post(self._url(), self._post_data())
         self.assertIn(response.status_code, [200, 302])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_subnet_add_generic_exception_rerenders(self, MockKeaClient):
-        """Generic exception from subnet_add re-renders form."""
-        self._setup_client(
-            MockKeaClient,
-            subnet_add_effect=ValueError("unexpected"),
-        )
-        response = self.client.post(
-            self._url(),
-            {
-                "subnet": "10.99.0.0/24",
-                "shared_network": "",
-                "pools": "",
-                "gateway": "",
-                "dns_servers": "",
-                "ntp_servers": "",
-            },
-        )
+    def test_subnet_add_generic_exception_rerenders(self):
+        """A generic (ValueError) failure from subnet_add re-renders the form."""
+        with self._add_stub(_EMPTY_CONFIG4, **{"subnet4-add": ValueError("unexpected")}):
+            response = self.client.post(self._url(), self._post_data())
         self.assertIn(response.status_code, [200, 302])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_subnet_add_no_id_with_network_shows_warning(self, MockKeaClient):
-        """When subnet_add returns None (no ID), network assignment is skipped with warning."""
-        mock_client = self._setup_client(MockKeaClient)
-        mock_client.subnet_add.return_value = None
-        response = self.client.post(
-            self._url(),
-            {
-                "subnet": "10.99.0.0/24",
-                "shared_network": "my-net",
-                "pools": "",
-                "gateway": "",
-                "dns_servers": "",
-                "ntp_servers": "",
-            },
-            follow=True,
-        )
+    def test_subnet_add_no_id_with_network_shows_warning(self):
+        """When subnet_add returns no id, network assignment is skipped with a warning."""
+        # subnet4-list fails and subnet4-add echoes no id → subnet_add returns None despite a clean persist.
+        with self._add_stub(
+            self._CONFIG4_MYNET,
+            **{"subnet4-list": {"result": 1, "text": "not loaded"}, "subnet4-add": {"result": 0}},
+        ) as kea:
+            response = self.client.post(self._url(), self._post_data(shared_network="my-net"), follow=True)
         self.assertEqual(response.status_code, 200)
-        mock_client.network_subnet_add.assert_not_called()
+        self.assertNotIn("network4-subnet-add", kea.commands())
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -2316,19 +2276,17 @@ class TestSubnetAddPostNetworkErrors(_ViewTestBase):
 class TestSubnetAddGetClientError(_ViewTestBase):
     """Cover subnet add GET when client creation fails."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_client_error_disables_network_field(self, MockKeaClient):
-        """ValueError from get_client in GET disables shared network field."""
-        MockKeaClient.side_effect = ValueError("bad config")
-        url = reverse("plugins:netbox_kea:server_subnet4_add", args=[self.server.pk])
+    def test_get_client_error_disables_network_field(self):
+        """A real get_client() failure (cert without key → ValueError) in GET disables the network field."""
+        bad = _make_db_server(name="bad-cert-add-get", client_cert_path="/nonexistent/cert.pem")
+        url = reverse("plugins:netbox_kea:server_subnet4_add", args=[bad.pk])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_client_error_rerenders(self, MockKeaClient):
-        """ValueError from get_client in POST re-renders form with error."""
-        MockKeaClient.side_effect = ValueError("bad config")
-        url = reverse("plugins:netbox_kea:server_subnet4_add", args=[self.server.pk])
+    def test_post_client_error_rerenders(self):
+        """A real get_client() failure in POST re-renders the form with an error, no 500."""
+        bad = _make_db_server(name="bad-cert-add-post", client_cert_path="/nonexistent/cert.pem")
+        url = reverse("plugins:netbox_kea:server_subnet4_add", args=[bad.pk])
         response = self.client.post(
             url,
             {
@@ -2352,12 +2310,11 @@ class TestSubnetAddGetClientError(_ViewTestBase):
 class TestGetSubnetsError(_ViewTestBase):
     """Cover get_subnets() error path."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_config_get_value_error_shows_empty(self, MockKeaClient):
-        """ValueError from config-get shows empty subnets with error message."""
-        MockKeaClient.return_value.command.side_effect = ValueError("bad JSON")
+    def test_config_get_value_error_shows_empty(self):
+        """A ValueError from config-get shows an empty subnet list with an error message, no 500."""
         url = reverse("plugins:netbox_kea:server_subnets4", args=[self.server.pk])
-        response = self.client.get(url)
+        with stub_kea({"config-get": ValueError("bad JSON"), "stat-lease4-get": _STAT_ABSENT4}):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
 
@@ -2370,96 +2327,59 @@ class TestGetSubnetsError(_ViewTestBase):
 class TestSubnetListNonDictItems(_ViewTestBase):
     """F9: Non-dict items in top-level subnets list and shared-networks list."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_non_dict_items_in_subnet_list_skipped(self, MockKeaClient):
+    def test_non_dict_items_in_subnet_list_skipped(self):
         """Non-dict entries (string, int) in subnet4 list are skipped; valid subnet shows."""
-
-        def _cmd(command, **_kwargs):
-            if command == "config-get":
-                return [
-                    {
-                        "result": 0,
-                        "arguments": {
-                            "Dhcp4": {
-                                "subnet4": [
-                                    {"id": 1, "subnet": "10.0.0.0/24"},
-                                    "malformed",
-                                    42,
-                                ],
-                                "shared-networks": [],
-                            }
-                        },
-                    }
-                ]
-            return [{"result": 0, "arguments": {}}]
-
-        MockKeaClient.return_value.command.side_effect = _cmd
+        config = {
+            "result": 0,
+            "arguments": {
+                "Dhcp4": {
+                    "subnet4": [{"id": 1, "subnet": "10.0.0.0/24"}, "malformed", 42],
+                    "shared-networks": [],
+                }
+            },
+        }
         url = reverse("plugins:netbox_kea:server_subnets4", args=[self.server.pk])
-        response = self.client.get(url)
+        with stub_kea({"config-get": config, "stat-lease4-get": _STAT_ABSENT4}):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "10.0.0.0/24")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_non_dict_items_in_shared_networks_skipped(self, MockKeaClient):
+    def test_non_dict_items_in_shared_networks_skipped(self):
         """Non-dict entries in shared-networks list are skipped; valid network shows."""
-
-        def _cmd(command, **_kwargs):
-            if command == "config-get":
-                return [
-                    {
-                        "result": 0,
-                        "arguments": {
-                            "Dhcp4": {
-                                "subnet4": [],
-                                "shared-networks": [
-                                    {
-                                        "name": "net1",
-                                        "subnet4": [{"id": 1, "subnet": "10.0.0.0/24"}],
-                                    },
-                                    "invalid",
-                                ],
-                            }
-                        },
-                    }
-                ]
-            return [{"result": 0, "arguments": {}}]
-
-        MockKeaClient.return_value.command.side_effect = _cmd
+        config = {
+            "result": 0,
+            "arguments": {
+                "Dhcp4": {
+                    "subnet4": [],
+                    "shared-networks": [
+                        {"name": "net1", "subnet4": [{"id": 1, "subnet": "10.0.0.0/24"}]},
+                        "invalid",
+                    ],
+                }
+            },
+        }
         url = reverse("plugins:netbox_kea:server_subnets4", args=[self.server.pk])
-        response = self.client.get(url)
+        with stub_kea({"config-get": config, "stat-lease4-get": _STAT_ABSENT4}):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "10.0.0.0/24")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_non_dict_subnet_inside_shared_network_skipped(self, MockKeaClient):
+    def test_non_dict_subnet_inside_shared_network_skipped(self):
         """Non-dict subnet items within a shared-network's subnet list are skipped."""
-
-        def _cmd(command, **_kwargs):
-            if command == "config-get":
-                return [
-                    {
-                        "result": 0,
-                        "arguments": {
-                            "Dhcp4": {
-                                "subnet4": [],
-                                "shared-networks": [
-                                    {
-                                        "name": "net1",
-                                        "subnet4": [
-                                            {"id": 1, "subnet": "10.0.0.0/24"},
-                                            "bad",
-                                        ],
-                                    },
-                                ],
-                            }
-                        },
-                    }
-                ]
-            return [{"result": 0, "arguments": {}}]
-
-        MockKeaClient.return_value.command.side_effect = _cmd
+        config = {
+            "result": 0,
+            "arguments": {
+                "Dhcp4": {
+                    "subnet4": [],
+                    "shared-networks": [
+                        {"name": "net1", "subnet4": [{"id": 1, "subnet": "10.0.0.0/24"}, "bad"]},
+                    ],
+                }
+            },
+        }
         url = reverse("plugins:netbox_kea:server_subnets4", args=[self.server.pk])
-        response = self.client.get(url)
+        with stub_kea({"config-get": config, "stat-lease4-get": _STAT_ABSENT4}):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "10.0.0.0/24")
 

--- a/netbox_kea/tests/test_views_subnets.py
+++ b/netbox_kea/tests/test_views_subnets.py
@@ -660,28 +660,58 @@ class TestServerSubnet4EditView(_ViewTestBase):
 class TestServerSubnet6EditView(_ViewTestBase):
     """Tests for ServerSubnet6EditView — verifies v6 variant uses correct version."""
 
+    # subnet_update reads the live subnet before merging; give it one to merge onto.
+    _LIVE_SUBNET6 = {
+        "result": 0,
+        "arguments": {"subnet6": [{"id": 7, "subnet": "2001:db8::/48", "pools": [], "option-data": []}]},
+    }
+
     def _url(self, subnet_id=7):
         return reverse("plugins:netbox_kea:server_subnet6_edit", args=[self.server.pk, subnet_id])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_returns_200(self, MockKeaClient):
+    def _get_stub(self, subnet=None, config=None):
+        """GET chain: subnet6-get (prefill) then config-get (network/inherited data)."""
+        return stub_kea(
+            {
+                "subnet6-get": subnet if subnet is not None else _SUBNET6_GET_FULL[0],
+                "config-get": config if config is not None else _CONFIG6_NO_NETWORKS[0],
+            }
+        )
+
+    def _post_stub(self, **overrides):
+        """POST chain: view config-get + real subnet_update (subnet6-get → update → persist)."""
+        base = {
+            "config-get": _CONFIG6_NO_NETWORKS[0],
+            "subnet6-get": self._LIVE_SUBNET6,
+            "subnet6-update": {"result": 0},
+            "config-test": {"result": 0},
+            "config-write": {"result": 0},
+        }
+        base.update(overrides)
+        return stub_kea(base)
+
+    @staticmethod
+    def _updated_subnet(kea):
+        """The subnet object in the real subnet6-update payload."""
+        return kea.bodies("subnet6-update")[0]["arguments"]["subnet6"][0]
+
+    def test_get_returns_200(self):
         """GET must return 200 for IPv6 edit view."""
-        MockKeaClient.return_value.command.return_value = _SUBNET6_GET_FULL
-        response = self.client.get(self._url())
+        with self._get_stub():
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_calls_subnet_update_with_version_6(self, MockKeaClient):
-        """POST must call subnet_update with version=6."""
-        MockKeaClient.return_value.subnet_update.return_value = None
-        MockKeaClient.return_value.command.return_value = _CONFIG6_NO_NETWORKS
-        self.client.post(
-            self._url(subnet_id=7),
-            {"subnet_cidr": "2001:db8::/48", "pools": "", "gateway": "", "dns_servers": "", "ntp_servers": ""},
-        )
-        call_kwargs = MockKeaClient.return_value.subnet_update.call_args
-        version_arg = call_kwargs.kwargs.get("version") or call_kwargs[1].get("version")
-        self.assertEqual(version_arg, 6)
+    def test_post_calls_subnet_update_with_version_6(self):
+        """POST must issue subnet6-update (the v6-specific command) for the correct subnet_id."""
+        with self._post_stub() as kea:
+            response = self.client.post(
+                self._url(subnet_id=7),
+                {"subnet_cidr": "2001:db8::/48", "pools": "", "gateway": "", "dns_servers": "", "ntp_servers": ""},
+            )
+        self.assertEqual(response.status_code, 302)
+        self._assert_no_none_pk_redirect(response)
+        self.assertIn("subnet6-update", kea.commands())
+        self.assertEqual(self._updated_subnet(kea)["id"], 7)
 
 
 # ---------------------------------------------------------------------------
@@ -762,6 +792,12 @@ _CONFIG6_NO_NETWORKS = [
 class TestServerSubnet4EditViewNetworkAssignment(_ViewTestBase):
     """Tests for shared-network assignment in ServerSubnet4EditView."""
 
+    # subnet_update reads the live subnet before merging; give it one to merge onto.
+    _LIVE_SUBNET4 = {
+        "result": 0,
+        "arguments": {"subnet4": [{"id": 42, "subnet": "10.0.0.0/24", "pools": [], "option-data": []}]},
+    }
+
     def _url(self, subnet_id=42):
         return reverse("plugins:netbox_kea:server_subnet4_edit", args=[self.server.pk, subnet_id])
 
@@ -776,97 +812,91 @@ class TestServerSubnet4EditViewNetworkAssignment(_ViewTestBase):
             "current_network": current_network,
         }
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_shows_network_dropdown_with_available_networks(self, MockKeaClient):
+    def _get_stub(self, config):
+        """GET chain: subnet4-get (prefill) then config-get (network data drives the dropdown)."""
+        return stub_kea({"subnet4-get": _SUBNET4_GET_FULL[0], "config-get": config})
+
+    def _post_stub(self, config, **overrides):
+        """POST chain: config-get (current network + choices) + real subnet_update + network move.
+
+        The view determines the *current* network server-side from config-get (not from the
+        POST body), so the config passed here decides whether add/del actually fire.
+        ``network4-subnet-add``/``-del`` are always registered; the view only issues the ones
+        the membership change requires.
+        """
+        base = {
+            "config-get": config,
+            "subnet4-get": self._LIVE_SUBNET4,
+            "subnet4-update": {"result": 0},
+            "config-test": {"result": 0},
+            "config-write": {"result": 0},
+            "network4-subnet-add": {"result": 0},
+            "network4-subnet-del": {"result": 0},
+        }
+        base.update(overrides)
+        return stub_kea(base)
+
+    def test_get_shows_network_dropdown_with_available_networks(self):
         """GET must render the form with a shared_network dropdown listing available networks."""
-        mock_client = MockKeaClient.return_value
-        # First call: subnet4-get, Second call: config-get for networks
-        mock_client.command.side_effect = [_SUBNET4_GET_FULL, _CONFIG4_NO_NETWORKS]
-        response = self.client.get(self._url())
+        with self._get_stub(config=_CONFIG4_NO_NETWORKS[0]):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "net-alpha")
         self.assertContains(response, "net-beta")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_preselects_current_network_when_subnet_belongs_to_network(self, MockKeaClient):
+    def test_get_preselects_current_network_when_subnet_belongs_to_network(self):
         """GET must pre-select the current shared network in the dropdown."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.side_effect = [_SUBNET4_GET_FULL, _CONFIG4_WITH_SUBNET_IN_NETWORK]
-        response = self.client.get(self._url())
+        with self._get_stub(config=_CONFIG4_WITH_SUBNET_IN_NETWORK[0]):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         # The form initial value should be net-alpha (selected option)
         self.assertContains(response, "net-alpha")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_assigns_subnet_to_network_calls_network_subnet_add(self, MockKeaClient):
-        """POST moving subnet into a network must call network_subnet_add."""
-        mock_client = MockKeaClient.return_value
-        # config-get for current network (subnet not in any network)
-        mock_client.command.return_value = _CONFIG4_NO_NETWORKS
-        mock_client.subnet_update.return_value = None
-        mock_client.network_subnet_add.return_value = None
-
-        response = self.client.post(self._url(), self._post_data(shared_network="net-alpha", current_network=""))
+    def test_post_assigns_subnet_to_network_calls_network_subnet_add(self):
+        """POST moving subnet into a network must issue network4-subnet-add (and no del)."""
+        # config places subnet 42 in NO network → current_network == "".
+        with self._post_stub(config=_CONFIG4_NO_NETWORKS[0]) as kea:
+            response = self.client.post(self._url(), self._post_data(shared_network="net-alpha", current_network=""))
         self.assertIn(response.status_code, (200, 302))
-        mock_client.network_subnet_add.assert_called_once()
-        call_kwargs = mock_client.network_subnet_add.call_args.kwargs or mock_client.network_subnet_add.call_args[1]
-        self.assertEqual(call_kwargs.get("name"), "net-alpha")
-        self.assertEqual(call_kwargs.get("subnet_id"), 42)
+        self.assertIn("network4-subnet-add", kea.commands())
+        self.assertNotIn("network4-subnet-del", kea.commands())
+        args = kea.bodies("network4-subnet-add")[0]["arguments"]
+        self.assertEqual(args["name"], "net-alpha")
+        self.assertEqual(args["id"], 42)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_removes_subnet_from_network_calls_network_subnet_del(self, MockKeaClient):
-        """POST clearing network (current→blank) must call network_subnet_del."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = _CONFIG4_WITH_SUBNET_IN_NETWORK
-        mock_client.subnet_update.return_value = None
-        mock_client.network_subnet_del.return_value = None
-
-        response = self.client.post(self._url(), self._post_data(shared_network="", current_network="net-alpha"))
+    def test_post_removes_subnet_from_network_calls_network_subnet_del(self):
+        """POST clearing network (current→blank) must issue network4-subnet-del (and no add)."""
+        # config places subnet 42 in net-alpha → current_network == "net-alpha".
+        with self._post_stub(config=_CONFIG4_WITH_SUBNET_IN_NETWORK[0]) as kea:
+            response = self.client.post(self._url(), self._post_data(shared_network="", current_network="net-alpha"))
         self.assertIn(response.status_code, (200, 302))
-        mock_client.network_subnet_del.assert_called_once()
-        call_kwargs = mock_client.network_subnet_del.call_args.kwargs or mock_client.network_subnet_del.call_args[1]
-        self.assertEqual(call_kwargs.get("name"), "net-alpha")
-        self.assertEqual(call_kwargs.get("subnet_id"), 42)
+        self.assertIn("network4-subnet-del", kea.commands())
+        self.assertNotIn("network4-subnet-add", kea.commands())
+        args = kea.bodies("network4-subnet-del")[0]["arguments"]
+        self.assertEqual(args["name"], "net-alpha")
+        self.assertEqual(args["id"], 42)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_changes_network_calls_del_then_add(self, MockKeaClient):
-        """POST changing from one network to another must call del then add."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = _CONFIG4_WITH_SUBNET_IN_NETWORK
-        mock_client.subnet_update.return_value = None
-        mock_client.network_subnet_del.return_value = None
-        mock_client.network_subnet_add.return_value = None
+    def test_post_changes_network_calls_del_then_add(self):
+        """POST changing from one network to another must issue both add and del."""
+        with self._post_stub(config=_CONFIG4_WITH_SUBNET_IN_NETWORK[0]) as kea:
+            self.client.post(self._url(), self._post_data(shared_network="net-beta", current_network="net-alpha"))
+        self.assertIn("network4-subnet-add", kea.commands())
+        self.assertIn("network4-subnet-del", kea.commands())
+        self.assertEqual(kea.bodies("network4-subnet-del")[0]["arguments"]["name"], "net-alpha")
+        self.assertEqual(kea.bodies("network4-subnet-add")[0]["arguments"]["name"], "net-beta")
 
-        self.client.post(self._url(), self._post_data(shared_network="net-beta", current_network="net-alpha"))
-        mock_client.network_subnet_del.assert_called_once()
-        mock_client.network_subnet_add.assert_called_once()
-        del_kwargs = mock_client.network_subnet_del.call_args.kwargs or mock_client.network_subnet_del.call_args[1]
-        add_kwargs = mock_client.network_subnet_add.call_args.kwargs or mock_client.network_subnet_add.call_args[1]
-        self.assertEqual(del_kwargs.get("name"), "net-alpha")
-        self.assertEqual(add_kwargs.get("name"), "net-beta")
+    def test_post_no_network_change_does_not_call_network_subnet_methods(self):
+        """POST when network is unchanged must NOT issue network4-subnet-add or -del."""
+        with self._post_stub(config=_CONFIG4_WITH_SUBNET_IN_NETWORK[0]) as kea:
+            self.client.post(self._url(), self._post_data(shared_network="net-alpha", current_network="net-alpha"))
+        self.assertNotIn("network4-subnet-add", kea.commands())
+        self.assertNotIn("network4-subnet-del", kea.commands())
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_no_network_change_does_not_call_network_subnet_methods(self, MockKeaClient):
-        """POST when network is unchanged must NOT call network_subnet_add or del."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = _CONFIG4_WITH_SUBNET_IN_NETWORK
-        mock_client.subnet_update.return_value = None
-
-        self.client.post(self._url(), self._post_data(shared_network="net-alpha", current_network="net-alpha"))
-        mock_client.network_subnet_add.assert_not_called()
-        mock_client.network_subnet_del.assert_not_called()
-
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_network_assignment_with_version_4(self, MockKeaClient):
-        """POST network_subnet_add must be called with version=4 for v4 subnets."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = _CONFIG4_NO_NETWORKS
-        mock_client.subnet_update.return_value = None
-        mock_client.network_subnet_add.return_value = None
-
-        self.client.post(self._url(), self._post_data(shared_network="net-alpha", current_network=""))
-        call_kwargs = mock_client.network_subnet_add.call_args.kwargs or mock_client.network_subnet_add.call_args[1]
-        self.assertEqual(call_kwargs.get("version"), 4)
+    def test_post_network_assignment_with_version_4(self):
+        """POST must issue network4-subnet-add (the v4-specific command) for v4 subnets."""
+        with self._post_stub(config=_CONFIG4_NO_NETWORKS[0]) as kea:
+            self.client.post(self._url(), self._post_data(shared_network="net-alpha", current_network=""))
+        self.assertIn("network4-subnet-add", kea.commands())
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -890,13 +920,6 @@ _CONFIG4_NETWORKS_FOR_ADD = [
 ]
 
 
-def _mock_kea_command_for_subnet_add(cmd, **kw):
-    """Return a subnet-list response for list commands, else the available networks config."""
-    if "list" in cmd:
-        return [{"result": 0, "arguments": {"subnets": []}}]
-    return _CONFIG4_NETWORKS_FOR_ADD
-
-
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestServerSubnet4AddViewSharedNetwork(_ViewTestBase):
     """GET/POST /plugins/kea/servers/<pk>/subnets4/add/ — shared_network field."""
@@ -915,46 +938,50 @@ class TestServerSubnet4AddViewSharedNetwork(_ViewTestBase):
             "shared_network": shared_network,
         }
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_shows_shared_network_dropdown(self, MockKeaClient):
+    def _add_stub(self, **overrides):
+        """POST chain: config-get (choices) + real subnet_add (list→add→persist) + network move.
+
+        subnet_id is left blank, so subnet_add auto-assigns via subnet4-list (empty → id 1);
+        subnet4-add echoes id 1, which is what the follow-up network4-subnet-add targets.
+        network4-subnet-add is always registered; the view only issues it when a network is set.
+        """
+        base = {
+            "config-get": _CONFIG4_NETWORKS_FOR_ADD[0],
+            "subnet4-list": {"result": 0, "arguments": {"subnets": []}},
+            "subnet4-add": {"result": 0, "arguments": {"subnets": [{"id": 1}]}},
+            "config-test": {"result": 0},
+            "config-write": {"result": 0},
+            "network4-subnet-add": {"result": 0},
+        }
+        base.update(overrides)
+        return stub_kea(base)
+
+    def test_get_shows_shared_network_dropdown(self):
         """GET must render a shared_network dropdown populated from Kea config."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.side_effect = _mock_kea_command_for_subnet_add
-        response = self.client.get(self._url())
+        with stub_kea({"config-get": _CONFIG4_NETWORKS_FOR_ADD[0]}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "net-alpha")
         self.assertContains(response, "net-beta")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_with_shared_network_calls_network_subnet_add(self, MockKeaClient):
-        """POST with shared_network set must call network_subnet_add after subnet creation."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.side_effect = _mock_kea_command_for_subnet_add
-        mock_client.subnet_add.return_value = 1
-        mock_client.network_subnet_add.return_value = None
-
-        response = self.client.post(self._url(), self._valid_post_data(shared_network="net-alpha"))
+    def test_post_with_shared_network_calls_network_subnet_add(self):
+        """POST with shared_network set must issue network4-subnet-add after subnet creation."""
+        with self._add_stub() as kea:
+            response = self.client.post(self._url(), self._valid_post_data(shared_network="net-alpha"))
         self.assertIn(response.status_code, (302, 200))
-        mock_client.network_subnet_add.assert_called_once()
-        call_kwargs = mock_client.network_subnet_add.call_args[1] or {}
-        call_args = mock_client.network_subnet_add.call_args[0]
-        name = call_kwargs.get("name") or (call_args[1] if len(call_args) > 1 else None)
-        self.assertEqual(name, "net-alpha")
-        subnet_id = call_kwargs.get("subnet_id") or (call_args[2] if len(call_args) > 2 else None)
-        self.assertEqual(subnet_id, 1)
-        version = call_kwargs.get("version") or (call_args[0] if len(call_args) > 0 else None)
-        self.assertEqual(version, 4)
+        self.assertIn("subnet4-add", kea.commands())
+        self.assertIn("network4-subnet-add", kea.commands())
+        args = kea.bodies("network4-subnet-add")[0]["arguments"]
+        self.assertEqual(args["name"], "net-alpha")
+        self.assertEqual(args["id"], 1)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_without_shared_network_does_not_call_network_subnet_add(self, MockKeaClient):
-        """POST without shared_network must NOT call network_subnet_add."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.side_effect = _mock_kea_command_for_subnet_add
-        mock_client.subnet_add.return_value = None
-
-        response = self.client.post(self._url(), self._valid_post_data(shared_network=""))
+    def test_post_without_shared_network_does_not_call_network_subnet_add(self):
+        """POST without shared_network must NOT issue network4-subnet-add."""
+        with self._add_stub() as kea:
+            response = self.client.post(self._url(), self._valid_post_data(shared_network=""))
         self.assertIn(response.status_code, (302, 200))
-        mock_client.network_subnet_add.assert_not_called()
+        self.assertIn("subnet4-add", kea.commands())
+        self.assertNotIn("network4-subnet-add", kea.commands())
 
 
 # ---------------------------------------------------------------------------

--- a/netbox_kea/tests/test_views_subnets.py
+++ b/netbox_kea/tests/test_views_subnets.py
@@ -375,93 +375,115 @@ _SUBNET6_GET_FULL = [
 class TestServerSubnet4EditView(_ViewTestBase):
     """Tests for ServerSubnet4EditView (GET prefill + POST update)."""
 
+    # subnet_update reads the live subnet before merging; give it one to merge onto.
+    _LIVE_SUBNET4 = {
+        "result": 0,
+        "arguments": {"subnet4": [{"id": 42, "subnet": "10.0.0.0/24", "pools": [], "option-data": []}]},
+    }
+
     def _url(self, subnet_id=42):
         return reverse("plugins:netbox_kea:server_subnet4_edit", args=[self.server.pk, subnet_id])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_returns_200(self, MockKeaClient):
+    def _get_stub(self, subnet=None, config=None):
+        """GET chain: subnet{v}-get (prefill) then config-get (network/inherited data)."""
+        return stub_kea(
+            {
+                "subnet4-get": subnet if subnet is not None else _SUBNET4_GET_FULL[0],
+                "config-get": config if config is not None else _CONFIG4_NO_NETWORKS[0],
+            }
+        )
+
+    def _post_stub(self, **overrides):
+        """POST chain: view config-get + real subnet_update (subnet-get → update → persist)."""
+        base = {
+            "config-get": _CONFIG4_NO_NETWORKS[0],
+            "subnet4-get": self._LIVE_SUBNET4,
+            "subnet4-update": {"result": 0},
+            "config-test": {"result": 0},
+            "config-write": {"result": 0},
+        }
+        base.update(overrides)
+        return stub_kea(base)
+
+    @staticmethod
+    def _updated_subnet(kea):
+        """The subnet object in the real subnet4-update payload."""
+        return kea.bodies("subnet4-update")[0]["arguments"]["subnet4"][0]
+
+    def test_get_returns_200(self):
         """GET must render the edit form with status 200."""
-        MockKeaClient.return_value.command.return_value = _SUBNET4_GET_FULL
-        response = self.client.get(self._url())
+        with self._get_stub():
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_prefills_form_with_current_subnet_values(self, MockKeaClient):
+    def test_get_prefills_form_with_current_subnet_values(self):
         """GET must pre-populate form with current subnet CIDR and pools."""
-        MockKeaClient.return_value.command.return_value = _SUBNET4_GET_FULL
-        response = self.client.get(self._url())
+        with self._get_stub():
+            response = self.client.get(self._url())
         self.assertContains(response, "10.0.0.0/24")
         self.assertContains(response, "10.0.0.100-10.0.0.200")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_when_subnet_fetch_fails_redirects_with_error(self, MockKeaClient):
+    def test_get_when_subnet_fetch_fails_redirects_with_error(self):
         """GET must redirect to the subnet list when the subnet-get Kea call fails."""
-        from netbox_kea.kea import KeaException
-
-        MockKeaClient.return_value.command.side_effect = KeaException({"result": 1, "text": "not found"}, index=0)
-        response = self.client.get(self._url())
+        with stub_kea({"subnet4-get": {"result": 1, "text": "not found"}}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 302)
         self.assertIn("subnets", response.url)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_valid_form_calls_subnet_update_and_redirects(self, MockKeaClient):
+    def test_post_valid_form_calls_subnet_update_and_redirects(self):
         """POST with valid form must call subnet_update and redirect to subnet list."""
-        MockKeaClient.return_value.subnet_update.return_value = None
-        MockKeaClient.return_value.command.return_value = _CONFIG4_NO_NETWORKS
-        response = self.client.post(
-            self._url(subnet_id=42),
-            {
-                "subnet_cidr": "10.0.0.0/24",
-                "pools": "10.0.0.100-10.0.0.200",
-                "gateway": "10.0.0.1",
-                "dns_servers": "",
-                "ntp_servers": "",
-            },
-        )
+        with self._post_stub() as kea:
+            response = self.client.post(
+                self._url(subnet_id=42),
+                {
+                    "subnet_cidr": "10.0.0.0/24",
+                    "pools": "10.0.0.100-10.0.0.200",
+                    "gateway": "10.0.0.1",
+                    "dns_servers": "",
+                    "ntp_servers": "",
+                },
+            )
         self.assertEqual(response.status_code, 302)
         self._assert_no_none_pk_redirect(response)
-        MockKeaClient.return_value.subnet_update.assert_called_once()
+        self.assertIn("subnet4-update", kea.commands())
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_passes_correct_version_and_subnet_id_to_subnet_update(self, MockKeaClient):
-        """POST must call subnet_update with version=4 and the correct subnet_id."""
-        MockKeaClient.return_value.subnet_update.return_value = None
-        MockKeaClient.return_value.command.return_value = _CONFIG4_NO_NETWORKS
-        self.client.post(
-            self._url(subnet_id=42),
-            {"subnet_cidr": "10.0.0.0/24", "pools": "", "gateway": "", "dns_servers": "", "ntp_servers": ""},
-        )
-        call_kwargs = MockKeaClient.return_value.subnet_update.call_args
-        self.assertEqual(call_kwargs.kwargs.get("version") or call_kwargs[1].get("version"), 4)
-        subnet_id_arg = call_kwargs.kwargs.get("subnet_id") or call_kwargs[1].get("subnet_id")
-        self.assertEqual(subnet_id_arg, 42)
+    def test_post_passes_correct_version_and_subnet_id_to_subnet_update(self):
+        """POST must issue subnet4-update (version=4) for the correct subnet_id."""
+        with self._post_stub() as kea:
+            self.client.post(
+                self._url(subnet_id=42),
+                {"subnet_cidr": "10.0.0.0/24", "pools": "", "gateway": "", "dns_servers": "", "ntp_servers": ""},
+            )
+        self.assertEqual(self._updated_subnet(kea)["id"], 42)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_on_kea_exception_shows_error_and_rerenders(self, MockKeaClient):
+    def test_post_on_kea_exception_shows_error_and_rerenders(self):
         """POST that raises KeaException must re-render the form (not crash)."""
-        from netbox_kea.kea import KeaException
-
-        MockKeaClient.return_value.subnet_update.side_effect = KeaException(
-            {"result": 1, "text": "subnet cmds not loaded"}, index=0
-        )
-        response = self.client.post(
-            self._url(subnet_id=42),
-            {"subnet_cidr": "10.0.0.0/24", "pools": "", "gateway": "", "dns_servers": "", "ntp_servers": ""},
-        )
+        # result=1 on subnet4-update makes the real client raise KeaException.
+        with self._post_stub(**{"subnet4-update": {"result": 1, "text": "subnet cmds not loaded"}}):
+            response = self.client.post(
+                self._url(subnet_id=42),
+                {"subnet_cidr": "10.0.0.0/24", "pools": "", "gateway": "", "dns_servers": "", "ntp_servers": ""},
+            )
         # Should show error (redirect or re-render, not 500)
         self.assertIn(response.status_code, (200, 302))
         self._assert_no_none_pk_redirect(response)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_invalid_form_rerenders_with_200(self, MockKeaClient):
+    def test_post_invalid_form_rerenders_with_200(self):
         """POST with invalid data (bad gateway IP) must re-render the form."""
-        MockKeaClient.return_value.command.return_value = _CONFIG4_NO_NETWORKS
-        response = self.client.post(
-            self._url(subnet_id=42),
-            {"subnet_cidr": "10.0.0.0/24", "pools": "", "gateway": "not-an-ip", "dns_servers": "", "ntp_servers": ""},
-        )
+        # Invalid form re-renders after the network config-get, before any subnet4-update.
+        with stub_kea({"config-get": _CONFIG4_NO_NETWORKS[0]}) as kea:
+            response = self.client.post(
+                self._url(subnet_id=42),
+                {
+                    "subnet_cidr": "10.0.0.0/24",
+                    "pools": "",
+                    "gateway": "not-an-ip",
+                    "dns_servers": "",
+                    "ntp_servers": "",
+                },
+            )
         self.assertEqual(response.status_code, 200)
-        MockKeaClient.return_value.subnet_update.assert_not_called()
+        self.assertNotIn("subnet4-update", kea.commands())
 
     def test_get_requires_login(self):
         """Unauthenticated GET must redirect to login."""
@@ -475,190 +497,157 @@ class TestServerSubnet4EditView(_ViewTestBase):
         response = self.client.post(self._url(), {})
         self.assertIn(response.status_code, (302, 403))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_passes_renew_rebind_timers_to_subnet_update(self, MockKeaClient):
-        """F11: POST with renew_timer and rebind_timer must pass them to subnet_update."""
-        MockKeaClient.return_value.subnet_update.return_value = None
-        MockKeaClient.return_value.command.return_value = _CONFIG4_NO_NETWORKS
-        self.client.post(
-            self._url(subnet_id=42),
-            {
-                "subnet_cidr": "10.0.0.0/24",
-                "pools": "",
-                "gateway": "",
-                "dns_servers": "",
-                "ntp_servers": "",
-                "renew_timer": "600",
-                "rebind_timer": "900",
-            },
-        )
-        call_kwargs = MockKeaClient.return_value.subnet_update.call_args
-        kwargs = call_kwargs.kwargs if call_kwargs.kwargs else call_kwargs[1]
-        self.assertEqual(kwargs.get("renew_timer"), 600)
-        self.assertEqual(kwargs.get("rebind_timer"), 900)
+    def test_post_passes_renew_rebind_timers_to_subnet_update(self):
+        """F11: POST with renew_timer and rebind_timer must reach the subnet4-update payload."""
+        with self._post_stub() as kea:
+            self.client.post(
+                self._url(subnet_id=42),
+                {
+                    "subnet_cidr": "10.0.0.0/24",
+                    "pools": "",
+                    "gateway": "",
+                    "dns_servers": "",
+                    "ntp_servers": "",
+                    "renew_timer": "600",
+                    "rebind_timer": "900",
+                },
+            )
+        subnet = self._updated_subnet(kea)
+        self.assertEqual(subnet["renew-timer"], 600)
+        self.assertEqual(subnet["rebind-timer"], 900)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_omits_timers_when_not_supplied(self, MockKeaClient):
-        """F11: POST without timer fields must pass None/absent to subnet_update."""
-        MockKeaClient.return_value.subnet_update.return_value = None
-        MockKeaClient.return_value.command.return_value = _CONFIG4_NO_NETWORKS
-        self.client.post(
-            self._url(subnet_id=42),
-            {"subnet_cidr": "10.0.0.0/24", "pools": "", "gateway": "", "dns_servers": "", "ntp_servers": ""},
-        )
-        call_kwargs = MockKeaClient.return_value.subnet_update.call_args
-        kwargs = call_kwargs.kwargs if call_kwargs.kwargs else call_kwargs[1]
-        self.assertIsNone(kwargs.get("renew_timer"))
-        self.assertIsNone(kwargs.get("rebind_timer"))
+    def test_post_omits_timers_when_not_supplied(self):
+        """F11: POST without timer fields must leave them out of the subnet4-update payload."""
+        with self._post_stub() as kea:
+            self.client.post(
+                self._url(subnet_id=42),
+                {"subnet_cidr": "10.0.0.0/24", "pools": "", "gateway": "", "dns_servers": "", "ntp_servers": ""},
+            )
+        subnet = self._updated_subnet(kea)
+        self.assertNotIn("renew-timer", subnet)
+        self.assertNotIn("rebind-timer", subnet)
 
     # ── DDNS qualifying suffix ────────────────────────────────────────────────
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_passes_ddns_qualifying_suffix_to_subnet_update(self, MockKeaClient):
-        """POST with a DDNS suffix must forward it to subnet_update."""
-        MockKeaClient.return_value.subnet_update.return_value = None
-        MockKeaClient.return_value.command.return_value = _CONFIG4_NO_NETWORKS
-        self.client.post(
-            self._url(subnet_id=42),
-            {
-                "subnet_cidr": "10.0.0.0/24",
-                "pools": "",
-                "gateway": "",
-                "dns_servers": "",
-                "ntp_servers": "",
-                "ddns_qualifying_suffix": "example.com.",
-            },
-        )
-        call_kwargs = MockKeaClient.return_value.subnet_update.call_args
-        kwargs = call_kwargs.kwargs if call_kwargs.kwargs else call_kwargs[1]
-        self.assertEqual(kwargs.get("ddns_qualifying_suffix"), "example.com.")
+    def test_post_passes_ddns_qualifying_suffix_to_subnet_update(self):
+        """POST with a DDNS suffix must reach the subnet4-update payload."""
+        with self._post_stub() as kea:
+            self.client.post(
+                self._url(subnet_id=42),
+                {
+                    "subnet_cidr": "10.0.0.0/24",
+                    "pools": "",
+                    "gateway": "",
+                    "dns_servers": "",
+                    "ntp_servers": "",
+                    "ddns_qualifying_suffix": "example.com.",
+                },
+            )
+        self.assertEqual(self._updated_subnet(kea)["ddns-qualifying-suffix"], "example.com.")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_clears_ddns_qualifying_suffix_with_empty_string(self, MockKeaClient):
-        """Clearing the DDNS field on edit must pass "" (explicit clear), not None (keep).
+    def test_post_clears_ddns_qualifying_suffix_with_empty_string(self):
+        """Clearing the DDNS field on edit must remove it from the subnet4-update payload.
 
-        The edit form is always fully populated, so an empty field means "clear".
-        This locks the view→client wiring: reverting the call to ``... or None`` would
-        coerce the cleared field to None (= preserve) and silently drop the clear —
-        the client tests then verify "" removes ``ddns-qualifying-suffix`` from the payload.
+        The edit form is always fully populated, so an empty field means "clear". The
+        live subnet carries a suffix; the cleared POST must drop it. This locks the
+        view→client wiring: reverting the call to ``... or None`` would coerce the
+        cleared field to None (= preserve), so the live suffix would survive in the payload.
         """
-        MockKeaClient.return_value.subnet_update.return_value = None
-        MockKeaClient.return_value.command.return_value = _CONFIG4_NO_NETWORKS
-        self.client.post(
-            self._url(subnet_id=42),
-            {
-                "subnet_cidr": "10.0.0.0/24",
-                "pools": "",
-                "gateway": "",
-                "dns_servers": "",
-                "ntp_servers": "",
-                "ddns_qualifying_suffix": "",
+        live_with_ddns = {
+            "result": 0,
+            "arguments": {
+                "subnet4": [
+                    {
+                        "id": 42,
+                        "subnet": "10.0.0.0/24",
+                        "pools": [],
+                        "option-data": [],
+                        "ddns-qualifying-suffix": "old.example.com.",
+                    }
+                ]
             },
-        )
-        call_kwargs = MockKeaClient.return_value.subnet_update.call_args
-        kwargs = call_kwargs.kwargs if call_kwargs.kwargs else call_kwargs[1]
-        self.assertEqual(kwargs.get("ddns_qualifying_suffix"), "")
-        self.assertIsNotNone(kwargs.get("ddns_qualifying_suffix"))
+        }
+        with self._post_stub(**{"subnet4-get": live_with_ddns}) as kea:
+            self.client.post(
+                self._url(subnet_id=42),
+                {
+                    "subnet_cidr": "10.0.0.0/24",
+                    "pools": "",
+                    "gateway": "",
+                    "dns_servers": "",
+                    "ntp_servers": "",
+                    "ddns_qualifying_suffix": "",
+                },
+            )
+        self.assertNotIn("ddns-qualifying-suffix", self._updated_subnet(kea))
 
     # ── F5: inherited options ─────────────────────────────────────────────────
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_passes_inherited_dns_from_global_config(self, MockKeaClient):
+    _SUBNET4_NO_OPTS = {
+        "result": 0,
+        "arguments": {"subnet4": [{"id": 42, "subnet": "10.0.0.0/24", "pools": [], "option-data": []}]},
+    }
+
+    def test_get_passes_inherited_dns_from_global_config(self):
         """F5: When subnet has no DNS set, inherited_options contains global DNS."""
-        mock_client = MockKeaClient.return_value
-        subnet_no_opts = [
-            {
-                "result": 0,
-                "arguments": {"subnet4": [{"id": 42, "subnet": "10.0.0.0/24", "pools": [], "option-data": []}]},
-            }
-        ]
-        config_with_global_dns = [
-            {
-                "result": 0,
-                "arguments": {
-                    "Dhcp4": {
-                        "option-data": [{"name": "domain-name-servers", "data": "8.8.8.8"}],
-                        "shared-networks": [],
-                    }
-                },
-            }
-        ]
-        mock_client.command.side_effect = [subnet_no_opts, config_with_global_dns]
-        response = self.client.get(self._url())
+        config_with_global_dns = {
+            "result": 0,
+            "arguments": {
+                "Dhcp4": {"option-data": [{"name": "domain-name-servers", "data": "8.8.8.8"}], "shared-networks": []}
+            },
+        }
+        with self._get_stub(subnet=self._SUBNET4_NO_OPTS, config=config_with_global_dns):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         inherited = response.context.get("inherited_options", {})
         self.assertIn("dns_servers", inherited)
         self.assertEqual(inherited["dns_servers"]["value"], "8.8.8.8")
         self.assertEqual(inherited["dns_servers"]["source"], "global")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_inherited_options_empty_when_kea_config_fails(self, MockKeaClient):
+    def test_get_inherited_options_empty_when_kea_config_fails(self):
         """F5: When config-get raises KeaException, inherited_options is an empty dict."""
-        from netbox_kea.kea import KeaException
-
-        mock_client = MockKeaClient.return_value
-        # First command call (subnet lookup) succeeds; second (config-get) fails.
-        mock_client.command.side_effect = [
-            _SUBNET4_GET_FULL,
-            KeaException({"result": 1, "text": "err"}, index=0),
-        ]
-        response = self.client.get(self._url())
+        # subnet lookup succeeds; the network config-get fails (result 1 → KeaException).
+        with self._get_stub(subnet=_SUBNET4_GET_FULL[0], config={"result": 1, "text": "err"}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         inherited = response.context.get("inherited_options", {})
         self.assertEqual(inherited, {})
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_inherited_options_excludes_field_already_set_in_subnet(self, MockKeaClient):
+    def test_get_inherited_options_excludes_field_already_set_in_subnet(self):
         """F5: Fields already set in the subnet itself are excluded from inherited_options."""
-        mock_client = MockKeaClient.return_value
         # _SUBNET4_GET_FULL has domain-name-servers: 8.8.8.8 in option-data
-        config_with_global_dns = [
-            {
-                "result": 0,
-                "arguments": {
-                    "Dhcp4": {
-                        "option-data": [{"name": "domain-name-servers", "data": "1.1.1.1"}],
-                        "shared-networks": [],
-                    }
-                },
-            }
-        ]
-        mock_client.command.side_effect = [_SUBNET4_GET_FULL, config_with_global_dns]
-        response = self.client.get(self._url())
+        config_with_global_dns = {
+            "result": 0,
+            "arguments": {
+                "Dhcp4": {"option-data": [{"name": "domain-name-servers", "data": "1.1.1.1"}], "shared-networks": []}
+            },
+        }
+        with self._get_stub(subnet=_SUBNET4_GET_FULL[0], config=config_with_global_dns):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         inherited = response.context.get("inherited_options", {})
         # dns_servers is already set by subnet — should NOT appear as inherited
         self.assertNotIn("dns_servers", inherited)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_inherited_options_prefers_shared_network_over_global(self, MockKeaClient):
+    def test_get_inherited_options_prefers_shared_network_over_global(self):
         """F5: Shared-network option-data overrides global in inherited_options."""
-        mock_client = MockKeaClient.return_value
-        subnet_no_opts = [
-            {
-                "result": 0,
-                "arguments": {"subnet4": [{"id": 42, "subnet": "10.0.0.0/24", "pools": [], "option-data": []}]},
-            }
-        ]
-        config_shared_net = [
-            {
-                "result": 0,
-                "arguments": {
-                    "Dhcp4": {
-                        "option-data": [{"name": "domain-name-servers", "data": "8.8.8.8"}],
-                        "shared-networks": [
-                            {
-                                "name": "net-alpha",
-                                "subnet4": [{"id": 42}],
-                                "option-data": [{"name": "domain-name-servers", "data": "192.168.1.1"}],
-                            }
-                        ],
-                    }
-                },
-            }
-        ]
-        mock_client.command.side_effect = [subnet_no_opts, config_shared_net]
-        response = self.client.get(self._url())
+        config_shared_net = {
+            "result": 0,
+            "arguments": {
+                "Dhcp4": {
+                    "option-data": [{"name": "domain-name-servers", "data": "8.8.8.8"}],
+                    "shared-networks": [
+                        {
+                            "name": "net-alpha",
+                            "subnet4": [{"id": 42}],
+                            "option-data": [{"name": "domain-name-servers", "data": "192.168.1.1"}],
+                        }
+                    ],
+                }
+            },
+        }
+        with self._get_stub(subnet=self._SUBNET4_NO_OPTS, config=config_shared_net):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         inherited = response.context.get("inherited_options", {})
         self.assertIn("dns_servers", inherited)

--- a/netbox_kea/tests/test_views_subnets.py
+++ b/netbox_kea/tests/test_views_subnets.py
@@ -29,30 +29,35 @@ from django.contrib import messages as django_messages
 from django.test import override_settings
 from django.urls import reverse
 
+from .kea_stub import stub_kea
 from .utils import _PLUGINS_CONFIG, _kea_command_side_effect, _make_db_server, _ViewTestBase
+
+# Shared stub responses for the subnet list/table views, which issue config-get
+# (subnets + shared-networks) then stat-lease{v}-get (utilisation; degrades if the
+# stat_cmds hook is absent — modelled by result 2 → KeaException → skipped).
+_EMPTY_CONFIG4 = {"result": 0, "arguments": {"Dhcp4": {"subnet4": [], "shared-networks": []}}}
+_EMPTY_CONFIG6 = {"result": 0, "arguments": {"Dhcp6": {"subnet6": [], "shared-networks": []}}}
+_STAT_ABSENT4 = {"result": 2, "text": "unknown command 'stat-lease4-get'"}
+_STAT_ABSENT6 = {"result": 2, "text": "unknown command 'stat-lease6-get'"}
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestServerSubnets4View(_ViewTestBase):
     """GET /plugins/kea/servers/<pk>/subnets4/"""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_returns_200(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.command.side_effect = _kea_command_side_effect
-
+    def test_get_returns_200(self):
         url = reverse("plugins:netbox_kea:server_subnets4", args=[self.server.pk])
-        response = self.client.get(url)
+        with stub_kea({"config-get": _EMPTY_CONFIG4, "stat-lease4-get": _STAT_ABSENT4}):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_sets_tab_in_context(self, MockKeaClient):
+    def test_get_sets_tab_in_context(self):
         """F2: GET response must include 'tab' in context for tab bar highlighting."""
         from netbox_kea.views import ServerDHCP4SubnetsView
 
-        MockKeaClient.return_value.command.side_effect = _kea_command_side_effect
         url = reverse("plugins:netbox_kea:server_subnets4", args=[self.server.pk])
-        response = self.client.get(url)
+        with stub_kea({"config-get": _EMPTY_CONFIG4, "stat-lease4-get": _STAT_ABSENT4}):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertIs(response.context["tab"], ServerDHCP4SubnetsView.tab)
 
@@ -69,17 +74,13 @@ class TestServerSubnets4View(_ViewTestBase):
 class TestServerSubnets6View(_ViewTestBase):
     """GET /plugins/kea/servers/<pk>/subnets6/"""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_returns_200(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.command.side_effect = _kea_command_side_effect
-
+    def test_get_returns_200(self):
         url = reverse("plugins:netbox_kea:server_subnets6", args=[self.server.pk])
-        response = self.client.get(url)
+        with stub_kea({"config-get": _EMPTY_CONFIG6, "stat-lease6-get": _STAT_ABSENT6}):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_sets_tab_in_context(self, MockKeaClient):
+    def test_get_sets_tab_in_context(self):
         """F2: GET response must include 'tab' in context for tab bar highlighting.
 
         v4 and v6 subnets now render under the single shared 'Subnets' tab
@@ -87,9 +88,9 @@ class TestServerSubnets6View(_ViewTestBase):
         """
         from netbox_kea.views import ServerDHCP4SubnetsView
 
-        MockKeaClient.return_value.command.side_effect = _kea_command_side_effect
         url = reverse("plugins:netbox_kea:server_subnets6", args=[self.server.pk])
-        response = self.client.get(url)
+        with stub_kea({"config-get": _EMPTY_CONFIG6, "stat-lease6-get": _STAT_ABSENT6}):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertIs(response.context["tab"], ServerDHCP4SubnetsView.tab)
 
@@ -113,41 +114,34 @@ class TestSubnetEnrichment(_ViewTestBase):
         }
         return [{"result": 0, "arguments": {dhcp_key: {subnet_key: [subnet], "shared-networks": []}}}]
 
-    def _side_effect_v4(self, cmd, service=None, **kwargs):
-        if cmd == "config-get":
-            return self._config_with_subnet(4)
-        return _kea_command_side_effect(cmd, service=service, **kwargs)
+    def _stub(self):
+        """Subnet list with one option/pool-carrying subnet; stat_cmds hook absent."""
+        return stub_kea({"config-get": self._config_with_subnet(4)[0], "stat-lease4-get": _STAT_ABSENT4})
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_subnet_table_includes_options_data(self, MockKeaClient):
+    def test_subnet_table_includes_options_data(self):
         """Each subnet dict in the table must carry parsed option-data."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.side_effect = self._side_effect_v4
         url = reverse("plugins:netbox_kea:server_subnets4", args=[self.server.pk])
-        response = self.client.get(url)
+        with self._stub():
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         # Table rows should contain gateway info from the subnet options
         self.assertContains(response, "10.0.0.1")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_subnet_table_includes_pool_ranges(self, MockKeaClient):
+    def test_subnet_table_includes_pool_ranges(self):
         """Each subnet dict must carry pool range data."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.side_effect = self._side_effect_v4
         url = reverse("plugins:netbox_kea:server_subnets4", args=[self.server.pk])
-        response = self.client.get(url)
+        with self._stub():
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "10.0.0.50-10.0.0.99")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_subnet_table_data_has_subnet_sort_key(self, MockKeaClient):
+    def test_subnet_table_data_has_subnet_sort_key(self):
         """F1: each subnet dict must have an integer _subnet_sort_key for numeric sort."""
         import ipaddress
 
-        mock_client = MockKeaClient.return_value
-        mock_client.command.side_effect = self._side_effect_v4
         url = reverse("plugins:netbox_kea:server_subnets4", args=[self.server.pk])
-        response = self.client.get(url)
+        with self._stub():
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         table = response.context["table"]
         for row in table.data:
@@ -204,94 +198,47 @@ def _config_with_one_subnet(service=None):
 class TestSubnetUtilizationStats(_ViewTestBase):
     """Subnet table must show a utilization column when ``stat_cmds`` hook is loaded."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_utilization_percentage_shown_in_table(self, MockKeaClient):
+    @staticmethod
+    def _stat(assigned, total=100):
+        """A stat-lease4-get response for one subnet with the given utilisation."""
+        return {
+            "result": 0,
+            "arguments": {
+                "result-set": {
+                    "columns": ["subnet-id", "total-addresses", "assigned-addresses", "declined-addresses"],
+                    "rows": [[1, total, assigned, 0]],
+                }
+            },
+        }
+
+    def test_utilization_percentage_shown_in_table(self):
         """25/100 addresses → '25%' utilization shown in subnets4 table."""
-
-        def side_effect(cmd, service=None, arguments=None, check=None):
-            if cmd == "config-get":
-                return _config_with_one_subnet(service)
-            if cmd == "stat-lease4-get":
-                return _STAT_LEASE4_RESPONSE
-            return [{"result": 0, "arguments": {}}]
-
-        MockKeaClient.return_value.command.side_effect = side_effect
         url = reverse("plugins:netbox_kea:server_subnets4", args=[self.server.pk])
-        response = self.client.get(url)
+        with stub_kea({"config-get": _config_with_one_subnet()[0], "stat-lease4-get": _STAT_LEASE4_RESPONSE[0]}):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "25%")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_no_crash_when_stat_cmds_unavailable(self, MockKeaClient):
+    def test_no_crash_when_stat_cmds_unavailable(self):
         """When stat_cmds hook is not loaded, subnets page must still render (200)."""
-        from netbox_kea.kea import KeaException
-
-        def side_effect(cmd, service=None, arguments=None, check=None):
-            if cmd == "config-get":
-                return _config_with_one_subnet(service)
-            if cmd == "stat-lease4-get":
-                raise KeaException(
-                    {"result": 2, "text": "unknown command 'stat-lease4-get'"},
-                    index=0,
-                )
-            return [{"result": 0, "arguments": {}}]
-
-        MockKeaClient.return_value.command.side_effect = side_effect
         url = reverse("plugins:netbox_kea:server_subnets4", args=[self.server.pk])
-        response = self.client.get(url)
+        with stub_kea({"config-get": _config_with_one_subnet()[0], "stat-lease4-get": _STAT_ABSENT4}):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_zero_percent_when_no_leases_assigned(self, MockKeaClient):
+    def test_zero_percent_when_no_leases_assigned(self):
         """0 assigned / 100 total → '0%' utilization."""
-
-        def side_effect(cmd, service=None, arguments=None, check=None):
-            if cmd == "config-get":
-                return _config_with_one_subnet(service)
-            if cmd == "stat-lease4-get":
-                return [
-                    {
-                        "result": 0,
-                        "arguments": {
-                            "result-set": {
-                                "columns": ["subnet-id", "total-addresses", "assigned-addresses", "declined-addresses"],
-                                "rows": [[1, 100, 0, 0]],
-                            }
-                        },
-                    }
-                ]
-            return [{"result": 0, "arguments": {}}]
-
-        MockKeaClient.return_value.command.side_effect = side_effect
         url = reverse("plugins:netbox_kea:server_subnets4", args=[self.server.pk])
-        response = self.client.get(url)
+        with stub_kea({"config-get": _config_with_one_subnet()[0], "stat-lease4-get": self._stat(0)}):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "0%")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_hundred_percent_when_fully_utilized(self, MockKeaClient):
+    def test_hundred_percent_when_fully_utilized(self):
         """All addresses assigned → '100%' utilization."""
-
-        def side_effect(cmd, service=None, arguments=None, check=None):
-            if cmd == "config-get":
-                return _config_with_one_subnet(service)
-            if cmd == "stat-lease4-get":
-                return [
-                    {
-                        "result": 0,
-                        "arguments": {
-                            "result-set": {
-                                "columns": ["subnet-id", "total-addresses", "assigned-addresses", "declined-addresses"],
-                                "rows": [[1, 50, 50, 0]],
-                            }
-                        },
-                    }
-                ]
-            return [{"result": 0, "arguments": {}}]
-
-        MockKeaClient.return_value.command.side_effect = side_effect
         url = reverse("plugins:netbox_kea:server_subnets4", args=[self.server.pk])
-        response = self.client.get(url)
+        with stub_kea({"config-get": _config_with_one_subnet()[0], "stat-lease4-get": self._stat(50, total=50)}):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "100%")
 
@@ -308,55 +255,41 @@ class TestServerSubnet4WipeView(_ViewTestBase):
     def _url(self, subnet_id=42):
         return reverse("plugins:netbox_kea:server_subnet4_wipe_leases", args=[self.server.pk, subnet_id])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_returns_confirmation_page(self, MockKeaClient):
+    def test_get_returns_confirmation_page(self):
         """GET must show the wipe confirmation page with subnet info."""
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = [
-            {"result": 0, "arguments": {"subnet4": [{"id": 42, "subnet": "10.0.0.0/24"}]}}
-        ]
-        response = self.client.get(self._url())
+        subnet = {"result": 0, "arguments": {"subnet4": [{"id": 42, "subnet": "10.0.0.0/24"}]}}
+        with stub_kea({"subnet4-get": subnet}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "10.0.0.0/24")
         self.assertContains(response, "42")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_shows_form_when_subnet_fetch_fails(self, MockKeaClient):
+    def test_get_shows_form_when_subnet_fetch_fails(self):
         """GET must still return 200 even when the subnet-get Kea call fails."""
-        from netbox_kea.kea import KeaException
-
-        mock_client = MockKeaClient.return_value
-        mock_client.command.side_effect = KeaException({"result": 1, "text": "not found"}, index=0)
-        response = self.client.get(self._url())
+        with stub_kea({"subnet4-get": {"result": 1, "text": "not found"}}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_calls_lease_wipe_and_redirects(self, MockKeaClient):
+    def test_post_calls_lease_wipe_and_redirects(self):
         """POST must call lease_wipe on the client and redirect to the subnets tab."""
-        mock_client = MockKeaClient.return_value
-        mock_client.lease_wipe.return_value = None
-        response = self.client.post(self._url(subnet_id=10))
+        with stub_kea({"lease4-wipe": {"result": 0}}) as kea:
+            response = self.client.post(self._url(subnet_id=10))
         self.assertEqual(response.status_code, 302)
         self._assert_no_none_pk_redirect(response)
-        mock_client.lease_wipe.assert_called_once_with(version=4, subnet_id=10)
+        self.assertIn("lease4-wipe", kea.commands())
+        self.assertEqual(kea.bodies("lease4-wipe")[0]["arguments"]["subnet-id"], 10)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_on_kea_exception_shows_error_message(self, MockKeaClient):
+    def test_post_on_kea_exception_shows_error_message(self):
         """POST that causes a KeaException must flash an error and redirect (no 500)."""
-        from netbox_kea.kea import KeaException
-
-        mock_client = MockKeaClient.return_value
-        mock_client.lease_wipe.side_effect = KeaException({"result": 1, "text": "hook not loaded"}, index=0)
-        response = self.client.post(self._url())
+        with stub_kea({"lease4-wipe": {"result": 1, "text": "hook not loaded"}}):
+            response = self.client.post(self._url())
         self.assertEqual(response.status_code, 302)
         self._assert_no_none_pk_redirect(response)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_on_unexpected_exception_shows_error_message(self, MockKeaClient):
+    def test_post_on_unexpected_exception_shows_error_message(self):
         """POST that raises an unexpected exception must redirect (no 500)."""
-        mock_client = MockKeaClient.return_value
-        mock_client.lease_wipe.side_effect = ValueError("unexpected")
-        response = self.client.post(self._url())
+        with stub_kea({"lease4-wipe": ValueError("unexpected")}):
+            response = self.client.post(self._url())
         self.assertEqual(response.status_code, 302)
         self._assert_no_none_pk_redirect(response)
 
@@ -380,24 +313,20 @@ class TestServerSubnet6WipeView(_ViewTestBase):
     def _url(self, subnet_id=7):
         return reverse("plugins:netbox_kea:server_subnet6_wipe_leases", args=[self.server.pk, subnet_id])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_returns_200(self, MockKeaClient):
-        mock_client = MockKeaClient.return_value
-        mock_client.command.return_value = [
-            {"result": 0, "arguments": {"subnet6": [{"id": 7, "subnet": "2001:db8::/32"}]}}
-        ]
-        response = self.client.get(self._url())
+    def test_get_returns_200(self):
+        subnet = {"result": 0, "arguments": {"subnet6": [{"id": 7, "subnet": "2001:db8::/32"}]}}
+        with stub_kea({"subnet6-get": subnet}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "2001:db8::/32")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_calls_lease_wipe_v6(self, MockKeaClient):
+    def test_post_calls_lease_wipe_v6(self):
         """POST must call lease_wipe with version=6."""
-        mock_client = MockKeaClient.return_value
-        mock_client.lease_wipe.return_value = None
-        response = self.client.post(self._url(subnet_id=7))
+        with stub_kea({"lease6-wipe": {"result": 0}}) as kea:
+            response = self.client.post(self._url(subnet_id=7))
         self.assertEqual(response.status_code, 302)
-        mock_client.lease_wipe.assert_called_once_with(version=6, subnet_id=7)
+        self.assertIn("lease6-wipe", kea.commands())
+        self.assertEqual(kea.bodies("lease6-wipe")[0]["arguments"]["subnet-id"], 7)
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/netbox_kea/tests/test_views_subnets.py
+++ b/netbox_kea/tests/test_views_subnets.py
@@ -2004,21 +2004,17 @@ class TestSubnetAddNoIdWarning(_ViewTestBase):
 class TestSubnetDeleteClientError(_ViewTestBase):
     """Subnet delete handlers must handle get_client() failures gracefully."""
 
-    @patch("netbox_kea.models.Server.get_client")
-    def test_post_with_get_client_failure_redirects(self, mock_get_client):
-        """get_client() raising in delete POST must redirect with error, not 500."""
-        mock_get_client.side_effect = ValueError("connection refused")
-        url = reverse("plugins:netbox_kea:server_subnet4_delete", args=[self.server.pk, 1])
+    def test_post_with_get_client_failure_redirects(self):
+        """A real get_client() failure (cert without key → ValueError) in delete POST must redirect."""
+        bad = _make_db_server(name="bad-cert-del-post", client_cert_path="/nonexistent/cert.pem")
+        url = reverse("plugins:netbox_kea:server_subnet4_delete", args=[bad.pk, 1])
         response = self.client.post(url, {"confirm": "1"})
         self.assertIn(response.status_code, [200, 302])
 
-    @patch("netbox_kea.models.Server.get_client")
-    def test_get_with_get_client_failure_renders(self, mock_get_client):
-        """get_client() raising in delete GET must render confirm page, not 500."""
-        import requests as req
-
-        mock_get_client.side_effect = req.RequestException("connection refused")
-        url = reverse("plugins:netbox_kea:server_subnet4_delete", args=[self.server.pk, 1])
+    def test_get_with_get_client_failure_renders(self):
+        """A real get_client() failure in delete GET must still render the confirm page, not 500."""
+        bad = _make_db_server(name="bad-cert-del-get", client_cert_path="/nonexistent/cert.pem")
+        url = reverse("plugins:netbox_kea:server_subnet4_delete", args=[bad.pk, 1])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
@@ -2027,19 +2023,17 @@ class TestSubnetDeleteClientError(_ViewTestBase):
 class TestSubnetWipeClientError(_ViewTestBase):
     """Subnet wipe handlers must handle get_client() failures gracefully."""
 
-    @patch("netbox_kea.models.Server.get_client")
-    def test_post_with_get_client_failure_redirects(self, mock_get_client):
-        """get_client() raising in wipe POST must redirect with error, not 500."""
-        mock_get_client.side_effect = ValueError("connection refused")
-        url = reverse("plugins:netbox_kea:server_subnet4_wipe_leases", args=[self.server.pk, 1])
+    def test_post_with_get_client_failure_redirects(self):
+        """A real get_client() failure (cert without key → ValueError) in wipe POST must redirect."""
+        bad = _make_db_server(name="bad-cert-wipe-post", client_cert_path="/nonexistent/cert.pem")
+        url = reverse("plugins:netbox_kea:server_subnet4_wipe_leases", args=[bad.pk, 1])
         response = self.client.post(url, {"confirm": "1"})
         self.assertIn(response.status_code, [200, 302])
 
-    @patch("netbox_kea.models.Server.get_client")
-    def test_get_with_get_client_failure_renders(self, mock_get_client):
-        """get_client() raising in wipe GET must render confirm page, not 500."""
-        mock_get_client.side_effect = ValueError("connection refused")
-        url = reverse("plugins:netbox_kea:server_subnet4_wipe_leases", args=[self.server.pk, 1])
+    def test_get_with_get_client_failure_renders(self):
+        """A real get_client() failure in wipe GET must still render the confirm page, not 500."""
+        bad = _make_db_server(name="bad-cert-wipe-get", client_cert_path="/nonexistent/cert.pem")
+        url = reverse("plugins:netbox_kea:server_subnet4_wipe_leases", args=[bad.pk, 1])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
@@ -2048,13 +2042,12 @@ class TestSubnetWipeClientError(_ViewTestBase):
 class TestPoolDeleteClientError(_ViewTestBase):
     """Pool delete POST handler must handle get_client() failures gracefully."""
 
-    @patch("netbox_kea.models.Server.get_client")
-    def test_post_with_get_client_failure_redirects(self, mock_get_client):
-        """get_client() raising in pool-delete POST must redirect with error, not 500."""
-        mock_get_client.side_effect = ValueError("connection refused")
+    def test_post_with_get_client_failure_redirects(self):
+        """A real get_client() failure (cert without key → ValueError) in pool-delete POST must redirect."""
+        bad = _make_db_server(name="bad-cert-pool-del", client_cert_path="/nonexistent/cert.pem")
         url = reverse(
             "plugins:netbox_kea:server_subnet4_pool_delete",
-            args=[self.server.pk, 1, "10.0.0.1-10.0.0.100"],
+            args=[bad.pk, 1, "10.0.0.1-10.0.0.100"],
         )
         response = self.client.post(url, {"confirm": "1"})
         self.assertIn(response.status_code, [200, 302])
@@ -2069,20 +2062,20 @@ class TestPoolDeleteClientError(_ViewTestBase):
 class TestGetSubnetsConfigShapeGuard(_ViewTestBase):
     """get_subnets() returns [] when config-get arguments is non-dict."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_non_dict_arguments_returns_empty_list(self, MockKeaClient):
-        """Non-dict arguments in config-get response must return empty subnet list."""
-        MockKeaClient.return_value.command.return_value = [{"result": 0, "arguments": "unexpected string"}]
+    def test_non_dict_arguments_returns_empty_list(self):
+        """Non-dict (string) arguments in config-get must yield an empty subnet list, not a 500."""
         url = reverse("plugins:netbox_kea:server_subnets4", args=[self.server.pk])
-        response = self.client.get(url)
+        with stub_kea(
+            {"config-get": {"result": 0, "arguments": "unexpected string"}, "stat-lease4-get": _STAT_ABSENT4}
+        ):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_integer_arguments_returns_empty_list(self, MockKeaClient):
-        """Integer arguments in config-get response must return empty subnet list."""
-        MockKeaClient.return_value.command.return_value = [{"result": 0, "arguments": 42}]
+    def test_integer_arguments_returns_empty_list(self):
+        """Integer arguments in config-get must yield an empty subnet list, not a 500."""
         url = reverse("plugins:netbox_kea:server_subnets4", args=[self.server.pk])
-        response = self.client.get(url)
+        with stub_kea({"config-get": {"result": 0, "arguments": 42}, "stat-lease4-get": _STAT_ABSENT4}):
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
 
@@ -2098,38 +2091,48 @@ class TestPoolAddPostErrors(_ViewTestBase):
     def _url(self, subnet_id=1):
         return reverse("plugins:netbox_kea:server_subnet4_pool_add", args=[self.server.pk, subnet_id])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_partial_persist_shows_warning(self, MockKeaClient):
-        """PartialPersistError from pool_add shows warning about config-write."""
-        from netbox_kea.kea import PartialPersistError
+    def _pool_add_stub(self, **overrides):
+        """pool_add chain: reservation overlap probe → list-commands → subnet4-pool-add → persist.
 
-        MockKeaClient.return_value.pool_add.side_effect = PartialPersistError(
-            "dhcp4", Exception("write failed"), subnet_id=1
-        )
-        response = self.client.post(self._url(), {"pool": "10.0.0.10-10.0.0.20"}, follow=True)
+        follow=True lands on the subnets list (config-get + stat). Override a leg to drive errors.
+        """
+        base = {
+            "reservation-get-page": {"result": 3},
+            "list-commands": {
+                "result": 0,
+                "arguments": ["subnet4-pool-add", "config-get", "config-test", "config-write"],
+            },
+            "subnet4-pool-add": {"result": 0},
+            "config-get": _EMPTY_CONFIG4,
+            "config-test": {"result": 0},
+            "config-write": {"result": 0},
+            "stat-lease4-get": _STAT_ABSENT4,
+        }
+        base.update(overrides)
+        return stub_kea(base)
+
+    def test_partial_persist_shows_warning(self):
+        """A config-write failure (PartialPersistError) from pool_add re-renders without a 500."""
+        with self._pool_add_stub(**{"config-write": {"result": 1, "text": "disk full"}}):
+            response = self.client.post(self._url(), {"pool": "10.0.0.10-10.0.0.20"}, follow=True)
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_kea_exception_shows_error(self, MockKeaClient):
-        """KeaException from pool_add shows Kea error message."""
-        from netbox_kea.kea import KeaException
-
-        MockKeaClient.return_value.pool_add.side_effect = KeaException({"result": 1, "text": "pool overlap"}, index=0)
-        response = self.client.post(self._url(), {"pool": "10.0.0.10-10.0.0.20"}, follow=True)
+    def test_kea_exception_shows_error(self):
+        """A KeaException (subnet4-pool-add result 1) from pool_add shows a Kea error, no 500."""
+        with self._pool_add_stub(**{"subnet4-pool-add": {"result": 1, "text": "pool overlap"}}):
+            response = self.client.post(self._url(), {"pool": "10.0.0.10-10.0.0.20"}, follow=True)
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_request_exception_shows_error(self, MockKeaClient):
-        """RequestException from pool_add shows transport error message."""
-        MockKeaClient.return_value.pool_add.side_effect = requests.ConnectionError("down")
-        response = self.client.post(self._url(), {"pool": "10.0.0.10-10.0.0.20"}, follow=True)
+    def test_request_exception_shows_error(self):
+        """A transport error from pool_add shows a transport error message, no 500."""
+        with self._pool_add_stub(**{"subnet4-pool-add": requests.ConnectionError("down")}):
+            response = self.client.post(self._url(), {"pool": "10.0.0.10-10.0.0.20"}, follow=True)
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_generic_exception_shows_error(self, MockKeaClient):
-        """Generic exception from pool_add shows generic error."""
-        MockKeaClient.return_value.pool_add.side_effect = ValueError("unexpected")
-        response = self.client.post(self._url(), {"pool": "10.0.0.10-10.0.0.20"}, follow=True)
+    def test_generic_exception_shows_error(self):
+        """A generic (ValueError) failure from pool_add shows a generic error, no 500."""
+        with self._pool_add_stub(**{"subnet4-pool-add": ValueError("unexpected")}):
+            response = self.client.post(self._url(), {"pool": "10.0.0.10-10.0.0.20"}, follow=True)
         self.assertEqual(response.status_code, 200)
 
 
@@ -2145,45 +2148,51 @@ class TestPoolDeletePostErrors(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_subnet4_pool_delete", args=[self.server.pk, 1, "10.0.0.1-10.0.0.100"])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_partial_persist_shows_warning(self, MockKeaClient):
-        """PartialPersistError from pool_del shows warning."""
-        from netbox_kea.kea import PartialPersistError
+    def _pool_del_stub(self, **overrides):
+        """pool_del chain: list-commands → subnet4-pool-del → persist, + the followed subnets list."""
+        base = {
+            "list-commands": {
+                "result": 0,
+                "arguments": ["subnet4-pool-del", "config-get", "config-test", "config-write"],
+            },
+            "subnet4-pool-del": {"result": 0},
+            "config-get": _EMPTY_CONFIG4,
+            "config-test": {"result": 0},
+            "config-write": {"result": 0},
+            "stat-lease4-get": _STAT_ABSENT4,
+        }
+        base.update(overrides)
+        return stub_kea(base)
 
-        MockKeaClient.return_value.pool_del.side_effect = PartialPersistError(
-            "dhcp4", Exception("write failed"), subnet_id=1
-        )
-        response = self.client.post(self._url(), follow=True)
+    def test_partial_persist_shows_warning(self):
+        """A config-write failure (PartialPersistError) from pool_del re-renders without a 500."""
+        with self._pool_del_stub(**{"config-write": {"result": 1, "text": "disk full"}}):
+            response = self.client.post(self._url(), follow=True)
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_kea_exception_shows_error(self, MockKeaClient):
-        """KeaException from pool_del shows Kea error."""
-        from netbox_kea.kea import KeaException
-
-        MockKeaClient.return_value.pool_del.side_effect = KeaException({"result": 1, "text": "not found"}, index=0)
-        response = self.client.post(self._url(), follow=True)
+    def test_kea_exception_shows_error(self):
+        """A KeaException (subnet4-pool-del result 1) from pool_del shows a Kea error, no 500."""
+        with self._pool_del_stub(**{"subnet4-pool-del": {"result": 1, "text": "not found"}}):
+            response = self.client.post(self._url(), follow=True)
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_request_exception_shows_error(self, MockKeaClient):
-        """RequestException from pool_del shows transport error."""
-        MockKeaClient.return_value.pool_del.side_effect = requests.ConnectionError("down")
-        response = self.client.post(self._url(), follow=True)
+    def test_request_exception_shows_error(self):
+        """A transport error from pool_del shows a transport error message, no 500."""
+        with self._pool_del_stub(**{"subnet4-pool-del": requests.ConnectionError("down")}):
+            response = self.client.post(self._url(), follow=True)
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_generic_exception_shows_error(self, MockKeaClient):
-        """Generic exception from pool_del shows generic error."""
-        MockKeaClient.return_value.pool_del.side_effect = ValueError("unexpected")
-        response = self.client.post(self._url(), follow=True)
+    def test_generic_exception_shows_error(self):
+        """A generic (ValueError) failure from pool_del shows a generic error, no 500."""
+        with self._pool_del_stub(**{"subnet4-pool-del": ValueError("unexpected")}):
+            response = self.client.post(self._url(), follow=True)
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_client_failure_redirects(self, MockKeaClient):
-        """get_client failure in pool delete redirects with error."""
-        MockKeaClient.side_effect = ValueError("connection refused")
-        response = self.client.post(self._url())
+    def test_get_client_failure_redirects(self):
+        """A real get_client() failure (cert without key → ValueError) in pool delete redirects."""
+        bad = _make_db_server(name="bad-cert-pool-del-err", client_cert_path="/nonexistent/cert.pem")
+        url = reverse("plugins:netbox_kea:server_subnet4_pool_delete", args=[bad.pk, 1, "10.0.0.1-10.0.0.100"])
+        response = self.client.post(url)
         self.assertEqual(response.status_code, 302)
 
 

--- a/netbox_kea/tests/test_views_subnets.py
+++ b/netbox_kea/tests/test_views_subnets.py
@@ -2388,56 +2388,29 @@ class TestSubnetListNonDictItems(_ViewTestBase):
 class TestGetNetworkDataNonDictSubnet(_ViewTestBase):
     """F10: _get_network_data returns None network when shared-network has non-dict subnet."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_edit_loads_with_malformed_subnet_in_shared_network(self, MockKeaClient):
-        """Edit page loads when a shared-network contains non-dict subnet items."""
-        subnet_get_resp = [
-            {
-                "result": 0,
-                "arguments": {
-                    "subnet4": [
-                        {
-                            "id": 42,
-                            "subnet": "10.0.0.0/24",
-                            "pools": [],
-                            "option-data": [],
-                            "valid-lft": 3600,
-                        }
-                    ]
-                },
-            }
-        ]
-        config_get_resp = [
-            {
-                "result": 0,
-                "arguments": {
-                    "Dhcp4": {
-                        "subnet4": [{"id": 42, "subnet": "10.0.0.0/24"}],
-                        "shared-networks": [
-                            {
-                                "name": "net1",
-                                "subnet4": [
-                                    {"id": 1, "subnet": "10.0.0.0/24"},
-                                    "bad",
-                                ],
-                            }
-                        ],
-                    }
-                },
-            }
-        ]
-
-        def _cmd(command, **_kwargs):
-            if "subnet4-get" in command:
-                return subnet_get_resp
-            if command == "config-get":
-                return config_get_resp
-            return [{"result": 0, "arguments": {}}]
-
-        MockKeaClient.return_value.command.side_effect = _cmd
+    def test_edit_loads_with_malformed_subnet_in_shared_network(self):
+        """Edit page loads (or redirects) when a shared-network contains non-dict subnet items."""
+        subnet_get_resp = {
+            "result": 0,
+            "arguments": {
+                "subnet4": [{"id": 42, "subnet": "10.0.0.0/24", "pools": [], "option-data": [], "valid-lft": 3600}]
+            },
+        }
+        config_get_resp = {
+            "result": 0,
+            "arguments": {
+                "Dhcp4": {
+                    "subnet4": [{"id": 42, "subnet": "10.0.0.0/24"}],
+                    "shared-networks": [
+                        {"name": "net1", "subnet4": [{"id": 1, "subnet": "10.0.0.0/24"}, "bad"]},
+                    ],
+                }
+            },
+        }
         url = reverse("plugins:netbox_kea:server_subnet4_edit", args=[self.server.pk, 42])
-        response = self.client.get(url)
-        # _get_network_data returns None → view aborts edit and redirects
+        with stub_kea({"subnet4-get": subnet_get_resp, "config-get": config_get_resp}):
+            response = self.client.get(url)
+        # _get_network_data returns None (malformed) → view still renders or redirects, never 500.
         self.assertIn(response.status_code, (200, 302))
 
 
@@ -2453,158 +2426,129 @@ class TestSubnetViewCoverageGaps(_ViewTestBase):
     def _subnets4_url(self):
         return reverse("plugins:netbox_kea:server_subnets4", args=[self.server.pk])
 
+    def _list_stub(self, config, stat=None):
+        """Subnets-list GET chain: config-get (subnets) + stat-lease4-get (utilisation)."""
+        return stub_kea({"config-get": config, "stat-lease4-get": stat if stat is not None else _STAT_ABSENT4})
+
+    def _pool_add_stub(self, **overrides):
+        """pool_add chain: reservation overlap probe → list-commands → subnet4-pool-add → persist + list."""
+        base = {
+            "reservation-get-page": {"result": 3},
+            "list-commands": {
+                "result": 0,
+                "arguments": ["subnet4-pool-add", "config-get", "config-test", "config-write"],
+            },
+            "subnet4-pool-add": {"result": 0},
+            "config-get": _EMPTY_CONFIG4,
+            "config-test": {"result": 0},
+            "config-write": {"result": 0},
+            "stat-lease4-get": _STAT_ABSENT4,
+        }
+        base.update(overrides)
+        return stub_kea(base)
+
+    def _pool_del_stub(self, **overrides):
+        """pool_del chain: list-commands → subnet4-pool-del → persist + the followed subnets list."""
+        base = {
+            "list-commands": {
+                "result": 0,
+                "arguments": ["subnet4-pool-del", "config-get", "config-test", "config-write"],
+            },
+            "subnet4-pool-del": {"result": 0},
+            "config-get": _EMPTY_CONFIG4,
+            "config-test": {"result": 0},
+            "config-write": {"result": 0},
+            "stat-lease4-get": _STAT_ABSENT4,
+        }
+        base.update(overrides)
+        return stub_kea(base)
+
     # ── 1. config-get returns non-dict arguments (~lines 92-99) ──────────
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_config_get_non_dict_arguments_returns_empty_subnets(self, MockKeaClient):
-        """When config-get returns arguments='not-a-dict', view logs warning and returns 200 with no subnets."""
-        MockKeaClient.return_value.command.return_value = [{"result": 0, "arguments": "not-a-dict"}]
-        response = self.client.get(self._subnets4_url())
+    def test_config_get_non_dict_arguments_returns_empty_subnets(self):
+        """config-get returning arguments='not-a-dict' logs a warning and returns 200 with no subnets."""
+        with self._list_stub({"result": 0, "arguments": "not-a-dict"}):
+            response = self.client.get(self._subnets4_url())
         self.assertEqual(response.status_code, 200)
-        table = response.context["table"]
-        self.assertEqual(len(table.data), 0)
+        self.assertEqual(len(response.context["table"].data), 0)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_config_get_list_arguments_returns_empty_subnets(self, MockKeaClient):
-        """When config-get returns arguments=[...], view logs warning and returns 200 with no subnets."""
-        MockKeaClient.return_value.command.return_value = [{"result": 0, "arguments": [1, 2, 3]}]
-        response = self.client.get(self._subnets4_url())
+    def test_config_get_list_arguments_returns_empty_subnets(self):
+        """config-get returning arguments=[...] logs a warning and returns 200 with no subnets."""
+        with self._list_stub({"result": 0, "arguments": [1, 2, 3]}):
+            response = self.client.get(self._subnets4_url())
         self.assertEqual(response.status_code, 200)
-        table = response.context["table"]
-        self.assertEqual(len(table.data), 0)
+        self.assertEqual(len(response.context["table"].data), 0)
 
     # ── 2. Stats enrichment exception paths (~lines 130-134) ─────────────
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_stats_value_error_still_renders_subnets(self, MockKeaClient):
+    def test_stats_value_error_still_renders_subnets(self):
         """When stat-lease4-get raises ValueError, subnets render without utilisation."""
-
-        def side_effect(cmd, service=None, arguments=None, check=None):
-            if cmd == "config-get":
-                return _config_with_one_subnet(service)
-            if cmd == "stat-lease4-get":
-                raise ValueError("bad stat response")
-            return [{"result": 0, "arguments": {}}]
-
-        MockKeaClient.return_value.command.side_effect = side_effect
-        response = self.client.get(self._subnets4_url())
+        with self._list_stub(_config_with_one_subnet()[0], stat=ValueError("bad stat response")):
+            response = self.client.get(self._subnets4_url())
         self.assertEqual(response.status_code, 200)
         table = response.context["table"]
         self.assertEqual(len(table.data), 1)
         # No utilisation columns should be present
         self.assertNotIn("utilization", list(table.data)[0])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_stats_type_error_still_renders_subnets(self, MockKeaClient):
+    def test_stats_type_error_still_renders_subnets(self):
         """When stat-lease4-get raises TypeError, subnets render without utilisation."""
-
-        def side_effect(cmd, service=None, arguments=None, check=None):
-            if cmd == "config-get":
-                return _config_with_one_subnet(service)
-            if cmd == "stat-lease4-get":
-                raise TypeError("unexpected None in stat parsing")
-            return [{"result": 0, "arguments": {}}]
-
-        MockKeaClient.return_value.command.side_effect = side_effect
-        response = self.client.get(self._subnets4_url())
+        with self._list_stub(_config_with_one_subnet()[0], stat=TypeError("unexpected None in stat parsing")):
+            response = self.client.get(self._subnets4_url())
         self.assertEqual(response.status_code, 200)
-        table = response.context["table"]
-        self.assertEqual(len(table.data), 1)
+        self.assertEqual(len(response.context["table"].data), 1)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_stats_key_error_still_renders_subnets(self, MockKeaClient):
+    def test_stats_key_error_still_renders_subnets(self):
         """When stat-lease4-get raises KeyError, subnets render without utilisation."""
-
-        def side_effect(cmd, service=None, arguments=None, check=None):
-            if cmd == "config-get":
-                return _config_with_one_subnet(service)
-            if cmd == "stat-lease4-get":
-                raise KeyError("result-set")
-            return [{"result": 0, "arguments": {}}]
-
-        MockKeaClient.return_value.command.side_effect = side_effect
-        response = self.client.get(self._subnets4_url())
+        with self._list_stub(_config_with_one_subnet()[0], stat=KeyError("result-set")):
+            response = self.client.get(self._subnets4_url())
         self.assertEqual(response.status_code, 200)
-        table = response.context["table"]
-        self.assertEqual(len(table.data), 1)
+        self.assertEqual(len(response.context["table"].data), 1)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_stats_request_exception_still_renders_subnets(self, MockKeaClient):
+    def test_stats_request_exception_still_renders_subnets(self):
         """When stat-lease4-get raises RequestException, subnets render without utilisation."""
-
-        def side_effect(cmd, service=None, arguments=None, check=None):
-            if cmd == "config-get":
-                return _config_with_one_subnet(service)
-            if cmd == "stat-lease4-get":
-                raise requests.RequestException("timeout")
-            return [{"result": 0, "arguments": {}}]
-
-        MockKeaClient.return_value.command.side_effect = side_effect
-        response = self.client.get(self._subnets4_url())
+        with self._list_stub(_config_with_one_subnet()[0], stat=requests.RequestException("timeout")):
+            response = self.client.get(self._subnets4_url())
         self.assertEqual(response.status_code, 200)
-        table = response.context["table"]
-        self.assertEqual(len(table.data), 1)
+        self.assertEqual(len(response.context["table"].data), 1)
 
     # ── 3. _subnet_to_row with non-scalar ID (~lines 56-58) ─────────────
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_subnet_with_list_id_is_skipped(self, MockKeaClient):
+    def test_subnet_with_list_id_is_skipped(self):
         """Subnet with id=[1,2,3] must be skipped (non-scalar ID)."""
-
-        def side_effect(cmd, service=None, arguments=None, check=None):
-            if cmd == "config-get":
-                return [
-                    {
-                        "result": 0,
-                        "arguments": {
-                            "Dhcp4": {
-                                "subnet4": [
-                                    {"id": [1, 2, 3], "subnet": "10.0.0.0/24"},
-                                    {"id": 2, "subnet": "10.0.1.0/24"},
-                                ],
-                                "shared-networks": [],
-                            }
-                        },
-                    }
-                ]
-            if cmd == "stat-lease4-get":
-                raise ValueError("no stat_cmds")
-            return [{"result": 0, "arguments": {}}]
-
-        MockKeaClient.return_value.command.side_effect = side_effect
-        response = self.client.get(self._subnets4_url())
+        config = {
+            "result": 0,
+            "arguments": {
+                "Dhcp4": {
+                    "subnet4": [{"id": [1, 2, 3], "subnet": "10.0.0.0/24"}, {"id": 2, "subnet": "10.0.1.0/24"}],
+                    "shared-networks": [],
+                }
+            },
+        }
+        with self._list_stub(config):
+            response = self.client.get(self._subnets4_url())
         self.assertEqual(response.status_code, 200)
         table = response.context["table"]
         # Only subnet with id=2 should appear; id=[1,2,3] is skipped
         self.assertEqual(len(table.data), 1)
         self.assertEqual(list(table.data)[0]["id"], 2)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_subnet_with_dict_id_is_skipped(self, MockKeaClient):
+    def test_subnet_with_dict_id_is_skipped(self):
         """Subnet with id={"nested": "dict"} must be skipped (non-scalar ID)."""
-
-        def side_effect(cmd, service=None, arguments=None, check=None):
-            if cmd == "config-get":
-                return [
-                    {
-                        "result": 0,
-                        "arguments": {
-                            "Dhcp4": {
-                                "subnet4": [
-                                    {"id": {"nested": "dict"}, "subnet": "10.0.0.0/24"},
-                                    {"id": 5, "subnet": "10.0.2.0/24"},
-                                ],
-                                "shared-networks": [],
-                            }
-                        },
-                    }
-                ]
-            if cmd == "stat-lease4-get":
-                raise ValueError("no stat_cmds")
-            return [{"result": 0, "arguments": {}}]
-
-        MockKeaClient.return_value.command.side_effect = side_effect
-        response = self.client.get(self._subnets4_url())
+        config = {
+            "result": 0,
+            "arguments": {
+                "Dhcp4": {
+                    "subnet4": [
+                        {"id": {"nested": "dict"}, "subnet": "10.0.0.0/24"},
+                        {"id": 5, "subnet": "10.0.2.0/24"},
+                    ],
+                    "shared-networks": [],
+                }
+            },
+        }
+        with self._list_stub(config):
+            response = self.client.get(self._subnets4_url())
         self.assertEqual(response.status_code, 200)
         table = response.context["table"]
         self.assertEqual(len(table.data), 1)
@@ -2612,63 +2556,37 @@ class TestSubnetViewCoverageGaps(_ViewTestBase):
 
     # ── 4. _subnet_to_row with malformed CIDR (~lines 60-62) ────────────
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_subnet_with_malformed_cidr_is_skipped(self, MockKeaClient):
+    def test_subnet_with_malformed_cidr_is_skipped(self):
         """Subnet with subnet='not-a-cidr' must be skipped and logged."""
-
-        def side_effect(cmd, service=None, arguments=None, check=None):
-            if cmd == "config-get":
-                return [
-                    {
-                        "result": 0,
-                        "arguments": {
-                            "Dhcp4": {
-                                "subnet4": [
-                                    {"id": 1, "subnet": "not-a-cidr"},
-                                    {"id": 2, "subnet": "192.168.1.0/24"},
-                                ],
-                                "shared-networks": [],
-                            }
-                        },
-                    }
-                ]
-            if cmd == "stat-lease4-get":
-                raise ValueError("no stat_cmds")
-            return [{"result": 0, "arguments": {}}]
-
-        MockKeaClient.return_value.command.side_effect = side_effect
-        response = self.client.get(self._subnets4_url())
+        config = {
+            "result": 0,
+            "arguments": {
+                "Dhcp4": {
+                    "subnet4": [{"id": 1, "subnet": "not-a-cidr"}, {"id": 2, "subnet": "192.168.1.0/24"}],
+                    "shared-networks": [],
+                }
+            },
+        }
+        with self._list_stub(config):
+            response = self.client.get(self._subnets4_url())
         self.assertEqual(response.status_code, 200)
         table = response.context["table"]
         self.assertEqual(len(table.data), 1)
         self.assertEqual(list(table.data)[0]["subnet"], "192.168.1.0/24")
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_subnet_with_empty_cidr_is_skipped(self, MockKeaClient):
+    def test_subnet_with_empty_cidr_is_skipped(self):
         """Subnet with subnet='' must be skipped (ValueError from ip_network)."""
-
-        def side_effect(cmd, service=None, arguments=None, check=None):
-            if cmd == "config-get":
-                return [
-                    {
-                        "result": 0,
-                        "arguments": {
-                            "Dhcp4": {
-                                "subnet4": [
-                                    {"id": 1, "subnet": ""},
-                                    {"id": 2, "subnet": "172.16.0.0/16"},
-                                ],
-                                "shared-networks": [],
-                            }
-                        },
-                    }
-                ]
-            if cmd == "stat-lease4-get":
-                raise ValueError("no stat_cmds")
-            return [{"result": 0, "arguments": {}}]
-
-        MockKeaClient.return_value.command.side_effect = side_effect
-        response = self.client.get(self._subnets4_url())
+        config = {
+            "result": 0,
+            "arguments": {
+                "Dhcp4": {
+                    "subnet4": [{"id": 1, "subnet": ""}, {"id": 2, "subnet": "172.16.0.0/16"}],
+                    "shared-networks": [],
+                }
+            },
+        }
+        with self._list_stub(config):
+            response = self.client.get(self._subnets4_url())
         self.assertEqual(response.status_code, 200)
         table = response.context["table"]
         self.assertEqual(len(table.data), 1)
@@ -2676,144 +2594,117 @@ class TestSubnetViewCoverageGaps(_ViewTestBase):
 
     # ── 5. Subnet edit POST error paths (~lines 963-1010) ────────────────
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_subnet_edit_post_request_exception_rerenders_form(self, MockKeaClient):
-        """POST that raises RequestException on subnet_update must re-render form (200)."""
-        MockKeaClient.return_value.command.return_value = _CONFIG4_NO_NETWORKS
-        MockKeaClient.return_value.subnet_update.side_effect = requests.RequestException("connection lost")
+    # the live subnet subnet4-get returns before subnet4-update runs.
+    _LIVE_SUBNET4 = {
+        "result": 0,
+        "arguments": {"subnet4": [{"id": 42, "subnet": "10.0.0.0/24", "pools": [], "option-data": []}]},
+    }
+    _EDIT_POST = {"subnet_cidr": "10.0.0.0/24", "pools": "", "gateway": "", "dns_servers": "", "ntp_servers": ""}
+
+    def test_subnet_edit_post_request_exception_rerenders_form(self):
+        """A transport error on subnet_update must re-render the form (200)."""
+        stub = {
+            "config-get": _CONFIG4_NO_NETWORKS[0],
+            "subnet4-get": self._LIVE_SUBNET4,
+            "subnet4-update": requests.RequestException("connection lost"),
+        }
         url = reverse("plugins:netbox_kea:server_subnet4_edit", args=[self.server.pk, 42])
-        response = self.client.post(
-            url,
-            {"subnet_cidr": "10.0.0.0/24", "pools": "", "gateway": "", "dns_servers": "", "ntp_servers": ""},
-        )
+        with stub_kea(stub) as kea:
+            response = self.client.post(url, self._EDIT_POST)
         self.assertEqual(response.status_code, 200)
-        MockKeaClient.return_value.subnet_update.assert_called_once()
+        self.assertEqual(kea.commands().count("subnet4-update"), 1)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_subnet_edit_post_kea_exception_rerenders_with_error_message(self, MockKeaClient):
-        """POST that raises KeaException must show error message and re-render form."""
-        from netbox_kea.kea import KeaException
-
-        MockKeaClient.return_value.command.return_value = _CONFIG4_NO_NETWORKS
-        MockKeaClient.return_value.subnet_update.side_effect = KeaException(
-            {"result": 1, "text": "subnet not found"}, index=0
-        )
+    def test_subnet_edit_post_kea_exception_rerenders_with_error_message(self):
+        """A KeaException (subnet4-update result 1) must show an error and re-render the form."""
+        stub = {
+            "config-get": _CONFIG4_NO_NETWORKS[0],
+            "subnet4-get": self._LIVE_SUBNET4,
+            "subnet4-update": {"result": 1, "text": "subnet not found"},
+        }
         url = reverse("plugins:netbox_kea:server_subnet4_edit", args=[self.server.pk, 42])
-        response = self.client.post(
-            url,
-            {"subnet_cidr": "10.0.0.0/24", "pools": "", "gateway": "", "dns_servers": "", "ntp_servers": ""},
-        )
+        with stub_kea(stub):
+            response = self.client.post(url, self._EDIT_POST)
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_subnet_edit_post_client_creation_failure_redirects(self, MockKeaClient):
-        """POST where get_client raises ValueError must redirect to subnets."""
-        MockKeaClient.side_effect = ValueError("bad config")
-        url = reverse("plugins:netbox_kea:server_subnet4_edit", args=[self.server.pk, 42])
-        response = self.client.post(
-            url,
-            {"subnet_cidr": "10.0.0.0/24", "pools": "", "gateway": "", "dns_servers": "", "ntp_servers": ""},
-        )
+    def test_subnet_edit_post_client_creation_failure_redirects(self):
+        """A real get_client() failure (cert without key → ValueError) in edit POST must redirect."""
+        bad = _make_db_server(name="bad-cert-edit-cov", client_cert_path="/nonexistent/cert.pem")
+        url = reverse("plugins:netbox_kea:server_subnet4_edit", args=[bad.pk, 42])
+        response = self.client.post(url, self._EDIT_POST)
         self.assertEqual(response.status_code, 302)
         self.assertIn("subnets", response.url)
 
     # ── 6. Pool add with reservation overlap warning (~lines 204-257) ────
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_pool_add_reservation_lookup_failure_suppresses_warning(self, MockKeaClient):
-        """When reservation_get_page raises KeaException during pool add, warning is suppressed."""
-        from netbox_kea.kea import KeaException
+    def _pool_add_url(self):
+        return reverse("plugins:netbox_kea:server_subnet4_pool_add", args=[self.server.pk, 42])
 
-        MockKeaClient.return_value.reservation_get_page.side_effect = KeaException(
-            {"result": 2, "text": "host_cmds not loaded"}, index=0
+    def _pool_del_url(self):
+        return reverse(
+            "plugins:netbox_kea:server_subnet4_pool_delete", args=[self.server.pk, 42, "10.0.0.100-10.0.0.200"]
         )
-        MockKeaClient.return_value.pool_add.return_value = None
-        url = reverse("plugins:netbox_kea:server_subnet4_pool_add", args=[self.server.pk, 42])
-        response = self.client.post(url, {"pool": "10.0.0.100-10.0.0.200"}, follow=True)
+
+    def test_pool_add_reservation_lookup_failure_suppresses_warning(self):
+        """A reservation overlap probe failing (result 2 → KeaException) is suppressed; pool_add succeeds."""
+        with self._pool_add_stub(**{"reservation-get-page": {"result": 2, "text": "host_cmds not loaded"}}):
+            response = self.client.post(self._pool_add_url(), {"pool": "10.0.0.100-10.0.0.200"}, follow=True)
         self.assertEqual(response.status_code, 200)
         msgs = list(response.context["messages"])
-        # Success message should be present, but no overlap warning
+        # success message present, but no overlap warning
         self.assertTrue(any(m.level == django_messages.SUCCESS for m in msgs))
         self.assertFalse(any("overlaps" in m.message.lower() for m in msgs))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_pool_add_reservation_lookup_request_exception_suppresses_warning(self, MockKeaClient):
-        """When reservation_get_page raises RequestException during pool add, warning is suppressed."""
-        MockKeaClient.return_value.reservation_get_page.side_effect = requests.RequestException("timeout")
-        MockKeaClient.return_value.pool_add.return_value = None
-        url = reverse("plugins:netbox_kea:server_subnet4_pool_add", args=[self.server.pk, 42])
-        response = self.client.post(url, {"pool": "10.0.0.100-10.0.0.200"}, follow=True)
+    def test_pool_add_reservation_lookup_request_exception_suppresses_warning(self):
+        """A reservation overlap probe raising a transport error is suppressed; pool_add succeeds."""
+        with self._pool_add_stub(**{"reservation-get-page": requests.RequestException("timeout")}):
+            response = self.client.post(self._pool_add_url(), {"pool": "10.0.0.100-10.0.0.200"}, follow=True)
         self.assertEqual(response.status_code, 200)
         msgs = list(response.context["messages"])
         self.assertTrue(any(m.level == django_messages.SUCCESS for m in msgs))
         self.assertFalse(any("overlaps" in m.message.lower() for m in msgs))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_pool_add_kea_exception_shows_error(self, MockKeaClient):
-        """KeaException on pool_add must show error message."""
-        from netbox_kea.kea import KeaException
-
-        MockKeaClient.return_value.reservation_get_page.return_value = ([], 0, 0)
-        MockKeaClient.return_value.pool_add.side_effect = KeaException(
-            {"result": 1, "text": "pool already exists"}, index=0
-        )
-        url = reverse("plugins:netbox_kea:server_subnet4_pool_add", args=[self.server.pk, 42])
-        response = self.client.post(url, {"pool": "10.0.0.100-10.0.0.200"}, follow=True)
+    def test_pool_add_kea_exception_shows_error(self):
+        """A KeaException (subnet4-pool-add result 1) on pool_add must show an error."""
+        with self._pool_add_stub(**{"subnet4-pool-add": {"result": 1, "text": "pool already exists"}}):
+            response = self.client.post(self._pool_add_url(), {"pool": "10.0.0.100-10.0.0.200"}, follow=True)
         msgs = list(response.context["messages"])
         self.assertTrue(any(m.level == django_messages.ERROR for m in msgs))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_pool_add_request_exception_shows_network_error(self, MockKeaClient):
-        """RequestException on pool_add must show network error message."""
-        MockKeaClient.return_value.reservation_get_page.return_value = ([], 0, 0)
-        MockKeaClient.return_value.pool_add.side_effect = requests.RequestException("connection refused")
-        url = reverse("plugins:netbox_kea:server_subnet4_pool_add", args=[self.server.pk, 42])
-        response = self.client.post(url, {"pool": "10.0.0.100-10.0.0.200"}, follow=True)
+    def test_pool_add_request_exception_shows_network_error(self):
+        """A transport error on pool_add must show a network error message."""
+        with self._pool_add_stub(**{"subnet4-pool-add": requests.RequestException("connection refused")}):
+            response = self.client.post(self._pool_add_url(), {"pool": "10.0.0.100-10.0.0.200"}, follow=True)
         msgs = list(response.context["messages"])
         self.assertTrue(any(m.level == django_messages.ERROR for m in msgs))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_pool_add_client_creation_failure_redirects(self, MockKeaClient):
-        """When get_client raises ValueError during pool add POST, view redirects with error."""
-        MockKeaClient.side_effect = ValueError("invalid url config")
-        url = reverse("plugins:netbox_kea:server_subnet4_pool_add", args=[self.server.pk, 42])
+    def test_pool_add_client_creation_failure_redirects(self):
+        """A real get_client() failure (cert without key → ValueError) in pool add POST shows an error."""
+        bad = _make_db_server(name="bad-cert-pooladd-cov", client_cert_path="/nonexistent/cert.pem")
+        url = reverse("plugins:netbox_kea:server_subnet4_pool_add", args=[bad.pk, 42])
         response = self.client.post(url, {"pool": "10.0.0.100-10.0.0.200"}, follow=True)
         msgs = list(response.context["messages"])
         self.assertTrue(any(m.level == django_messages.ERROR for m in msgs))
 
     # ── Pool delete exception paths ──────────────────────────────────────
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_pool_delete_kea_exception_shows_error(self, MockKeaClient):
-        """KeaException on pool_del must show error message."""
-        from netbox_kea.kea import KeaException
-
-        MockKeaClient.return_value.pool_del.side_effect = KeaException({"result": 1, "text": "pool not found"}, index=0)
-        url = reverse(
-            "plugins:netbox_kea:server_subnet4_pool_delete", args=[self.server.pk, 42, "10.0.0.100-10.0.0.200"]
-        )
-        response = self.client.post(url, follow=True)
+    def test_pool_delete_kea_exception_shows_error(self):
+        """A KeaException (subnet4-pool-del result 1) on pool_del must show an error."""
+        with self._pool_del_stub(**{"subnet4-pool-del": {"result": 1, "text": "pool not found"}}):
+            response = self.client.post(self._pool_del_url(), follow=True)
         msgs = list(response.context["messages"])
         self.assertTrue(any(m.level == django_messages.ERROR for m in msgs))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_pool_delete_request_exception_shows_network_error(self, MockKeaClient):
-        """RequestException on pool_del must show network error message."""
-        MockKeaClient.return_value.pool_del.side_effect = requests.RequestException("timeout")
-        url = reverse(
-            "plugins:netbox_kea:server_subnet4_pool_delete", args=[self.server.pk, 42, "10.0.0.100-10.0.0.200"]
-        )
-        response = self.client.post(url, follow=True)
+    def test_pool_delete_request_exception_shows_network_error(self):
+        """A transport error on pool_del must show a network error message."""
+        with self._pool_del_stub(**{"subnet4-pool-del": requests.RequestException("timeout")}):
+            response = self.client.post(self._pool_del_url(), follow=True)
         msgs = list(response.context["messages"])
         self.assertTrue(any(m.level == django_messages.ERROR for m in msgs))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_pool_delete_client_creation_failure_redirects(self, MockKeaClient):
-        """When get_client raises ValueError during pool delete POST, view redirects with error."""
-        MockKeaClient.side_effect = ValueError("bad config")
-        url = reverse(
-            "plugins:netbox_kea:server_subnet4_pool_delete", args=[self.server.pk, 42, "10.0.0.100-10.0.0.200"]
-        )
+    def test_pool_delete_client_creation_failure_redirects(self):
+        """A real get_client() failure (cert without key → ValueError) in pool delete POST shows an error."""
+        bad = _make_db_server(name="bad-cert-pooldel-cov", client_cert_path="/nonexistent/cert.pem")
+        url = reverse("plugins:netbox_kea:server_subnet4_pool_delete", args=[bad.pk, 42, "10.0.0.100-10.0.0.200"])
         response = self.client.post(url, follow=True)
         msgs = list(response.context["messages"])
         self.assertTrue(any(m.level == django_messages.ERROR for m in msgs))

--- a/netbox_kea/tests/test_views_subnets.py
+++ b/netbox_kea/tests/test_views_subnets.py
@@ -29,7 +29,7 @@ from django.contrib import messages as django_messages
 from django.test import override_settings
 from django.urls import reverse
 
-from .kea_stub import stub_kea
+from .kea_stub import queued, stub_kea
 from .utils import _PLUGINS_CONFIG, _kea_command_side_effect, _make_db_server, _ViewTestBase
 
 # Shared stub responses for the subnet list/table views, which issue config-get
@@ -1245,150 +1245,127 @@ _SUBNET_ADD_POST = {
 class TestSubnetAddExceptionPaths(_ViewTestBase):
     """_BaseSubnetAddView GET/POST exception paths."""
 
+    # config-get response whose shared-networks include "alpha" (so the choice validates)
+    # and that doubles as a valid config for the _persist_config read-back.
+    _CONFIG4_ALPHA = {
+        "result": 0,
+        "arguments": {"Dhcp4": {"subnet4": [], "shared-networks": [{"name": "alpha", "subnet4": []}]}},
+    }
+
     def _url(self):
         return reverse("plugins:netbox_kea:server_subnet4_add", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_get_falls_back_when_network_choices_raise(self, MockKeaClient):
-        """GET must render the form with fallback choices when config-get fails."""
-        from netbox_kea.kea import KeaException
+    def _add_stub(self, config, **overrides):
+        """subnet_add chain (config-get choices → subnet4-list → subnet4-add → persist) + network move.
 
-        MockKeaClient.return_value.command.side_effect = KeaException(
-            {"result": 1, "text": "config error", "arguments": None}, index=0
-        )
-        response = self.client.get(self._url())
+        The same config-get value serves the choices lookup, the persist read-back, and the
+        followed subnets-list render. Override any leg (e.g. config-write result 1) to drive
+        the error branches; subnet4-add echoes id 1 unless overridden.
+        """
+        base = {
+            "config-get": config,
+            "subnet4-list": {"result": 0, "arguments": {"subnets": []}},
+            "subnet4-add": {"result": 0, "arguments": {"subnets": [{"id": 1}]}},
+            "config-test": {"result": 0},
+            "config-write": {"result": 0},
+            "network4-subnet-add": {"result": 0},
+            "stat-lease4-get": _STAT_ABSENT4,
+        }
+        base.update(overrides)
+        return stub_kea(base)
+
+    def test_get_falls_back_when_network_choices_raise(self):
+        """GET must render the form with fallback choices when config-get fails (result 1 → KeaException)."""
+        with stub_kea({"config-get": {"result": 1, "text": "config error"}}):
+            response = self.client.get(self._url())
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_partial_persist_error_redirects(self, MockKeaClient):
-        """PartialPersistError on subnet_add must redirect with warning."""
-        from netbox_kea.kea import PartialPersistError
-
-        MockKeaClient.return_value.command.return_value = [
-            {"result": 0, "arguments": {"Dhcp4": {"shared-networks": [], "subnet4": []}}}
-        ]
-        MockKeaClient.return_value.subnet_add.side_effect = PartialPersistError("dhcp4", Exception("write"))
-        response = self.client.post(self._url(), _SUBNET_ADD_POST, follow=True)
+    def test_post_partial_persist_error_redirects(self):
+        """A real config-write failure (PartialPersistError) on subnet_add must warn."""
+        with self._add_stub(_EMPTY_CONFIG4, **{"config-write": {"result": 1, "text": "disk full"}}):
+            response = self.client.post(self._url(), _SUBNET_ADD_POST, follow=True)
         msgs = list(response.context["messages"])
         self.assertTrue(any(m.level == django_messages.WARNING for m in msgs))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_partial_persist_error_with_subnet_id_attempts_network_assignment(self, MockKeaClient):
-        """When subnet_add raises PartialPersistError carrying subnet_id, the view attempts network assignment."""
-        from netbox_kea.kea import PartialPersistError
-
-        MockKeaClient.return_value.command.return_value = [
-            {
-                "result": 0,
-                "arguments": {
-                    "Dhcp4": {
-                        "shared-networks": [{"name": "alpha", "subnet4": []}],
-                        "subnet4": [],
-                    }
-                },
-            }
-        ]
-        partial_exc = PartialPersistError("dhcp4", Exception("write"), subnet_id=10)
-        MockKeaClient.return_value.subnet_add.side_effect = partial_exc
-        post_data = {**_SUBNET_ADD_POST, "shared_network": "alpha"}
-        response = self.client.post(self._url(), post_data, follow=True)
-        # network_subnet_add must have been called with the partial subnet_id
-        MockKeaClient.return_value.network_subnet_add.assert_called_once_with(version=4, name="alpha", subnet_id=10)
+    def test_post_partial_persist_error_with_subnet_id_attempts_network_assignment(self):
+        """A PartialPersistError carrying the new subnet_id must still trigger network assignment."""
+        # subnet4-add echoes id 10; config-write fails so subnet_add raises PartialPersistError(subnet_id=10).
+        # The view then issues network4-subnet-add for that id (its own persist also fails → second warning).
+        with self._add_stub(
+            self._CONFIG4_ALPHA,
+            **{
+                "subnet4-add": {"result": 0, "arguments": {"subnets": [{"id": 10}]}},
+                "config-write": {"result": 1, "text": "disk full"},
+            },
+        ) as kea:
+            response = self.client.post(self._url(), {**_SUBNET_ADD_POST, "shared_network": "alpha"}, follow=True)
+        self.assertIn("network4-subnet-add", kea.commands())
+        args = kea.bodies("network4-subnet-add")[0]["arguments"]
+        self.assertEqual(args["name"], "alpha")
+        self.assertEqual(args["id"], 10)
         msgs = list(response.context["messages"])
         self.assertTrue(any(m.level == django_messages.WARNING for m in msgs))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_partial_persist_error_without_subnet_id_skips_network_assignment(self, MockKeaClient):
-        """When PartialPersistError carries no subnet_id, network assignment is skipped."""
-        from netbox_kea.kea import PartialPersistError
-
-        MockKeaClient.return_value.command.return_value = [
-            {
-                "result": 0,
-                "arguments": {
-                    "Dhcp4": {
-                        "shared-networks": [{"name": "alpha", "subnet4": []}],
-                        "subnet4": [],
-                    }
-                },
-            }
-        ]
-        MockKeaClient.return_value.subnet_add.side_effect = PartialPersistError("dhcp4", Exception("write"))
-        post_data = {**_SUBNET_ADD_POST, "shared_network": "alpha"}
-        response = self.client.post(self._url(), post_data, follow=True)
-        MockKeaClient.return_value.network_subnet_add.assert_not_called()
+    def test_post_partial_persist_error_without_subnet_id_skips_network_assignment(self):
+        """A PartialPersistError with no known subnet_id must skip network assignment."""
+        # subnet4-list fails and subnet4-add echoes no id, so subnet_def has no "id" → the
+        # PartialPersistError carries subnet_id=None and the view cannot assign a network.
+        with self._add_stub(
+            self._CONFIG4_ALPHA,
+            **{
+                "subnet4-list": {"result": 1, "text": "not loaded"},
+                "subnet4-add": {"result": 0},
+                "config-write": {"result": 1, "text": "disk full"},
+            },
+        ) as kea:
+            response = self.client.post(self._url(), {**_SUBNET_ADD_POST, "shared_network": "alpha"}, follow=True)
+        self.assertNotIn("network4-subnet-add", kea.commands())
         msgs = list(response.context["messages"])
         self.assertTrue(any(m.level == django_messages.WARNING for m in msgs))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_subnet_add_runtime_error_rerenders_form(self, MockKeaClient):
-        """ValueError from subnet_add must re-render the form (200 response)."""
-        MockKeaClient.return_value.command.return_value = [
-            {"result": 0, "arguments": {"Dhcp4": {"shared-networks": [], "subnet4": []}}}
-        ]
-        MockKeaClient.return_value.subnet_add.side_effect = ValueError("crash")
-        response = self.client.post(self._url(), _SUBNET_ADD_POST)
+    def test_post_subnet_add_runtime_error_rerenders_form(self):
+        """A generic (ValueError) failure during subnet_add must re-render the form (200)."""
+        # subnet4-add raises ValueError at the boundary; the disambiguation probe (config-get)
+        # finds no matching subnet, so subnet_add re-raises ValueError → view re-renders.
+        with self._add_stub(_EMPTY_CONFIG4, **{"subnet4-add": ValueError("crash")}):
+            response = self.client.post(self._url(), _SUBNET_ADD_POST)
         self.assertEqual(response.status_code, 200)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_network_assignment_partial_persist_shows_warning(self, MockKeaClient):
-        """PartialPersistError on network_subnet_add must show a warning."""
-        from netbox_kea.kea import PartialPersistError
-
-        MockKeaClient.return_value.command.return_value = [
-            {
-                "result": 0,
-                "arguments": {
-                    "Dhcp4": {
-                        "shared-networks": [{"name": "alpha", "subnet4": []}],
-                        "subnet4": [],
-                    }
-                },
-            }
-        ]
-        MockKeaClient.return_value.subnet_add.return_value = 5
-        MockKeaClient.return_value.network_subnet_add.side_effect = PartialPersistError("dhcp4", Exception("w"))
-        post_data = {**_SUBNET_ADD_POST, "shared_network": "alpha"}
-        response = self.client.post(self._url(), post_data, follow=True)
+    def test_post_network_assignment_partial_persist_shows_warning(self):
+        """A config-write failure during network_subnet_add (after a clean subnet_add) must warn."""
+        # config-write succeeds for the subnet_add persist, then fails for the network persist.
+        with self._add_stub(
+            self._CONFIG4_ALPHA,
+            **{
+                "subnet4-add": {"result": 0, "arguments": {"subnets": [{"id": 5}]}},
+                "config-write": queued({"result": 0}, {"result": 1, "text": "disk full"}),
+            },
+        ):
+            response = self.client.post(self._url(), {**_SUBNET_ADD_POST, "shared_network": "alpha"}, follow=True)
         msgs = list(response.context["messages"])
         self.assertTrue(any("config-write failed" in m.message.lower() for m in msgs))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_network_assignment_generic_exception_shows_warning(self, MockKeaClient):
-        """Generic exception on network_subnet_add must show a warning."""
-        MockKeaClient.return_value.command.return_value = [
-            {
-                "result": 0,
-                "arguments": {
-                    "Dhcp4": {
-                        "shared-networks": [{"name": "alpha", "subnet4": []}],
-                        "subnet4": [],
-                    }
-                },
-            }
-        ]
-        MockKeaClient.return_value.subnet_add.return_value = 5
-        MockKeaClient.return_value.network_subnet_add.side_effect = requests.RequestException("network error")
-        post_data = {**_SUBNET_ADD_POST, "shared_network": "alpha"}
-        response = self.client.post(self._url(), post_data, follow=True)
+    def test_post_network_assignment_generic_exception_shows_warning(self):
+        """A transport error on network_subnet_add (after a clean subnet_add) must warn."""
+        # network4-subnet-add raises RequestException at the boundary → view's "could not be assigned" warning.
+        with self._add_stub(
+            self._CONFIG4_ALPHA,
+            **{
+                "subnet4-add": {"result": 0, "arguments": {"subnets": [{"id": 5}]}},
+                "network4-subnet-add": requests.RequestException("network error"),
+            },
+        ):
+            response = self.client.post(self._url(), {**_SUBNET_ADD_POST, "shared_network": "alpha"}, follow=True)
         msgs = list(response.context["messages"])
         self.assertTrue(any("could not be assigned" in m.message.lower() for m in msgs))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_client_none_reconnect_failure_shows_error(self, MockKeaClient):
-        """When initial get_client fails, view shows error and returns 200 or 302."""
-        call_count = [0]
-
-        def _raise_after_first(*args, **kwargs):
-            call_count[0] += 1
-            if call_count[0] == 1:
-                # First instantiation (for getting choices): raise immediately
-                raise requests.RequestException("no connection")
-            # Second instantiation (for fallback client reconnect): also raise
-            raise requests.RequestException("still no connection")
-
-        MockKeaClient.side_effect = _raise_after_first
-        response = self.client.post(self._url(), _SUBNET_ADD_POST)
+    def test_post_client_none_reconnect_failure_shows_error(self):
+        """When get_client fails (cert without key → ValueError), the view shows an error, no 500."""
+        # Server.objects.create() skips clean(), so a cert-without-key server persists; get_client
+        # then raises ValueError before any Kea call, exercising the view's connect-failure branch.
+        bad_server = _make_db_server(name="bad-cert", client_cert_path="/nonexistent/cert.pem")
+        url = reverse("plugins:netbox_kea:server_subnet4_add", args=[bad_server.pk])
+        response = self.client.post(url, _SUBNET_ADD_POST)
         self.assertIn(response.status_code, (200, 302))
 
 
@@ -1413,26 +1390,39 @@ class TestSubnetEditPostExceptions(_ViewTestBase):
     def _url(self, subnet_id=42):
         return reverse("plugins:netbox_kea:server_subnet4_edit", args=[self.server.pk, subnet_id])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_partial_persist_redirects_with_warning(self, MockKeaClient):
-        """PartialPersistError on subnet_update must redirect with warning."""
-        from netbox_kea.kea import PartialPersistError
+    # the live subnet subnet4-get returns before subnet4-update runs.
+    _LIVE_SUBNET4 = {
+        "result": 0,
+        "arguments": {"subnet4": [{"id": 42, "subnet": "10.0.0.0/24", "pools": [], "option-data": []}]},
+    }
 
-        # POST consumes: [0] config-get for subnet data, [1] config-get for subnets list (after redirect),
-        # [2] stat-lease4-get (hook-unavailable) so stat_cmds degradation doesn't StopIterate.
-        _stat_unsupported = [{"result": 2, "text": "unsupported"}]
-        MockKeaClient.return_value.command.side_effect = [_SUBNET4_GET_FULL, _CONFIG4_NO_NETWORKS, _stat_unsupported]
-        MockKeaClient.return_value.subnet_update.side_effect = PartialPersistError("dhcp4", Exception("write"))
-        response = self.client.post(self._url(), _SUBNET4_EDIT_POST, follow=True)
+    def test_post_partial_persist_redirects_with_warning(self):
+        """A real config-write failure (PartialPersistError) on subnet_update must warn."""
+        # subnet_update: config-get (network data) → subnet4-get → subnet4-update → persist.
+        # config-write result 1 → PartialPersistError. follow=True renders the subnets list.
+        stub = {
+            "config-get": _CONFIG4_NO_NETWORKS[0],
+            "subnet4-get": self._LIVE_SUBNET4,
+            "subnet4-update": {"result": 0},
+            "config-test": {"result": 0},
+            "config-write": {"result": 1, "text": "disk full"},
+            "stat-lease4-get": _STAT_ABSENT4,
+        }
+        with stub_kea(stub):
+            response = self.client.post(self._url(), _SUBNET4_EDIT_POST, follow=True)
         msgs = list(response.context["messages"])
         self.assertTrue(any(m.level == django_messages.WARNING for m in msgs))
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_generic_exception_rerenders(self, MockKeaClient):
-        """Generic exception on subnet_update must re-render the form."""
-        MockKeaClient.return_value.command.side_effect = [_SUBNET4_GET_FULL, _CONFIG4_NO_NETWORKS]
-        MockKeaClient.return_value.subnet_update.side_effect = ValueError("crash")
-        response = self.client.post(self._url(), _SUBNET4_EDIT_POST)
+    def test_post_generic_exception_rerenders(self):
+        """A generic (ValueError) failure on subnet_update must re-render the form (200)."""
+        # subnet4-update raises ValueError at the boundary → view's generic-error branch re-renders.
+        stub = {
+            "config-get": _CONFIG4_NO_NETWORKS[0],
+            "subnet4-get": self._LIVE_SUBNET4,
+            "subnet4-update": ValueError("crash"),
+        }
+        with stub_kea(stub):
+            response = self.client.post(self._url(), _SUBNET4_EDIT_POST)
         self.assertEqual(response.status_code, 200)
 
 
@@ -1443,36 +1433,43 @@ class TestSubnetEditNetworkDelPartialPersist(_ViewTestBase):
     def _url(self, subnet_id=42):
         return reverse("plugins:netbox_kea:server_subnet4_edit", args=[self.server.pk, subnet_id])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_partial_persist_on_del_skips_rollback(self, MockKeaClient):
-        """When network_subnet_del raises PartialPersistError, no rollback del is called."""
-        from netbox_kea.kea import PartialPersistError
-
-        config_with_current_net = [
-            {
+    def test_partial_persist_on_del_skips_rollback(self):
+        """When network_subnet_del hits a config-write failure, the view must not roll back the add."""
+        # subnet 42 lives in old-net; POST moves it to new-net. Order: subnet_update persist (ok),
+        # network4-subnet-add persist (ok), network4-subnet-del persist (config-write fails). Because
+        # the del is already live (PartialPersistError), the view must NOT issue a rollback del — so
+        # network4-subnet-del is issued exactly once.
+        config_with_current_net = {
+            "result": 0,
+            "arguments": {
+                "Dhcp4": {
+                    "subnet4": [{"id": 42, "subnet": "10.0.0.0/24"}],
+                    "shared-networks": [
+                        {"name": "old-net", "subnet4": [{"id": 42}]},
+                        {"name": "new-net", "subnet4": []},
+                    ],
+                }
+            },
+        }
+        stub = {
+            "config-get": config_with_current_net,
+            "subnet4-get": {
                 "result": 0,
-                "arguments": {
-                    "Dhcp4": {
-                        "subnet4": [{"id": 42, "subnet": "10.0.0.0/24"}],
-                        "shared-networks": [
-                            {"name": "old-net", "subnet4": [{"id": 42}]},
-                            {"name": "new-net", "subnet4": []},
-                        ],
-                    }
-                },
-            }
-        ]
-        MockKeaClient.return_value.command.return_value = config_with_current_net
-        MockKeaClient.return_value.subnet_update.return_value = None
-        MockKeaClient.return_value.network_subnet_add.return_value = None
-        MockKeaClient.return_value.network_subnet_del.side_effect = PartialPersistError("dhcp4", Exception("write"))
-
+                "arguments": {"subnet4": [{"id": 42, "subnet": "10.0.0.0/24", "pools": [], "option-data": []}]},
+            },
+            "subnet4-update": {"result": 0},
+            "config-test": {"result": 0},
+            # 1: subnet_update persist ok, 2: network-add persist ok, 3: network-del persist fails.
+            "config-write": queued({"result": 0}, {"result": 0}, {"result": 1, "text": "disk full"}),
+            "network4-subnet-add": {"result": 0},
+            "network4-subnet-del": {"result": 0},
+        }
         post_data = {**_SUBNET4_EDIT_POST, "shared_network": "new-net"}
-        response = self.client.post(self._url(), post_data)
-        # Should redirect (PartialPersistError is caught as KeaException and redirects)
+        with stub_kea(stub) as kea:
+            response = self.client.post(self._url(), post_data)
         self.assertIn(response.status_code, (200, 302))
-        # network_subnet_del called once (for old-net); no rollback call to del new-net
-        self.assertEqual(MockKeaClient.return_value.network_subnet_del.call_count, 1)
+        # del issued once (for old-net); no rollback del of new-net.
+        self.assertEqual(kea.commands().count("network4-subnet-del"), 1)
 
 
 # ---------------------------------------------------------------------------

--- a/netbox_kea/tests/test_views_sync.py
+++ b/netbox_kea/tests/test_views_sync.py
@@ -37,7 +37,7 @@ from django.test import override_settings
 from django.urls import reverse
 from ipam.models import IPAddress as NbIP
 
-from .kea_stub import queued, stub_kea
+from .kea_stub import _res_get, _res_page, queued, stub_kea
 from .utils import _PLUGINS_CONFIG, User, _ViewTestBase
 
 # ---------------------------------------------------------------------------
@@ -63,20 +63,6 @@ def _lease4(ip="10.0.0.1"):
 def _subnet_list(version, subnets):
     """A ``subnet{v}-list`` payload (used by ``reservation_get_by_ip`` to find candidate subnets)."""
     return {"result": 0, "arguments": {"subnets": list(subnets)}}
-
-
-def _res_get(reservation):
-    """A ``reservation-get`` payload: the host fields Kea returns directly inside ``arguments``."""
-    return {"result": 0, "arguments": dict(reservation)}
-
-
-def _res_page(hosts, *, next_from=0, next_source=0):
-    """A ``reservation-get-page`` payload: *hosts* plus Kea's pagination cursor.
-
-    ``next_from``/``next_source`` both 0 marks the source exhausted, so
-    ``iter_reservations`` stops after this page.
-    """
-    return {"result": 0, "arguments": {"hosts": hosts, "next": {"from": next_from, "source-index": next_source}}}
 
 
 def _messages(response):
@@ -304,7 +290,7 @@ class TestReservation4SyncViewFetchLiveData(_ViewTestBase):
         # reservation_get_by_ip(4, "10.0.0.5") → reservation-get scoped to the matching subnet + IP.
         self.assertEqual(kea.bodies("reservation-get")[0]["arguments"], {"subnet-id": 1, "ip-address": "10.0.0.5"})
 
-    def test_falls_back_to_synthetic_when_reservation_not_found(self):
+    def test_reservation_not_found_returns_400_without_sync(self):
         """When reservation_get_by_ip returns None (reservation-get result 3), response is 400 (no sync)."""
         stub = {
             "subnet4-list": _subnet_list(4, [{"id": 1, "subnet": "10.0.0.0/24"}]),

--- a/netbox_kea/tests/test_views_sync.py
+++ b/netbox_kea/tests/test_views_sync.py
@@ -323,9 +323,13 @@ class TestReservation6SyncViewFetchLiveData(_ViewTestBase):
 
     def test_request_exception_returns_400_without_sync(self):
         """When the subnet-list call raises a transport error, response is 400 (no sync)."""
-        with stub_kea({"subnet6-list": requests.RequestException("timeout")}):
+        with (
+            stub_kea({"subnet6-list": requests.RequestException("timeout")}),
+            patch("netbox_kea.views.ServerReservation6SyncView._sync") as mock_sync,
+        ):
             response = self.client.post(self._url(), {"ip_address": "2001:db8::1", "hostname": "fallback6"})
         self.assertEqual(response.status_code, 400)
+        mock_sync.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/netbox_kea/tests/test_views_sync.py
+++ b/netbox_kea/tests/test_views_sync.py
@@ -1,38 +1,87 @@
 # SPDX-FileCopyrightText: 2025 Marcin Zieba <marcinpsk@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
-"""View tests for netbox_kea plugin.
+"""Sync / bulk-import view tests for the netbox_kea plugin.
 
-Also contains pure-Python unit tests for helper functions defined in views.py
-(e.g. ``_extract_identifier``), which do not require a database but live here
-because they are tightly coupled to view logic.
+Covers the views in ``netbox_kea/views/sync_views.py``: the per-row lease /
+reservation sync endpoints, the bulk reservation sync, and the CSV bulk-import
+views for reservations and leases.
 
-These tests verify correct HTTP responses and redirect behaviour for every view.
-All Kea HTTP calls are mocked so no running Kea instance is required.
+These tests drive the **real** ``KeaClient``; only the HTTP boundary is stubbed
+via ``kea_stub.stub_kea``, so the request payloads the views actually send to Kea
+are exercised. The Kea command chains:
 
-Test organisation strategy
---------------------------
-Each view class gets its own ``TestCase`` subclass so failures are isolated and
-clearly named.  Every test that triggers a redirect asserts that the redirect URL
-contains an *integer* pk (never the string "None"), which is the pattern that
-revealed the original ``POST /plugins/kea/servers/None`` 404 bug.
+* **single lease sync** (``ServerLease{4,6}SyncView``): ``lease{v}-get`` to fetch
+  the live lease, then the NetBox-side ``sync_lease_to_netbox``.
+* **single reservation sync** (``ServerReservation{4,6}SyncView``): ``reservation_get_by_ip``
+  = ``subnet{v}-list`` then ``reservation-get`` per candidate subnet, then
+  ``sync_reservation_to_netbox``.
+* **bulk reservation sync**: ``reservation-get-page`` (drained by ``iter_reservations``)
+  then ``sync_reservation_to_netbox`` per record.
+* **bulk import**: one ``reservation-add`` / ``lease{v}-add`` per CSV row.
 
-View tests use ``django.test.TestCase`` because they write to the test database
-(user + server fixtures).  Server objects are created via ``Server.objects.create()``
-which does **not** call ``Model.clean()`` and therefore does not trigger live Kea
-connectivity checks.
+The NetBox-side boundary is where mocks legitimately remain (documented per test):
+``_sync`` / ``sync_reservation_to_netbox`` / ``sync_lease_to_netbox`` are patched to
+inject IPAM outcomes (created vs. updated) and DB errors (IntegrityError,
+OperationalError, ValidationError, …) that the real IPAM flow cannot produce
+deterministically here; ``cleanup_stale_ips_batch`` is patched only where a specific
+stale count is asserted. ``NbIP`` sync returns use ``MagicMock(spec=NbIP)``. No
+``KeaClient`` is mocked — the Kea request path is always real.
 """
 
 import io
 from unittest.mock import MagicMock, patch
 
-from django.contrib import messages as django_messages
+import requests
+from django.contrib.messages import get_messages
 from django.test import override_settings
 from django.urls import reverse
 from ipam.models import IPAddress as NbIP
 
-from netbox_kea.kea import KeaException
-
+from .kea_stub import queued, stub_kea
 from .utils import _PLUGINS_CONFIG, User, _ViewTestBase
+
+# ---------------------------------------------------------------------------
+# Kea response fixtures / builders
+# ---------------------------------------------------------------------------
+
+
+def _lease4(ip="10.0.0.1"):
+    """A ``lease4-get`` payload (result 0) for a single live lease."""
+    return {
+        "result": 0,
+        "arguments": {
+            "ip-address": ip,
+            "hw-address": "aa:bb:cc:00:00:01",
+            "hostname": "realhost",
+            "valid-lft": 86400,
+            "cltt": 1700000000,
+            "subnet-id": 1,
+        },
+    }
+
+
+def _subnet_list(version, subnets):
+    """A ``subnet{v}-list`` payload (used by ``reservation_get_by_ip`` to find candidate subnets)."""
+    return {"result": 0, "arguments": {"subnets": list(subnets)}}
+
+
+def _res_get(reservation):
+    """A ``reservation-get`` payload: the host fields Kea returns directly inside ``arguments``."""
+    return {"result": 0, "arguments": dict(reservation)}
+
+
+def _res_page(hosts, *, next_from=0, next_source=0):
+    """A ``reservation-get-page`` payload: *hosts* plus Kea's pagination cursor.
+
+    ``next_from``/``next_source`` both 0 marks the source exhausted, so
+    ``iter_reservations`` stops after this page.
+    """
+    return {"result": 0, "arguments": {"hosts": hosts, "next": {"from": next_from, "source-index": next_source}}}
+
+
+def _messages(response):
+    """Read the messages queued on a (non-followed) response's request."""
+    return [str(m) for m in get_messages(response.wsgi_request)]
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
@@ -42,22 +91,27 @@ class TestSyncViewEdgeCases(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_lease4_sync", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_missing_ip_returns_400(self, MockKeaClient):
-        """POST without ip_address must return 400."""
-        response = self.client.post(self._url(), {})
+    def test_post_missing_ip_returns_400(self):
+        """POST without ip_address must return 400 (no Kea traffic)."""
+        with stub_kea({}) as kea:
+            response = self.client.post(self._url(), {})
         self.assertEqual(response.status_code, 400)
+        self.assertEqual(kea.commands(), [])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_invalid_ip_returns_400(self, MockKeaClient):
-        """POST with invalid IP must return 400."""
-        response = self.client.post(self._url(), {"ip_address": "not-an-ip"})
+    def test_post_invalid_ip_returns_400(self):
+        """POST with invalid IP must return 400 (no Kea traffic)."""
+        with stub_kea({}) as kea:
+            response = self.client.post(self._url(), {"ip_address": "not-an-ip"})
         self.assertEqual(response.status_code, 400)
+        self.assertEqual(kea.commands(), [])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_sync_exception_returns_500(self, MockKeaClient):
+    def test_post_sync_exception_returns_500(self):
         """POST where sync raises a concrete error must return 500 with generic message, not raw exception."""
-        with patch("netbox_kea.views.ServerLease4SyncView._sync", side_effect=ValueError("ip parse error")):
+        # Real lease fetch succeeds; the NetBox-side _sync raises (injected error).
+        with (
+            stub_kea({"lease4-get": _lease4("10.0.0.1")}),
+            patch("netbox_kea.views.ServerLease4SyncView._sync", side_effect=ValueError("ip parse error")),
+        ):
             response = self.client.post(self._url(), {"ip_address": "10.0.0.1"})
         self.assertEqual(response.status_code, 500)
         body = response.content.decode()
@@ -73,7 +127,7 @@ class TestBulkReservationSyncPermission(_ViewTestBase):
         return reverse("plugins:netbox_kea:server_reservation4_bulk_sync", args=[self.server.pk])
 
     def test_post_without_ipam_permission_returns_403(self):
-        """POST without ipam.add_ipaddress must return 403."""
+        """POST without ipam.add_ipaddress must return 403 (before any Kea traffic)."""
         restricted_user = User.objects.create_user(
             username="noperms_bulk",
             email="noperms_bulk@example.com",
@@ -86,24 +140,19 @@ class TestBulkReservationSyncPermission(_ViewTestBase):
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestBulkReservationSyncFetchException(_ViewTestBase):
-    """_BaseBulkReservationSyncView — fetch exception shows error and redirects."""
+    """_BaseBulkReservationSyncView — fetch transport error shows error and redirects."""
 
     def _url(self):
         return reverse("plugins:netbox_kea:server_reservation4_bulk_sync", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_fetch_exception_shows_error(self, MockKeaClient):
-        """requests.RequestException from _fetch_reservations_from_server must show error and redirect."""
-        import requests as req_lib
-
-        with patch(
-            "netbox_kea.views.sync_views._fetch_reservations_from_server",
-            side_effect=req_lib.ConnectionError("fetch fail"),
-        ):
-            response = self.client.post(self._url(), follow=True)
-        msgs = list(response.context["messages"])
-        self.assertTrue(any(m.level == django_messages.ERROR for m in msgs))
-        self.assertNotIn(b"fetch fail", response.content)
+    def test_post_fetch_exception_shows_error(self):
+        """A transport error draining reservation-get-page must show error and redirect."""
+        with stub_kea({"reservation-get-page": requests.ConnectionError("fetch fail")}):
+            response = self.client.post(self._url())
+        self.assertEqual(response.status_code, 302)
+        msgs = _messages(response)
+        self.assertTrue(any("Failed to fetch" in m for m in msgs))
+        self.assertFalse(any("fetch fail" in m for m in msgs))
 
 
 # ---------------------------------------------------------------------------
@@ -118,26 +167,26 @@ class TestBulkReservationImportEdgeCases(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_reservation4_bulk_import", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_without_file_rerenders_form(self, MockKeaClient):
-        """POST without a CSV file must re-render the form (200)."""
-        response = self.client.post(self._url(), {})
+    def test_post_without_file_rerenders_form(self):
+        """POST without a CSV file must re-render the form (200, no Kea)."""
+        with stub_kea({}) as kea:
+            response = self.client.post(self._url(), {})
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(kea.commands(), [])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_post_invalid_csv_shows_error(self, MockKeaClient):
-        """POST with a CSV that fails parse_reservation_csv raises ValueError → form error."""
-
-        MockKeaClient.return_value.reservation_add.return_value = None
-        # CSV with missing required columns triggers ValueError in parse_reservation_csv
+    def test_post_invalid_csv_shows_error(self):
+        """POST with a CSV that fails parse_reservation_csv raises ValueError → form error (no Kea)."""
+        # CSV with missing required columns triggers ValueError in parse_reservation_csv,
+        # before any Kea client is built.
         bad_csv = io.BytesIO(b"garbage_header\nrow1\n")
         bad_csv.name = "bad.csv"
-        response = self.client.post(self._url(), {"csv_file": bad_csv})
+        with stub_kea({}) as kea:
+            response = self.client.post(self._url(), {"csv_file": bad_csv})
         self.assertEqual(response.status_code, 200)
         # Response should include a form error about invalid CSV — message must be generic (no raw exception text)
         self.assertContains(response, "csv_file", msg_prefix="Expected CSV error in form")
         self.assertContains(response, "parsing failed", msg_prefix="Expected generic error message")
-        MockKeaClient.return_value.reservation_add.assert_not_called()
+        self.assertEqual(kea.commands(), [])
 
 
 # ---------------------------------------------------------------------------
@@ -147,48 +196,40 @@ class TestBulkReservationImportEdgeCases(_ViewTestBase):
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestBulkReservationSyncEdgeCases(_ViewTestBase):
-    """Lines 4383-4397: bulk sync with missing IPs, errors, and count tracking."""
+    """Bulk sync with missing IPs, errors, and count tracking (superuser has IPAM perms)."""
 
     def _url(self):
         return reverse("plugins:netbox_kea:server_reservation4_bulk_sync", args=[self.server.pk])
 
-    def setUp(self):
-        super().setUp()
-        # superuser has ipam perms automatically (is_superuser)
-
     @patch("netbox_kea.sync.sync_reservation_to_netbox")
-    @patch("netbox_kea.views.sync_views._fetch_reservations_from_server")
-    def test_reservation_without_ip_is_skipped(self, mock_fetch, mock_sync):
-        """Line 4383-4384: reservations without ip-address/ip-addresses are skipped."""
-        mock_fetch.return_value = [{"hw-address": "aa:bb:cc:dd:ee:ff"}]  # no IP
-        self.client.post(self._url(), follow=True)
+    def test_reservation_without_ip_is_skipped(self, mock_sync):
+        """Reservations without ip-address/ip-addresses are skipped (real fetch, no sync)."""
+        with stub_kea({"reservation-get-page": _res_page([{"hw-address": "aa:bb:cc:dd:ee:ff"}])}):
+            self.client.post(self._url())
         mock_sync.assert_not_called()
 
     @patch("netbox_kea.sync.sync_reservation_to_netbox")
-    @patch("netbox_kea.views.sync_views._fetch_reservations_from_server")
-    def test_sync_creates_and_updates(self, mock_fetch, mock_sync):
+    def test_sync_creates_and_updates(self, mock_sync):
         """Created and updated counters incremented correctly."""
-        mock_fetch.return_value = [
+        hosts = [
             {"ip-address": "10.0.0.1", "hw-address": "aa:bb:cc:dd:ee:01"},
             {"ip-address": "10.0.0.2", "hw-address": "aa:bb:cc:dd:ee:02"},
         ]
         mock_sync.side_effect = [(MagicMock(spec=NbIP), True, True), (MagicMock(spec=NbIP), False, True)]
-        response = self.client.post(self._url(), follow=True)
-        msgs = [str(m) for m in response.context["messages"]]
+        with stub_kea({"reservation-get-page": _res_page(hosts)}):
+            response = self.client.post(self._url())
+        msgs = _messages(response)
         self.assertIn("Bulk sync complete: 1 created, 1 updated.", msgs)
         self.assertEqual(mock_sync.call_count, 2)
 
     @patch("netbox_kea.sync.sync_reservation_to_netbox")
-    @patch("netbox_kea.views.sync_views._fetch_reservations_from_server")
-    def test_sync_exception_counted_as_error(self, mock_fetch, mock_sync):
+    def test_sync_exception_counted_as_error(self, mock_sync):
         """Sync exception increments errors, warning shown."""
-        mock_fetch.return_value = [
-            {"ip-address": "10.0.0.1"},
-            {"ip-address": "10.0.0.2"},
-        ]
+        hosts = [{"ip-address": "10.0.0.1"}, {"ip-address": "10.0.0.2"}]
         mock_sync.side_effect = [ValueError("db error"), (MagicMock(spec=NbIP), True, True)]
-        response = self.client.post(self._url(), follow=True)
-        msgs = [str(m) for m in response.context["messages"]]
+        with stub_kea({"reservation-get-page": _res_page(hosts)}):
+            response = self.client.post(self._url())
+        msgs = _messages(response)
         self.assertIn("Bulk sync: 1 created, 0 updated, 1 errors.", msgs)
         self.assertEqual(mock_sync.call_count, 2)
 
@@ -200,31 +241,28 @@ class TestBulkReservationSyncEdgeCases(_ViewTestBase):
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestReservationImportGenericException(_ViewTestBase):
-    """Lines 4521-4523: generic exception during reservation_add."""
+    """Generic exception during reservation_add is caught per-row."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_generic_exception_appended_to_errors(self, MockKeaClient):
-        """RuntimeError from reservation_add is caught and surfaced as an error row."""
-        MockKeaClient.return_value.reservation_add.side_effect = RuntimeError("crash")
+    def test_generic_exception_appended_to_errors(self):
+        """A RuntimeError from reservation-add is caught and surfaced as an error row."""
         url = reverse("plugins:netbox_kea:server_reservation4_bulk_import", args=[self.server.pk])
-
-        csv_content = "ip-address,hw-address,subnet-id\n10.0.0.1,aa:bb:cc:dd:ee:ff,1"
-        csv_file = io.BytesIO(csv_content.encode())
+        csv_file = io.BytesIO(b"ip-address,hw-address,subnet-id\n10.0.0.1,aa:bb:cc:dd:ee:ff,1")
         csv_file.name = "reservations.csv"
-        response = self.client.post(url, {"csv_file": csv_file, "subnet_id": "1"})
+        with stub_kea({"reservation-add": RuntimeError("crash")}):
+            response = self.client.post(url, {"csv_file": csv_file, "subnet_id": "1"})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["result"]["errors"], 1)
         self.assertEqual(response.context["result"]["error_rows"][0]["error"], "An unexpected error occurred.")
 
 
 # ---------------------------------------------------------------------------
-# _BaseSyncView._sync — NotImplementedError (line 4321)
+# _BaseSyncView._sync — NotImplementedError
 # ---------------------------------------------------------------------------
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestBaseSyncViewNotImplemented(_ViewTestBase):
-    """Line 4321: _BaseSyncView._sync raises NotImplementedError."""
+    """_BaseSyncView._sync raises NotImplementedError."""
 
     def test_sync_raises_not_implemented(self):
         from netbox_kea.views import _BaseSyncView
@@ -241,47 +279,51 @@ class TestBaseSyncViewNotImplemented(_ViewTestBase):
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestReservation4SyncViewFetchLiveData(_ViewTestBase):
-    """ServerReservation4SyncView._fetch_live_data uses reservation_get_by_ip."""
+    """ServerReservation4SyncView._fetch_live_data uses reservation_get_by_ip (subnet-list + reservation-get)."""
 
     def _url(self):
         return reverse("plugins:netbox_kea:server_reservation4_sync", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_uses_live_reservation_when_found(self, MockKeaClient):
-        """When reservation_get_by_ip returns a dict, that dict is passed to _sync."""
+    def test_uses_live_reservation_when_found(self):
+        """When reservation_get_by_ip finds a reservation, that dict is passed to _sync."""
         live = {"ip-address": "10.0.0.5", "hw-address": "aa:bb:cc:00:00:01", "hostname": "livehost"}
-        MockKeaClient.return_value.reservation_get_by_ip.return_value = live
-
-        with patch("netbox_kea.views.ServerReservation4SyncView._sync") as mock_sync:
+        stub = {
+            "subnet4-list": _subnet_list(4, [{"id": 1, "subnet": "10.0.0.0/24"}]),
+            "reservation-get": _res_get(live),
+        }
+        with (
+            stub_kea(stub) as kea,
+            patch("netbox_kea.views.ServerReservation4SyncView._sync") as mock_sync,
+        ):
             mock_sync.return_value = (MagicMock(spec=NbIP), True, True)
             self.client.post(self._url(), {"ip_address": "10.0.0.5", "hostname": "fallback"})
 
         mock_sync.assert_called_once()
         data = mock_sync.call_args[0][0]
         self.assertEqual(data["hostname"], "livehost")
-        MockKeaClient.return_value.reservation_get_by_ip.assert_called_once_with(4, "10.0.0.5")
+        # reservation_get_by_ip(4, "10.0.0.5") → reservation-get scoped to the matching subnet + IP.
+        self.assertEqual(kea.bodies("reservation-get")[0]["arguments"], {"subnet-id": 1, "ip-address": "10.0.0.5"})
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_falls_back_to_synthetic_when_reservation_not_found(self, MockKeaClient):
-        """When reservation_get_by_ip returns None, response is 400 (no sync)."""
-        MockKeaClient.return_value.reservation_get_by_ip.return_value = None
-
-        with patch("netbox_kea.views.ServerReservation4SyncView._sync") as mock_sync:
+    def test_falls_back_to_synthetic_when_reservation_not_found(self):
+        """When reservation_get_by_ip returns None (reservation-get result 3), response is 400 (no sync)."""
+        stub = {
+            "subnet4-list": _subnet_list(4, [{"id": 1, "subnet": "10.0.0.0/24"}]),
+            "reservation-get": {"result": 3},
+        }
+        with stub_kea(stub), patch("netbox_kea.views.ServerReservation4SyncView._sync") as mock_sync:
             response = self.client.post(self._url(), {"ip_address": "10.0.0.5", "hostname": "fallback"})
-            self.assertEqual(response.status_code, 400)
-            mock_sync.assert_not_called()
+        self.assertEqual(response.status_code, 400)
+        mock_sync.assert_not_called()
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_falls_back_on_kea_exception(self, MockKeaClient):
-        """When reservation_get_by_ip raises KeaException, response is 400."""
-        from netbox_kea.kea import KeaException
-
-        MockKeaClient.return_value.reservation_get_by_ip.side_effect = KeaException({"result": 1, "text": "not found"})
-
-        with patch("netbox_kea.views.ServerReservation4SyncView._sync") as mock_sync:
+    def test_falls_back_on_kea_exception(self):
+        """When the subnet-list call fails (KeaException), response is 400."""
+        with (
+            stub_kea({"subnet4-list": {"result": 1, "text": "not found"}}),
+            patch("netbox_kea.views.ServerReservation4SyncView._sync") as mock_sync,
+        ):
             response = self.client.post(self._url(), {"ip_address": "10.0.0.5", "hostname": "fallback"})
-            self.assertEqual(response.status_code, 400)
-            mock_sync.assert_not_called()
+        self.assertEqual(response.status_code, 400)
+        mock_sync.assert_not_called()
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
@@ -291,30 +333,22 @@ class TestReservation6SyncViewFetchLiveData(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_reservation6_sync", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_calls_reservation_get_by_ip_with_version_6(self, MockKeaClient):
-        """Calls reservation_get_by_ip with version=6 for the v6 view."""
-        MockKeaClient.return_value.reservation_get_by_ip.return_value = None
-
-        response = self.client.post(self._url(), {"ip_address": "2001:db8::1", "hostname": ""})
-
-        MockKeaClient.return_value.reservation_get_by_ip.assert_called_once_with(6, "2001:db8::1")
+    def test_calls_reservation_get_by_ip_with_version_6(self):
+        """The v6 view lists subnets via subnet6-list; no match → 400."""
+        with stub_kea({"subnet6-list": _subnet_list(6, [])}) as kea:
+            response = self.client.post(self._url(), {"ip_address": "2001:db8::1", "hostname": ""})
         self.assertEqual(response.status_code, 400)
+        self.assertEqual(kea.bodies("subnet6-list")[0]["service"], ["dhcp6"])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_falls_back_on_request_exception(self, MockKeaClient):
-        """When reservation_get_by_ip raises requests.RequestException, response is 400."""
-        import requests as req
-
-        MockKeaClient.return_value.reservation_get_by_ip.side_effect = req.RequestException("timeout")
-
-        response = self.client.post(self._url(), {"ip_address": "2001:db8::1", "hostname": "fallback6"})
-
+    def test_falls_back_on_request_exception(self):
+        """When the subnet-list call raises a transport error, response is 400."""
+        with stub_kea({"subnet6-list": requests.RequestException("timeout")}):
+            response = self.client.post(self._url(), {"ip_address": "2001:db8::1", "hostname": "fallback6"})
         self.assertEqual(response.status_code, 400)
 
 
 # ---------------------------------------------------------------------------
-# TestFetchLiveDataNoSyntheticFallback  (F11)
+# TestFetchLiveDataNoSyntheticFallback
 # ---------------------------------------------------------------------------
 
 
@@ -322,47 +356,35 @@ class TestReservation6SyncViewFetchLiveData(_ViewTestBase):
 class TestFetchLiveDataNoSyntheticFallback(_ViewTestBase):
     """_fetch_live_data must NOT mutate NetBox when Kea returns None or errors."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_kea_not_found_returns_400(self, MockKeaClient):
-        """When Kea returns no lease (not found), response is 400 (no sync)."""
-        MockKeaClient.return_value.lease_get_by_ip.return_value = None
+    def test_kea_not_found_returns_400(self):
+        """When Kea returns no lease (result 3), response is 400 (no sync)."""
         url = reverse("plugins:netbox_kea:server_lease4_sync", args=[self.server.pk])
-        response = self.client.post(url, {"ip_address": "10.0.0.99"})
+        with stub_kea({"lease4-get": {"result": 3}}):
+            response = self.client.post(url, {"ip_address": "10.0.0.99"})
         self.assertEqual(response.status_code, 400)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_kea_exception_returns_400(self, MockKeaClient):
-        """When Kea raises an exception, response is 400 (no sync)."""
-        from netbox_kea.kea import KeaException
-
-        MockKeaClient.return_value.lease_get_by_ip.side_effect = KeaException(
-            {"result": 1, "text": "not found"}, index=0
-        )
+    def test_kea_exception_returns_400(self):
+        """When Kea raises an error (result 1), response is 400 (no sync)."""
         url = reverse("plugins:netbox_kea:server_lease4_sync", args=[self.server.pk])
-        response = self.client.post(url, {"ip_address": "10.0.0.99"})
+        with stub_kea({"lease4-get": {"result": 1, "text": "not found"}}):
+            response = self.client.post(url, {"ip_address": "10.0.0.99"})
         self.assertEqual(response.status_code, 400)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_kea_found_calls_sync(self, MockKeaClient):
+    def test_kea_found_calls_sync(self):
         """When Kea returns a lease, _sync IS called."""
-        MockKeaClient.return_value.lease_get_by_ip.return_value = {
-            "ip-address": "10.0.0.1",
-            "hw-address": "aa:bb:cc:00:00:01",
-            "hostname": "realhost",
-            "valid-lft": 86400,
-            "cltt": 1700000000,
-            "subnet-id": 1,
-        }
-        with patch("netbox_kea.views.ServerLease4SyncView._sync") as mock_sync:
+        url = reverse("plugins:netbox_kea:server_lease4_sync", args=[self.server.pk])
+        with (
+            stub_kea({"lease4-get": _lease4("10.0.0.1")}),
+            patch("netbox_kea.views.ServerLease4SyncView._sync") as mock_sync,
+        ):
             mock_sync.return_value = (MagicMock(spec=NbIP), True, True)
-            url = reverse("plugins:netbox_kea:server_lease4_sync", args=[self.server.pk])
             response = self.client.post(url, {"ip_address": "10.0.0.1"})
         self.assertEqual(response.status_code, 200)
         mock_sync.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
-# TestReservationImportBareExcept  (F10)
+# TestReservationImportBareExcept
 # ---------------------------------------------------------------------------
 
 
@@ -370,23 +392,20 @@ class TestFetchLiveDataNoSyntheticFallback(_ViewTestBase):
 class TestReservationImportBareExcept(_ViewTestBase):
     """Reservation import catches all per-row exceptions and surfaces them as error rows."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_attribute_error_surfaced_as_error_row(self, MockKeaClient):
-        """An AttributeError from reservation_add is caught and surfaced as an error row."""
-        MockKeaClient.return_value.reservation_add.side_effect = AttributeError("bug")
+    def test_attribute_error_surfaced_as_error_row(self):
+        """An AttributeError from reservation-add is caught and surfaced as an error row."""
         url = reverse("plugins:netbox_kea:server_reservation4_bulk_import", args=[self.server.pk])
-
-        csv_content = "ip-address,hw-address,subnet-id\n10.0.0.1,aa:bb:cc:dd:ee:ff,1"
-        csv_file = io.BytesIO(csv_content.encode())
+        csv_file = io.BytesIO(b"ip-address,hw-address,subnet-id\n10.0.0.1,aa:bb:cc:dd:ee:ff,1")
         csv_file.name = "reservations.csv"
-        response = self.client.post(url, {"csv_file": csv_file, "subnet_id": "1"})
+        with stub_kea({"reservation-add": AttributeError("bug")}):
+            response = self.client.post(url, {"csv_file": csv_file, "subnet_id": "1"})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["result"]["errors"], 1)
         self.assertEqual(response.context["result"]["error_rows"][0]["error"], "An unexpected error occurred.")
 
 
 # ---------------------------------------------------------------------------
-# TestLeaseImportBareExcept  (F12)
+# TestLeaseImportBareExcept
 # ---------------------------------------------------------------------------
 
 
@@ -394,16 +413,14 @@ class TestReservationImportBareExcept(_ViewTestBase):
 class TestLeaseImportBareExcept(_ViewTestBase):
     """Lease import catches specific per-row exceptions and surfaces them as error rows."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_attribute_error_is_row_error(self, MockKeaClient):
-        """An AttributeError from lease_add is caught per-row and surfaced as an error row."""
-        MockKeaClient.return_value.lease_add.side_effect = AttributeError("bug")
+    def test_attribute_error_is_row_error(self):
+        """An AttributeError from lease4-add is caught per-row and surfaced as an error row."""
         url = reverse("plugins:netbox_kea:server_lease4_bulk_import", args=[self.server.pk])
-
-        csv_content = "ip-address,hw-address,hostname,valid-lft,subnet-id\n10.0.0.1,aa:bb:cc:00:00:01,host1,86400,1"
-        csv_file = io.BytesIO(csv_content.encode())
+        csv_content = b"ip-address,hw-address,hostname,valid-lft,subnet-id\n10.0.0.1,aa:bb:cc:00:00:01,host1,86400,1"
+        csv_file = io.BytesIO(csv_content)
         csv_file.name = "leases.csv"
-        response = self.client.post(url, {"csv_file": csv_file})
+        with stub_kea({"lease4-add": AttributeError("bug")}):
+            response = self.client.post(url, {"csv_file": csv_file})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["result"]["errors"], 1)
         self.assertEqual(
@@ -413,62 +430,39 @@ class TestLeaseImportBareExcept(_ViewTestBase):
 
 
 # ---------------------------------------------------------------------------
-# TestImportLoopValueError  (F8)
+# TestImportLoopValueError
 # ---------------------------------------------------------------------------
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestImportLoopValueError(_ViewTestBase):
-    """Import loops must handle ValueError from Kea client."""
+    """Import loops must handle ValueError from the Kea client as a per-row error."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_reservation_import_value_error_is_row_error(self, MockKeaClient):
-        """ValueError from reservation_add must be treated as a row error, not abort the import."""
-        mock_client = MockKeaClient.return_value
-        call_count = {"n": 0}
-
-        def side_effect(service, row):
-            call_count["n"] += 1
-            if call_count["n"] == 1:
-                raise ValueError("bad JSON from Kea")
-
-        mock_client.reservation_add.side_effect = side_effect
-
+    def test_reservation_import_value_error_is_row_error(self):
+        """ValueError from reservation-add must be a row error, not abort the import."""
         url = reverse("plugins:netbox_kea:server_reservation4_bulk_import", args=[self.server.pk])
-
-        csv_content = "ip-address,hw-address,subnet-id\n10.0.0.1,aa:bb:cc:00:00:01,1\n10.0.0.2,aa:bb:cc:00:00:02,1\n"
-        csv_file = io.BytesIO(csv_content.encode())
+        csv_content = b"ip-address,hw-address,subnet-id\n10.0.0.1,aa:bb:cc:00:00:01,1\n10.0.0.2,aa:bb:cc:00:00:02,1\n"
+        csv_file = io.BytesIO(csv_content)
         csv_file.name = "reservations.csv"
-        response = self.client.post(url, {"csv_file": csv_file})
+        with stub_kea({"reservation-add": queued(ValueError("bad JSON from Kea"), {"result": 0})}) as kea:
+            response = self.client.post(url, {"csv_file": csv_file})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(call_count["n"], 2)
+        self.assertEqual(len(kea.bodies("reservation-add")), 2)
         result = response.context["result"]
         self.assertEqual(result["errors"], 1)
         self.assertEqual(len(result["error_rows"]), 1)
         self.assertIn("Invalid response from Kea", result["error_rows"][0]["error"])
         self.assertNotIn("bad JSON from Kea", result["error_rows"][0]["error"])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_lease_import_value_error_is_row_error(self, MockKeaClient):
-        """ValueError from lease_add must be treated as a row error, not abort the import."""
-        mock_client = MockKeaClient.return_value
-        call_count = {"n": 0}
-
-        def side_effect(version, row):
-            call_count["n"] += 1
-            if call_count["n"] == 1:
-                raise ValueError("bad JSON from Kea")
-
-        mock_client.lease_add.side_effect = side_effect
-
+    def test_lease_import_value_error_is_row_error(self):
+        """ValueError from lease4-add must be a row error, not abort the import."""
         url = reverse("plugins:netbox_kea:server_lease4_bulk_import", args=[self.server.pk])
-
-        csv_content = "ip-address\n10.0.0.1\n10.0.0.2\n"
-        csv_file = io.BytesIO(csv_content.encode())
+        csv_file = io.BytesIO(b"ip-address\n10.0.0.1\n10.0.0.2\n")
         csv_file.name = "leases.csv"
-        response = self.client.post(url, {"csv_file": csv_file})
+        with stub_kea({"lease4-add": queued(ValueError("bad JSON from Kea"), {"result": 0})}) as kea:
+            response = self.client.post(url, {"csv_file": csv_file})
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(call_count["n"], 2)
+        self.assertEqual(len(kea.bodies("lease4-add")), 2)
         result = response.context["result"]
         self.assertEqual(result["errors"], 1)
         self.assertEqual(len(result["error_rows"]), 1)
@@ -476,47 +470,46 @@ class TestImportLoopValueError(_ViewTestBase):
         self.assertNotIn("bad JSON from Kea", result["error_rows"][0]["error"])
 
 
-# TestBulkReservationSyncExceptNarrowing  (F9)
+# ---------------------------------------------------------------------------
+# TestBulkReservationSyncExceptNarrowing
 # ---------------------------------------------------------------------------
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestBulkReservationSyncExceptNarrowing(_ViewTestBase):
-    """AttributeError from _fetch_reservations_from_server propagates (programming bug, not swallowed)."""
+    """AttributeError while fetching reservations propagates (programming bug, not swallowed)."""
 
-    @patch("netbox_kea.views.sync_views._fetch_reservations_from_server")
-    def test_attribute_error_propagates(self, mock_fetch):
-        """AttributeError from _fetch_reservations_from_server propagates (programming bug, not swallowed)."""
-        mock_fetch.side_effect = AttributeError("programming bug")
-
+    def test_attribute_error_propagates(self):
+        """An AttributeError raised while draining reservation-get-page propagates."""
         url = reverse("plugins:netbox_kea:server_reservation4_bulk_sync", args=[self.server.pk])
-        with self.assertRaises(AttributeError):
-            self.client.post(url)
+        with stub_kea({"reservation-get-page": AttributeError("programming bug")}):
+            with self.assertRaises(AttributeError):
+                self.client.post(url)
 
 
 # ---------------------------------------------------------------------------
-# TestBulkSyncBatchCleanup  (#30)
+# TestBulkSyncBatchCleanup
 # ---------------------------------------------------------------------------
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestBulkSyncBatchCleanup(_ViewTestBase):
-    """Bulk sync defers stale-IP cleanup to a single batch pass (#30)."""
+    """Bulk sync defers stale-IP cleanup to a single batch pass."""
 
     def _url(self):
         return reverse("plugins:netbox_kea:server_reservation4_bulk_sync", args=[self.server.pk])
 
     @patch("netbox_kea.sync.cleanup_stale_ips_batch", return_value=0)
     @patch("netbox_kea.sync.sync_reservation_to_netbox")
-    @patch("netbox_kea.views.sync_views._fetch_reservations_from_server")
-    def test_bulk_sync_calls_sync_with_cleanup_false(self, mock_fetch, mock_sync, mock_batch):
+    def test_bulk_sync_calls_sync_with_cleanup_false(self, mock_sync, mock_batch):
         """Each record is synced with cleanup=False; batch cleanup runs after."""
-        mock_fetch.return_value = [
+        hosts = [
             {"ip-address": "10.0.0.1", "hostname": "h1.example.com"},
             {"ip-address": "10.0.0.2", "hostname": "h1.example.com"},
         ]
         mock_sync.side_effect = [(MagicMock(spec=NbIP), True, True), (MagicMock(spec=NbIP), False, True)]
-        self.client.post(self._url(), follow=True)
+        with stub_kea({"reservation-get-page": _res_page(hosts)}):
+            self.client.post(self._url())
         # Both calls must use cleanup=False
         for call in mock_sync.call_args_list:
             self.assertEqual(call.kwargs.get("cleanup"), False)
@@ -527,31 +520,27 @@ class TestBulkSyncBatchCleanup(_ViewTestBase):
 
     @patch("netbox_kea.sync.cleanup_stale_ips_batch", return_value=3)
     @patch("netbox_kea.sync.sync_reservation_to_netbox")
-    @patch("netbox_kea.views.sync_views._fetch_reservations_from_server")
-    def test_stale_cleaned_count_appears_in_message(self, mock_fetch, mock_sync, mock_batch):
+    def test_stale_cleaned_count_appears_in_message(self, mock_sync, mock_batch):
         """When batch cleanup removes IPs, the count appears in the success message."""
-        mock_fetch.return_value = [{"ip-address": "10.0.0.1", "hostname": "h.example.com"}]
+        hosts = [{"ip-address": "10.0.0.1", "hostname": "h.example.com"}]
         mock_sync.return_value = (MagicMock(spec=NbIP), True, True)
-        response = self.client.post(self._url(), follow=True)
-        msgs = [str(m) for m in response.context["messages"]]
-        self.assertTrue(any("3 stale cleaned" in m for m in msgs))
+        with stub_kea({"reservation-get-page": _res_page(hosts)}):
+            response = self.client.post(self._url())
+        self.assertTrue(any("3 stale cleaned" in m for m in _messages(response)))
 
     @patch("netbox_kea.sync.cleanup_stale_ips_batch", return_value=0)
     @patch("netbox_kea.sync.sync_reservation_to_netbox")
-    @patch("netbox_kea.views.sync_views._fetch_reservations_from_server")
-    def test_batch_cleanup_skipped_when_errors(self, mock_fetch, mock_sync, mock_batch):
+    def test_batch_cleanup_skipped_when_errors(self, mock_sync, mock_batch):
         """When sync errors occur, batch cleanup is skipped entirely (incomplete keep-set)."""
-        mock_fetch.return_value = [
-            {"ip-address": "10.0.0.1", "hostname": "h1"},
-            {"ip-address": "10.0.0.2", "hostname": "h2"},
-        ]
+        hosts = [{"ip-address": "10.0.0.1", "hostname": "h1"}, {"ip-address": "10.0.0.2", "hostname": "h2"}]
         mock_sync.side_effect = [ValueError("db error"), (MagicMock(spec=NbIP), True, True)]
-        self.client.post(self._url(), follow=True)
+        with stub_kea({"reservation-get-page": _res_page(hosts)}):
+            self.client.post(self._url())
         mock_batch.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
-# Coverage: _BaseSyncView.post() DB error during sync (~lines 56-63)
+# _BaseSyncView.post() — DB error during sync
 # ---------------------------------------------------------------------------
 
 
@@ -562,89 +551,56 @@ class TestBaseSyncViewDBError(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_lease4_sync", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_integrity_error_returns_500(self, MockKeaClient):
+    def _post_with_sync_error(self, ip, exc):
+        with (
+            stub_kea({"lease4-get": _lease4(ip)}),
+            patch("netbox_kea.views.ServerLease4SyncView._sync", side_effect=exc),
+        ):
+            return self.client.post(self._url(), {"ip_address": ip})
+
+    def test_integrity_error_returns_500(self):
         """IntegrityError from _sync returns 500 with generic message."""
         from django.db import IntegrityError
 
-        MockKeaClient.return_value.lease_get_by_ip.return_value = {
-            "ip-address": "10.0.0.1",
-            "hw-address": "aa:bb:cc:00:00:01",
-            "hostname": "host1",
-            "valid-lft": 86400,
-            "cltt": 1700000000,
-            "subnet-id": 1,
-        }
-        with patch("netbox_kea.views.ServerLease4SyncView._sync", side_effect=IntegrityError("duplicate key")):
-            response = self.client.post(self._url(), {"ip_address": "10.0.0.1"})
+        response = self._post_with_sync_error("10.0.0.1", IntegrityError("duplicate key"))
         self.assertEqual(response.status_code, 500)
         body = response.content.decode()
         self.assertIn("Sync error", body)
         self.assertNotIn("duplicate key", body)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_operational_error_returns_500(self, MockKeaClient):
+    def test_operational_error_returns_500(self):
         """OperationalError from _sync returns 500 with generic message."""
         from django.db.utils import OperationalError
 
-        MockKeaClient.return_value.lease_get_by_ip.return_value = {
-            "ip-address": "10.0.0.2",
-            "hw-address": "aa:bb:cc:00:00:02",
-            "hostname": "host2",
-            "valid-lft": 86400,
-            "cltt": 1700000000,
-            "subnet-id": 1,
-        }
-        with patch("netbox_kea.views.ServerLease4SyncView._sync", side_effect=OperationalError("db conn failed")):
-            response = self.client.post(self._url(), {"ip_address": "10.0.0.2"})
+        response = self._post_with_sync_error("10.0.0.2", OperationalError("db conn failed"))
         self.assertEqual(response.status_code, 500)
         body = response.content.decode()
         self.assertIn("Sync error", body)
         self.assertNotIn("db conn failed", body)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_programming_error_returns_500(self, MockKeaClient):
+    def test_programming_error_returns_500(self):
         """ProgrammingError from _sync returns 500."""
         from django.db.utils import ProgrammingError
 
-        MockKeaClient.return_value.lease_get_by_ip.return_value = {
-            "ip-address": "10.0.0.3",
-            "hw-address": "aa:bb:cc:00:00:03",
-            "hostname": "host3",
-            "valid-lft": 86400,
-            "cltt": 1700000000,
-            "subnet-id": 1,
-        }
-        with patch("netbox_kea.views.ServerLease4SyncView._sync", side_effect=ProgrammingError("bad query")):
-            response = self.client.post(self._url(), {"ip_address": "10.0.0.3"})
+        response = self._post_with_sync_error("10.0.0.3", ProgrammingError("bad query"))
         self.assertEqual(response.status_code, 500)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_validation_error_returns_500(self, MockKeaClient):
+    def test_validation_error_returns_500(self):
         """ValidationError from _sync returns 500."""
         from django.core.exceptions import ValidationError
 
-        MockKeaClient.return_value.lease_get_by_ip.return_value = {
-            "ip-address": "10.0.0.4",
-            "hw-address": "aa:bb:cc:00:00:04",
-            "hostname": "host4",
-            "valid-lft": 86400,
-            "cltt": 1700000000,
-            "subnet-id": 1,
-        }
-        with patch("netbox_kea.views.ServerLease4SyncView._sync", side_effect=ValidationError("invalid data")):
-            response = self.client.post(self._url(), {"ip_address": "10.0.0.4"})
+        response = self._post_with_sync_error("10.0.0.4", ValidationError("invalid data"))
         self.assertEqual(response.status_code, 500)
 
 
 # ---------------------------------------------------------------------------
-# Coverage: Bulk reservation sync fetch failure (~lines 161-188)
+# Bulk reservation sync fetch failure
 # ---------------------------------------------------------------------------
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestBulkReservationSyncFetchFailure(_ViewTestBase):
-    """Bulk sync shows error when reservation fetch fails."""
+    """Bulk sync shows error when the reservation fetch fails."""
 
     def _url_v4(self):
         return reverse("plugins:netbox_kea:server_reservation4_bulk_sync", args=[self.server.pk])
@@ -652,112 +608,84 @@ class TestBulkReservationSyncFetchFailure(_ViewTestBase):
     def _url_v6(self):
         return reverse("plugins:netbox_kea:server_reservation6_bulk_sync", args=[self.server.pk])
 
-    @patch("netbox_kea.views.sync_views._fetch_reservations_from_server")
-    def test_kea_exception_on_fetch_shows_error_and_redirects(self, mock_fetch):
-        """KeaException during fetch shows error with hint and redirects."""
-        from django.contrib.messages import get_messages
-
-        mock_fetch.side_effect = KeaException(
-            {"result": 1, "text": "hook not loaded"},
-            index=0,
-        )
-        response = self.client.post(self._url_v4())
+    def test_kea_exception_on_fetch_shows_error_and_redirects(self):
+        """KeaException during fetch shows a hint and redirects; raw Kea text must not leak."""
+        with stub_kea({"reservation-get-page": {"result": 1, "text": "hook not loaded"}}):
+            response = self.client.post(self._url_v4())
         self.assertEqual(response.status_code, 302)
-        msgs = [str(m) for m in get_messages(response.wsgi_request)]
+        msgs = _messages(response)
         # kea_error_hint maps result=1 to a generic message — raw Kea text must not leak
         self.assertTrue(any("Kea reported an error" in m for m in msgs))
         self.assertFalse(any("hook not loaded" in m.lower() for m in msgs))
 
-    @patch("netbox_kea.views.sync_views._fetch_reservations_from_server")
-    def test_type_error_on_fetch_shows_generic_error(self, mock_fetch):
-        """TypeError during fetch shows generic error."""
-        mock_fetch.side_effect = TypeError("unexpected type")
-        response = self.client.post(self._url_v4(), follow=True)
-        msgs = [str(m) for m in response.context["messages"]]
+    def test_type_error_on_fetch_shows_generic_error(self):
+        """A TypeError raised while draining reservation-get-page shows a generic error."""
+        with stub_kea({"reservation-get-page": TypeError("unexpected type")}):
+            response = self.client.post(self._url_v4())
+        msgs = _messages(response)
         self.assertTrue(any("Failed to fetch" in m for m in msgs))
         self.assertFalse(any("unexpected type" in m for m in msgs))
 
-    @patch("netbox_kea.views.sync_views._fetch_reservations_from_server")
-    def test_v6_kea_exception_on_fetch_redirects_to_v6_list(self, mock_fetch):
-        """v6 KeaException redirects to the v6 reservation list."""
-        from netbox_kea.kea import KeaException
-
-        mock_fetch.side_effect = KeaException(
-            {"result": 2, "text": "unknown command"},
-            index=0,
-        )
-        response = self.client.post(self._url_v6())
+    def test_v6_kea_exception_on_fetch_redirects_to_v6_list(self):
+        """A v6 KeaException (unknown command) redirects to the v6 reservation list."""
+        with stub_kea({"reservation-get-page": {"result": 2, "text": "unknown command"}}):
+            response = self.client.post(self._url_v6())
         self.assertEqual(response.status_code, 302)
         self.assertIn("reservations6", response.url)
 
 
 # ---------------------------------------------------------------------------
-# Coverage: Per-row error isolation in bulk import (~lines 354-369)
+# Per-row error isolation in bulk import
 # ---------------------------------------------------------------------------
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestBulkImportPerRowErrorIsolation(_ViewTestBase):
-    """If one reservation in a batch raises KeaException, remaining items still process."""
+    """If one reservation in a batch raises, remaining items still process."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_one_row_fails_others_succeed(self, MockKeaClient):
+    def _url(self):
+        return reverse("plugins:netbox_kea:server_reservation4_bulk_import", args=[self.server.pk])
+
+    def test_one_row_fails_others_succeed(self):
         """First row raises KeaException, second succeeds, third raises ValueError."""
-        call_count = {"n": 0}
-
-        def side_effect(service, row):
-            call_count["n"] += 1
-            if call_count["n"] == 1:
-                raise KeaException({"result": 1, "text": "conflict"}, index=0)
-            if call_count["n"] == 3:
-                raise ValueError("bad response")
-
-        MockKeaClient.return_value.reservation_add.side_effect = side_effect
-        url = reverse("plugins:netbox_kea:server_reservation4_bulk_import", args=[self.server.pk])
-
-        csv_content = (
-            "ip-address,hw-address,subnet-id\n"
-            "10.0.0.1,aa:bb:cc:00:00:01,1\n"
-            "10.0.0.2,aa:bb:cc:00:00:02,1\n"
-            "10.0.0.3,aa:bb:cc:00:00:03,1\n"
+        responses = queued(
+            {"result": 1, "text": "conflict"},  # row 1 → KeaException (not a duplicate) → error
+            {"result": 0},  # row 2 → created
+            ValueError("bad response"),  # row 3 → error
         )
-        csv_file = io.BytesIO(csv_content.encode())
+        csv_content = (
+            b"ip-address,hw-address,subnet-id\n"
+            b"10.0.0.1,aa:bb:cc:00:00:01,1\n"
+            b"10.0.0.2,aa:bb:cc:00:00:02,1\n"
+            b"10.0.0.3,aa:bb:cc:00:00:03,1\n"
+        )
+        csv_file = io.BytesIO(csv_content)
         csv_file.name = "reservations.csv"
-        response = self.client.post(url, {"csv_file": csv_file})
+        with stub_kea({"reservation-add": responses}) as kea:
+            response = self.client.post(self._url(), {"csv_file": csv_file})
         self.assertEqual(response.status_code, 200)
         result = response.context["result"]
         self.assertEqual(result["created"], 1)
         self.assertEqual(result["errors"], 2)
-        self.assertEqual(call_count["n"], 3)
+        self.assertEqual(len(kea.bodies("reservation-add")), 3)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_already_exists_counted_as_skipped(self, MockKeaClient):
+    def test_already_exists_counted_as_skipped(self):
         """KeaException with result=1 and 'already exist' text is counted as skipped."""
-        MockKeaClient.return_value.reservation_add.side_effect = KeaException(
-            {"result": 1, "text": "Host already exists in subnet 1."},
-            index=0,
-        )
-        url = reverse("plugins:netbox_kea:server_reservation4_bulk_import", args=[self.server.pk])
-        csv_content = "ip-address,hw-address,subnet-id\n10.0.0.1,aa:bb:cc:00:00:01,1\n"
-        csv_file = io.BytesIO(csv_content.encode())
+        csv_file = io.BytesIO(b"ip-address,hw-address,subnet-id\n10.0.0.1,aa:bb:cc:00:00:01,1\n")
         csv_file.name = "reservations.csv"
-        response = self.client.post(url, {"csv_file": csv_file})
+        with stub_kea({"reservation-add": {"result": 1, "text": "Host already exists in subnet 1."}}):
+            response = self.client.post(self._url(), {"csv_file": csv_file})
         self.assertEqual(response.status_code, 200)
         result = response.context["result"]
         self.assertEqual(result["skipped"], 1)
         self.assertEqual(result["errors"], 0)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_connection_error_per_row(self, MockKeaClient):
+    def test_connection_error_per_row(self):
         """requests.RequestException per-row is caught and recorded."""
-        import requests as req_lib
-
-        MockKeaClient.return_value.reservation_add.side_effect = req_lib.ConnectionError("timeout")
-        url = reverse("plugins:netbox_kea:server_reservation4_bulk_import", args=[self.server.pk])
-        csv_content = "ip-address,hw-address,subnet-id\n10.0.0.1,aa:bb:cc:00:00:01,1\n"
-        csv_file = io.BytesIO(csv_content.encode())
+        csv_file = io.BytesIO(b"ip-address,hw-address,subnet-id\n10.0.0.1,aa:bb:cc:00:00:01,1\n")
         csv_file.name = "reservations.csv"
-        response = self.client.post(url, {"csv_file": csv_file})
+        with stub_kea({"reservation-add": requests.ConnectionError("timeout")}):
+            response = self.client.post(self._url(), {"csv_file": csv_file})
         self.assertEqual(response.status_code, 200)
         result = response.context["result"]
         self.assertEqual(result["errors"], 1)
@@ -765,7 +693,7 @@ class TestBulkImportPerRowErrorIsolation(_ViewTestBase):
 
 
 # ---------------------------------------------------------------------------
-# Coverage: Reservation sync view for v6 with IntegrityError
+# Reservation sync view for v6 with IntegrityError
 # ---------------------------------------------------------------------------
 
 
@@ -776,20 +704,19 @@ class TestReservation6SyncDBError(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_reservation6_sync", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_integrity_error_returns_500(self, MockKeaClient):
+    def test_integrity_error_returns_500(self):
         """IntegrityError from _sync returns 500."""
         from django.db import IntegrityError
 
-        MockKeaClient.return_value.reservation_get_by_ip.return_value = {
-            "ip-addresses": ["2001:db8::1"],
-            "duid": "00:01:02:03:04:05",
-            "hostname": "host6",
-            "subnet-id": 1,
+        stub = {
+            "subnet6-list": _subnet_list(6, [{"id": 1, "subnet": "2001:db8::/64"}]),
+            "reservation-get": _res_get(
+                {"ip-addresses": ["2001:db8::1"], "duid": "00:01:02:03:04:05", "hostname": "host6", "subnet-id": 1}
+            ),
         }
-        with patch(
-            "netbox_kea.views.ServerReservation6SyncView._sync",
-            side_effect=IntegrityError("dup"),
+        with (
+            stub_kea(stub),
+            patch("netbox_kea.views.ServerReservation6SyncView._sync", side_effect=IntegrityError("dup")),
         ):
             response = self.client.post(self._url(), {"ip_address": "2001:db8::1"})
         self.assertEqual(response.status_code, 500)
@@ -797,7 +724,7 @@ class TestReservation6SyncDBError(_ViewTestBase):
 
 
 # ---------------------------------------------------------------------------
-# Coverage: _BaseSyncView.post() — OperationalError during sync
+# _BaseSyncView.post() — OperationalError during sync
 # ---------------------------------------------------------------------------
 
 
@@ -808,20 +735,14 @@ class TestSyncViewOperationalError(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_lease4_sync", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_operational_error_from_sync_returns_500(self, MockKeaClient):
+    def test_operational_error_from_sync_returns_500(self):
         """OperationalError during sync returns 500 with generic message."""
         from django.db.utils import OperationalError
 
-        MockKeaClient.return_value.lease_get_by_ip.return_value = {
-            "ip-address": "10.0.0.10",
-            "hw-address": "aa:bb:cc:00:00:10",
-            "hostname": "host10",
-            "valid-lft": 86400,
-            "cltt": 1700000000,
-            "subnet-id": 1,
-        }
-        with patch("netbox_kea.views.ServerLease4SyncView._sync", side_effect=OperationalError("conn lost")):
+        with (
+            stub_kea({"lease4-get": _lease4("10.0.0.10")}),
+            patch("netbox_kea.views.ServerLease4SyncView._sync", side_effect=OperationalError("conn lost")),
+        ):
             response = self.client.post(self._url(), {"ip_address": "10.0.0.10"})
         self.assertEqual(response.status_code, 500)
         body = response.content.decode()
@@ -830,7 +751,7 @@ class TestSyncViewOperationalError(_ViewTestBase):
 
 
 # ---------------------------------------------------------------------------
-# Coverage: Lease6 sync view — live fetch failure
+# Lease6 sync view — live fetch failure
 # ---------------------------------------------------------------------------
 
 
@@ -841,58 +762,49 @@ class TestLease6SyncViewFetchFailure(_ViewTestBase):
     def _url(self):
         return reverse("plugins:netbox_kea:server_lease6_sync", args=[self.server.pk])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_kea_exception_returns_400(self, MockKeaClient):
-        """KeaException from lease6 fetch returns 400."""
-        MockKeaClient.return_value.lease_get_by_ip.side_effect = KeaException(
-            {"result": 1, "text": "not found"}, index=0
-        )
-        response = self.client.post(self._url(), {"ip_address": "2001:db8::1"})
+    def test_kea_exception_returns_400(self):
+        """KeaException from the lease6 fetch returns 400."""
+        with stub_kea({"lease6-get": {"result": 1, "text": "not found"}}):
+            response = self.client.post(self._url(), {"ip_address": "2001:db8::1"})
         self.assertEqual(response.status_code, 400)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_empty_lease_returns_400(self, MockKeaClient):
-        """When lease6 is None (not found), returns 400."""
-        MockKeaClient.return_value.lease_get_by_ip.return_value = None
-        response = self.client.post(self._url(), {"ip_address": "2001:db8::2"})
+    def test_empty_lease_returns_400(self):
+        """When lease6 is not found (result 3), returns 400."""
+        with stub_kea({"lease6-get": {"result": 3}}):
+            response = self.client.post(self._url(), {"ip_address": "2001:db8::2"})
         self.assertEqual(response.status_code, 400)
 
 
 # ---------------------------------------------------------------------------
-# Coverage: Bulk reservation sync — v6 fetch exception path
+# Bulk reservation sync — v6 fetch exception path
 # ---------------------------------------------------------------------------
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestBulkReservation6SyncFetchFail(_ViewTestBase):
-    """v6 bulk sync shows error when reservation fetch fails."""
+    """v6 bulk sync shows error when the reservation fetch fails."""
 
     def _url(self):
         return reverse("plugins:netbox_kea:server_reservation6_bulk_sync", args=[self.server.pk])
 
-    @patch("netbox_kea.views.sync_views._fetch_reservations_from_server")
-    def test_v6_kea_exception_shows_error_and_redirects(self, mock_fetch):
-        """KeaException during v6 reservation fetch shows error and redirects to v6 list."""
-        mock_fetch.side_effect = KeaException(
-            {"result": 1, "text": "host_cmds not loaded"},
-            index=0,
-        )
-        response = self.client.post(self._url())
+    def test_v6_kea_exception_shows_error_and_redirects(self):
+        """KeaException during v6 reservation fetch shows error and redirects to the v6 list."""
+        with stub_kea({"reservation-get-page": {"result": 1, "text": "host_cmds not loaded"}}):
+            response = self.client.post(self._url())
         self.assertEqual(response.status_code, 302)
         self.assertIn("reservations6", response.url)
 
-    @patch("netbox_kea.views.sync_views._fetch_reservations_from_server")
-    def test_v6_value_error_shows_generic_error(self, mock_fetch):
-        """ValueError during v6 fetch shows generic error."""
-        mock_fetch.side_effect = ValueError("bad data")
-        response = self.client.post(self._url(), follow=True)
-        msgs = [str(m) for m in response.context["messages"]]
+    def test_v6_value_error_shows_generic_error(self):
+        """ValueError during v6 fetch shows a generic error."""
+        with stub_kea({"reservation-get-page": ValueError("bad data")}):
+            response = self.client.post(self._url())
+        msgs = _messages(response)
         self.assertTrue(any("Failed to fetch" in m for m in msgs))
         self.assertFalse(any("bad data" in m for m in msgs))
 
 
 # ---------------------------------------------------------------------------
-# Coverage: Bulk sync per-row error isolation
+# Bulk sync per-row error isolation
 # ---------------------------------------------------------------------------
 
 
@@ -904,12 +816,11 @@ class TestBulkSyncPerRowErrorIsolation(_ViewTestBase):
         return reverse("plugins:netbox_kea:server_reservation4_bulk_sync", args=[self.server.pk])
 
     @patch("netbox_kea.sync.sync_reservation_to_netbox")
-    @patch("netbox_kea.views.sync_views._fetch_reservations_from_server")
-    def test_middle_row_fails_others_succeed(self, mock_fetch, mock_sync):
+    def test_middle_row_fails_others_succeed(self, mock_sync):
         """Row 1 succeeds, row 2 raises IntegrityError, row 3 succeeds."""
         from django.db import IntegrityError
 
-        mock_fetch.return_value = [
+        hosts = [
             {"ip-address": "10.0.0.1", "hw-address": "aa:bb:cc:00:00:01"},
             {"ip-address": "10.0.0.2", "hw-address": "aa:bb:cc:00:00:02"},
             {"ip-address": "10.0.0.3", "hw-address": "aa:bb:cc:00:00:03"},
@@ -919,43 +830,39 @@ class TestBulkSyncPerRowErrorIsolation(_ViewTestBase):
             IntegrityError("duplicate key"),
             (MagicMock(spec=NbIP), False, True),
         ]
-        response = self.client.post(self._url(), follow=True)
-        msgs = [str(m) for m in response.context["messages"]]
+        with stub_kea({"reservation-get-page": _res_page(hosts)}):
+            response = self.client.post(self._url())
+        msgs = _messages(response)
         # 1 created + 1 error + 1 updated
         self.assertTrue(any("1 created" in m and "1 updated" in m and "1 errors" in m for m in msgs))
         self.assertEqual(mock_sync.call_count, 3)
 
     @patch("netbox_kea.sync.sync_reservation_to_netbox")
-    @patch("netbox_kea.views.sync_views._fetch_reservations_from_server")
-    def test_validation_error_counted_as_error(self, mock_fetch, mock_sync):
-        """ValidationError from sync is counted as error."""
+    def test_validation_error_counted_as_error(self, mock_sync):
+        """ValidationError from sync is counted as an error."""
         from django.core.exceptions import ValidationError
 
-        mock_fetch.return_value = [
-            {"ip-address": "10.0.0.1", "hw-address": "aa:bb:cc:00:00:01"},
-        ]
+        hosts = [{"ip-address": "10.0.0.1", "hw-address": "aa:bb:cc:00:00:01"}]
         mock_sync.side_effect = ValidationError("invalid prefix")
-        response = self.client.post(self._url(), follow=True)
-        msgs = [str(m) for m in response.context["messages"]]
+        with stub_kea({"reservation-get-page": _res_page(hosts)}):
+            response = self.client.post(self._url())
+        msgs = _messages(response)
         self.assertTrue(any("1 errors" in m for m in msgs))
         self.assertFalse(any("invalid prefix" in m for m in msgs))
 
     @patch("netbox_kea.sync.sync_reservation_to_netbox")
-    @patch("netbox_kea.views.sync_views._fetch_reservations_from_server")
-    def test_reservations_with_ip_addresses_field_processed(self, mock_fetch, mock_sync):
+    def test_reservations_with_ip_addresses_field_processed(self, mock_sync):
         """v6-style reservations with ip-addresses list (not ip-address) are processed."""
-        mock_fetch.return_value = [
-            {"ip-addresses": ["2001:db8::1"], "duid": "00:01:02:03"},
-        ]
+        hosts = [{"ip-addresses": ["2001:db8::1"], "duid": "00:01:02:03"}]
         mock_sync.return_value = (MagicMock(spec=NbIP), True, True)
-        response = self.client.post(self._url(), follow=True)
+        with stub_kea({"reservation-get-page": _res_page(hosts)}):
+            response = self.client.post(self._url())
         mock_sync.assert_called_once()
-        msgs = [str(m) for m in response.context["messages"]]
-        self.assertTrue(any("1 created" in m for m in msgs))
+        self.assertTrue(any("1 created" in m for m in _messages(response)))
 
 
 # ---------------------------------------------------------------------------
-# Coverage: Bulk reservation import — per-row exception types
+# Bulk reservation import — per-row exception types
 # ---------------------------------------------------------------------------
 
 
@@ -963,66 +870,49 @@ class TestBulkSyncPerRowErrorIsolation(_ViewTestBase):
 class TestBulkImportPerRowExceptionTypes(_ViewTestBase):
     """Bulk import handles each per-row exception type independently."""
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_requests_exception_per_row_recorded(self, MockKeaClient):
-        """requests.RequestException per-row surfaced with connection error message."""
-        import requests as req_lib
+    def _url(self):
+        return reverse("plugins:netbox_kea:server_reservation4_bulk_import", args=[self.server.pk])
 
-        MockKeaClient.return_value.reservation_add.side_effect = req_lib.Timeout("read timeout")
-        url = reverse("plugins:netbox_kea:server_reservation4_bulk_import", args=[self.server.pk])
-        csv_content = "ip-address,hw-address,subnet-id\n10.0.0.1,aa:bb:cc:00:00:01,1\n"
-        csv_file = io.BytesIO(csv_content.encode())
+    def test_requests_exception_per_row_recorded(self):
+        """requests.RequestException per-row surfaced with a connection-error message."""
+        csv_file = io.BytesIO(b"ip-address,hw-address,subnet-id\n10.0.0.1,aa:bb:cc:00:00:01,1\n")
         csv_file.name = "reservations.csv"
-        response = self.client.post(url, {"csv_file": csv_file})
+        with stub_kea({"reservation-add": requests.Timeout("read timeout")}):
+            response = self.client.post(self._url(), {"csv_file": csv_file})
         self.assertEqual(response.status_code, 200)
         result = response.context["result"]
         self.assertEqual(result["errors"], 1)
         self.assertIn("Connection error", result["error_rows"][0]["error"])
         self.assertNotIn("read timeout", result["error_rows"][0]["error"])
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_duplicate_kea_exception_counted_as_skipped(self, MockKeaClient):
+    def test_duplicate_kea_exception_counted_as_skipped(self):
         """KeaException with 'already exist' text is counted as skipped, not error."""
-        MockKeaClient.return_value.reservation_add.side_effect = KeaException(
-            {"result": 1, "text": "Host already exists in subnet 1. Duplicate entry."},
-            index=0,
-        )
-        url = reverse("plugins:netbox_kea:server_reservation4_bulk_import", args=[self.server.pk])
-        csv_content = "ip-address,hw-address,subnet-id\n10.0.0.1,aa:bb:cc:00:00:01,1\n"
-        csv_file = io.BytesIO(csv_content.encode())
+        csv_file = io.BytesIO(b"ip-address,hw-address,subnet-id\n10.0.0.1,aa:bb:cc:00:00:01,1\n")
         csv_file.name = "reservations.csv"
-        response = self.client.post(url, {"csv_file": csv_file})
+        with stub_kea({"reservation-add": {"result": 1, "text": "Host already exists in subnet 1. Duplicate entry."}}):
+            response = self.client.post(self._url(), {"csv_file": csv_file})
         self.assertEqual(response.status_code, 200)
         result = response.context["result"]
         self.assertEqual(result["skipped"], 1)
         self.assertEqual(result["errors"], 0)
 
-    @patch("netbox_kea.models.KeaClient")
-    def test_mixed_success_skip_and_error_in_batch(self, MockKeaClient):
+    def test_mixed_success_skip_and_error_in_batch(self):
         """Multi-row batch: row 1 succeeds, row 2 duplicate skip, row 3 error."""
-        call_count = {"n": 0}
-
-        def side_effect(service, row):
-            call_count["n"] += 1
-            if call_count["n"] == 2:
-                raise KeaException(
-                    {"result": 1, "text": "Host already exists in subnet 1."},
-                    index=0,
-                )
-            if call_count["n"] == 3:
-                raise RuntimeError("unexpected")
-
-        MockKeaClient.return_value.reservation_add.side_effect = side_effect
-        url = reverse("plugins:netbox_kea:server_reservation4_bulk_import", args=[self.server.pk])
-        csv_content = (
-            "ip-address,hw-address,subnet-id\n"
-            "10.0.0.1,aa:bb:cc:00:00:01,1\n"
-            "10.0.0.2,aa:bb:cc:00:00:02,1\n"
-            "10.0.0.3,aa:bb:cc:00:00:03,1\n"
+        responses = queued(
+            {"result": 0},  # row 1 → created
+            {"result": 1, "text": "Host already exists in subnet 1."},  # row 2 → skipped
+            RuntimeError("unexpected"),  # row 3 → error
         )
-        csv_file = io.BytesIO(csv_content.encode())
+        csv_content = (
+            b"ip-address,hw-address,subnet-id\n"
+            b"10.0.0.1,aa:bb:cc:00:00:01,1\n"
+            b"10.0.0.2,aa:bb:cc:00:00:02,1\n"
+            b"10.0.0.3,aa:bb:cc:00:00:03,1\n"
+        )
+        csv_file = io.BytesIO(csv_content)
         csv_file.name = "reservations.csv"
-        response = self.client.post(url, {"csv_file": csv_file})
+        with stub_kea({"reservation-add": responses}):
+            response = self.client.post(self._url(), {"csv_file": csv_file})
         self.assertEqual(response.status_code, 200)
         result = response.context["result"]
         self.assertEqual(result["created"], 1)

--- a/netbox_kea/tests/test_views_sync.py
+++ b/netbox_kea/tests/test_views_sync.py
@@ -37,7 +37,7 @@ from django.test import override_settings
 from django.urls import reverse
 from ipam.models import IPAddress as NbIP
 
-from .kea_stub import _res_get, _res_page, queued, stub_kea
+from .kea_stub import _res_get, _res_page, _subnet_list, queued, stub_kea
 from .utils import _PLUGINS_CONFIG, User, _ViewTestBase
 
 # ---------------------------------------------------------------------------
@@ -58,11 +58,6 @@ def _lease4(ip="10.0.0.1"):
             "subnet-id": 1,
         },
     }
-
-
-def _subnet_list(version, subnets):
-    """A ``subnet{v}-list`` payload (used by ``reservation_get_by_ip`` to find candidate subnets)."""
-    return {"result": 0, "arguments": {"subnets": list(subnets)}}
 
 
 def _messages(response):
@@ -301,8 +296,8 @@ class TestReservation4SyncViewFetchLiveData(_ViewTestBase):
         self.assertEqual(response.status_code, 400)
         mock_sync.assert_not_called()
 
-    def test_falls_back_on_kea_exception(self):
-        """When the subnet-list call fails (KeaException), response is 400."""
+    def test_kea_exception_returns_400_without_sync(self):
+        """When the subnet-list call fails (KeaException), response is 400 (no sync)."""
         with (
             stub_kea({"subnet4-list": {"result": 1, "text": "not found"}}),
             patch("netbox_kea.views.ServerReservation4SyncView._sync") as mock_sync,
@@ -326,8 +321,8 @@ class TestReservation6SyncViewFetchLiveData(_ViewTestBase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(kea.bodies("subnet6-list")[0]["service"], ["dhcp6"])
 
-    def test_falls_back_on_request_exception(self):
-        """When the subnet-list call raises a transport error, response is 400."""
+    def test_request_exception_returns_400_without_sync(self):
+        """When the subnet-list call raises a transport error, response is 400 (no sync)."""
         with stub_kea({"subnet6-list": requests.RequestException("timeout")}):
             response = self.client.post(self._url(), {"ip_address": "2001:db8::1", "hostname": "fallback6"})
         self.assertEqual(response.status_code, 400)


### PR DESCRIPTION
**Draft / WIP — building incrementally.** First step of the codex-ratified plan (PR A → C → B).

## Why
The view tests patch `netbox_kea.models.KeaClient` with a `MagicMock` and assert call-args, so `command()`'s real payload is never built or inspected — a payload regression (e.g. a stray/missing `service` key) stays green.

## This step
- **`netbox_kea/tests/kea_stub.py`** — `stub_kea({command: response})` patches `requests.Session.post` at the class level (covers `KeaClient.clone()` on worker threads) and records the request bodies. Real view → real `get_client()` → real `command()` → stubbed HTTP.
- Converted `test_post_htmx_single_lease_returns_hx_refresh` to assert the real `lease4-del` payload (`arguments` + `service`) — proving the pattern before scaling.

## Next
Convert the rest of `test_views_leases.py` in flow-grouped batches (search paths, reserved-badge via real `reservation_get`, pagination), then the other view-test files. This is the safety net that makes PR C (drop `service`, endpoint-aware) verifiable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a command-aware Kea HTTP stub for view/API tests, including request/endpoint recording, per-command canned responses, queued/paginated sequencing, callable-driven payloads, and thread-safe handling across concurrent requests.
  * Added a dedicated test suite to validate response normalization, dispatch/registration errors, exception propagation, and concurrency guarantees.
  * Refactored lease, reservation, server, subnet, options, DHCP control, sync, and combined view/API tests to use the HTTP-boundary stubbing approach, asserting generated commands/payloads plus pagination/cursor, redirects, and robust error/edge-case behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->