### PR TITLE
feat: omit the Kea `service` arg on direct-daemon connections

### DIFF
--- a/netbox_kea/kea.py
+++ b/netbox_kea/kea.py
@@ -31,6 +31,7 @@ class KeaClient:
         client_key: str | None = None,
         timeout: int = 30,
         persist_config: bool = True,
+        send_service: bool = True,
     ):
         """Initialise a Kea HTTP client session.
 
@@ -46,6 +47,12 @@ class KeaClient:
                 each mutation.  Set to False when Kea configuration is managed
                 externally (e.g. Ansible, Puppet) and you do not want the plugin
                 to overwrite the on-disk config file.
+            send_service: When True (default), the ``service`` argument is included
+                in the command body — correct for a Control Agent, which routes by
+                service.  Set to False when *url* points **directly** at a DHCP
+                daemon: Kea 3.2.0+ rejects a ``service`` that does not match the
+                daemon, and ISC recommends omitting it for direct connections
+                (3.0.x silently ignored it).
 
         Raises:
             ValueError: If only one of client_cert/client_key is provided.
@@ -57,6 +64,7 @@ class KeaClient:
         self.url = url
         self.timeout = timeout
         self.persist_config = persist_config
+        self.send_service = send_service
 
         self._session = requests.Session()
         if verify is not None:
@@ -78,6 +86,8 @@ class KeaClient:
         Args:
             command: Kea command name (e.g. ``"lease4-get-all"``).
             service: List of target services (e.g. ``["dhcp4"]``). Omit for CA-level commands.
+                Dropped from the request body when the client targets a DHCP daemon
+                directly (``send_service=False``) — see :meth:`__init__`.
             arguments: Optional command arguments payload.
             check: Sequence of acceptable result codes. Pass ``None`` to skip checking.
 
@@ -91,7 +101,10 @@ class KeaClient:
         """
         body: dict[str, Any] = {"command": command}
 
-        if service is not None:
+        # A direct daemon connection must not carry ``service``: Kea 3.2.0+ rejects a
+        # non-matching service, and callers pass a version-matched singleton that is
+        # redundant when the URL already targets that one daemon.
+        if service is not None and self.send_service:
             body["service"] = service
 
         if arguments is not None:
@@ -121,6 +134,7 @@ class KeaClient:
         new._session.verify = self._session.verify
         new._session.cert = self._session.cert
         new.persist_config = self.persist_config
+        new.send_service = self.send_service
         return new
 
     def close(self) -> None:

--- a/netbox_kea/models.py
+++ b/netbox_kea/models.py
@@ -203,6 +203,15 @@ class Server(JobsMixin, NetBoxModel):
     def get_client(self, version: Literal[4, 6] | None = None) -> KeaClient:
         """Return a configured KeaClient, targeting the protocol-specific URL and credentials when available.
 
+        The ``service`` command argument is sent only when this server is fronted by
+        a Control Agent (``has_control_agent``), which routes commands to daemons by
+        service. When connecting directly to a DHCP daemon (``has_control_agent`` is
+        False) ``service`` is dropped, because Kea 3.2.0+ rejects a ``service`` that
+        does not match the daemon the request lands on. ``has_control_agent`` is the
+        single source of truth here: a protocol-specific ``dhcp{4,6}_url`` may itself
+        point at a per-protocol Control Agent (Kea < 3.0) or a bare daemon socket
+        (Kea 3.0+), so the routing decision follows the flag, not the URL.
+
         Args:
             version: DHCP protocol version (4 or 6). When provided and a protocol-specific
                 URL is configured, that URL and its corresponding per-protocol credentials
@@ -232,6 +241,7 @@ class Server(JobsMixin, NetBoxModel):
             client_key=self.client_key_path or None,
             timeout=_get_kea_timeout(),
             persist_config=self.persist_config,
+            send_service=self.has_control_agent,
         )
 
     def clean(self) -> None:

--- a/netbox_kea/tests/test_kea_client.py
+++ b/netbox_kea/tests/test_kea_client.py
@@ -114,6 +114,11 @@ class TestKeaClientInit(TestCase):
         cloned = client.clone()
         self.assertEqual(cloned._session.cert, client._session.cert)
 
+    def test_clone_preserves_send_service(self):
+        """clone() carries send_service so a cloned worker-thread client stays direct."""
+        self.assertFalse(KeaClient(url="http://kea:8000", send_service=False).clone().send_service)
+        self.assertTrue(KeaClient(url="http://kea:8000").clone().send_service)
+
     """Tests for KeaClient.command()."""
 
     def setUp(self):
@@ -144,6 +149,15 @@ class TestKeaClientInit(TestCase):
         resp = [{"result": 0, "text": "ok"}]
         with patch.object(self.client._session, "post", return_value=_mock_http_response(resp)) as mock_post:
             self.client.command("list-commands")
+        sent_json = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        self.assertNotIn("service", sent_json)
+
+    def test_command_omits_service_when_send_service_false(self):
+        """A direct-daemon client (send_service=False) drops a supplied service from the body."""
+        client = KeaClient(url="http://kea-daemon:8000", send_service=False)
+        resp = [{"result": 0, "text": "ok"}]
+        with patch.object(client._session, "post", return_value=_mock_http_response(resp)) as mock_post:
+            client.command("lease4-get", service=["dhcp4"])
         sent_json = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
         self.assertNotIn("service", sent_json)
 

--- a/netbox_kea/tests/test_models.py
+++ b/netbox_kea/tests/test_models.py
@@ -239,6 +239,54 @@ class TestServerGetClient(SimpleTestCase):
         self.assertEqual(client._session.auth.password, "v6-pass")
 
 
+@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
+class TestGetClientSendService(SimpleTestCase):
+    """get_client() decides whether ``service`` is sent, and command() honours it end-to-end.
+
+    ``has_control_agent`` is the single source of truth: a Control Agent routes by
+    ``service`` (send it); a direct DHCP-daemon connection must omit it (Kea 3.2.0+
+    rejects a mismatched service). This holds regardless of *which* URL is used —
+    a protocol-specific ``dhcp{4,6}_url`` may itself point at a per-protocol Control
+    Agent (Kea < 3.0) or a bare daemon socket (Kea 3.0+).
+    """
+
+    def _sent_body(self, client, cmd="lease4-get"):
+        """Issue *cmd* through the real client against the HTTP-boundary stub; return the sent body."""
+        with stub_kea({cmd: {"result": 0, "arguments": {}}}) as kea:
+            client.command(cmd, service=["dhcp4"])
+        return kea.bodies(cmd)[0]
+
+    def test_control_agent_sends_service(self):
+        # ca_url + has_control_agent → CA endpoint → service is included.
+        client = _make_server(ca_url="https://kea.example.com", has_control_agent=True).get_client(version=4)
+        self.assertTrue(client.send_service)
+        self.assertEqual(self._sent_body(client)["service"], ["dhcp4"])
+
+    def test_direct_daemon_omits_service(self):
+        # ca_url points straight at a daemon (no Control Agent) → service dropped.
+        client = _make_server(ca_url="https://kea-daemon.example.com", has_control_agent=False).get_client(version=4)
+        self.assertFalse(client.send_service)
+        self.assertNotIn("service", self._sent_body(client))
+
+    def test_protocol_url_control_agent_still_routes_by_service(self):
+        # A protocol-specific URL pointing at a per-protocol Control Agent (Kea < 3.0)
+        # must KEEP service so the CA can route to the daemon (regression for the case
+        # where every dhcp{4,6}_url was wrongly treated as a bare daemon).
+        client = _make_server(dhcp4_url="https://kea-v4-ca.example.com", has_control_agent=True).get_client(version=4)
+        self.assertTrue(client.send_service)
+        self.assertEqual(self._sent_body(client)["service"], ["dhcp4"])
+
+    def test_protocol_url_direct_daemon_omits_service(self):
+        # A protocol-specific bare daemon socket (Kea 3.0+, no Control Agent) → service dropped.
+        client = _make_server(dhcp6_url="https://kea-v6.example.com", has_control_agent=False).get_client(version=6)
+        self.assertFalse(client.send_service)
+
+    def test_clone_preserves_send_service(self):
+        # Worker threads clone(); the flag must survive so a cloned direct client stays direct.
+        client = _make_server(has_control_agent=False).get_client(version=4)
+        self.assertFalse(client.clone().send_service)
+
+
 class TestServerCleanFieldValidation(SimpleTestCase):
     """Tests for Server.clean() — field-level validation that runs before connectivity checks."""
 


### PR DESCRIPTION
## What & why

Kea 3.2.0+ **rejects** a `service` argument that does not match the daemon a request lands on (Kea 3.0.x silently ignored it), and ISC recommends omitting `service` entirely for direct daemon connections. Today `KeaClient.command()` always sends the `service` a caller passes, so in direct-daemon mode a version-matched (or fallback-mismatched) `service` will break under 3.2.0.

This is **PR C** of the A → C → B sequence (A: de-mock the view tests #97, merged; C: this; B: bump CI to Kea 3.2.0). It lands before the 3.2.0 bump so the harness change in B is safe.

## Change

- `KeaClient` gains a `send_service: bool = True` flag. `command()` includes `service` only when the flag is set; `clone()` propagates it to worker-thread clients.
- `Server.get_client()` sets the flag from **`has_control_agent`** — the documented single source of truth for *Control Agent vs direct daemon*:
  - Control Agent → routes by `service` → **send** it.
  - Direct daemon → **omit** it.

  This holds regardless of which URL is used, because a protocol-specific `dhcp{4,6}_url` may itself front a per-protocol Control Agent (Kea < 3.0) or a bare daemon socket (Kea 3.0+) — the routing decision follows the flag, not the URL.
- **No call-site changes**: callers still pass a version-matched `service`; `command()` decides whether to send it. Response handling (`resp[0]`) is unchanged.

## Tests

- `TestGetClientSendService` (`test_models.py`) drives **real** `Server.get_client()` → **real** `command()` through the HTTP-boundary stub and asserts the actual request body:
  - Control Agent (`ca_url` **and** a per-protocol `dhcp4_url`) → `service` present.
  - Direct daemon (`has_control_agent=False`, any URL) → `service` absent.
  - `clone()` preserves the flag.
- `test_kea_client.py` covers `command()` / `clone()` directly.
- Red-green verified (forcing `command()` to always send `service` turns the omit tests red).

Full suite: **2294 passed**. Adversarially reviewed with codex (gpt-5.6-sol, xhigh).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved compatibility when connecting directly to DHCP daemons by omitting unnecessary service information from requests.
  * Service routing is now automatically handled based on the configured connection type.
  * Cloned client connections preserve the same service-routing behavior.

* **Bug Fixes**
  * Prevented request rejections caused by mismatched service information when using direct daemon or protocol-specific connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->