### PR TITLE
ci: bump the Kea test harness to 3.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The plugin degrades gracefully when optional hooks are absent — tabs for unava
 |---|---|---|
 | 1.x | 4.3 – 4.6 | 3.0+ recommended (2.4+ via Control Agent) |
 
-On Kea 3.0+ the plugin talks directly to each DHCP daemon's HTTP control socket; on Kea < 3.0 it connects through the (now-deprecated) Control Agent. CI tests against **Kea 3.0.3** using the `memfile` lease database.
+On Kea 3.0+ the plugin talks directly to each DHCP daemon's HTTP control socket; on Kea < 3.0 it connects through the (now-deprecated) Control Agent. CI tests against **Kea 3.2.0** using the `memfile` lease database.
 
 ---
 

--- a/netbox_kea/tests/test_views_server.py
+++ b/netbox_kea/tests/test_views_server.py
@@ -45,7 +45,7 @@ from .utils import _PLUGINS_CONFIG, User, _make_db_server, _ViewTestBase
 # test needs CA-vs-service-specific responses it registers a callable
 # ``(body) -> payload`` that branches on ``body.get("service")``.
 
-_VERSION_OK = {"result": 0, "arguments": {"extended": "3.0.3"}}
+_VERSION_OK = {"result": 0, "arguments": {"extended": "3.2.0"}}
 
 
 def _ok_status(**args):

--- a/netbox_kea/tests/utils.py
+++ b/netbox_kea/tests/utils.py
@@ -47,7 +47,7 @@ def _kea_command_side_effect(cmd, service=None, arguments=None, check=None):
     if cmd == "status-get":
         return [{"result": 0, "arguments": {"pid": 1234, "uptime": 3600, "reload": 0}}]
     if cmd == "version-get":
-        return [{"result": 0, "arguments": {"extended": "3.0.3"}}]
+        return [{"result": 0, "arguments": {"extended": "3.2.0"}}]
     if cmd == "config-get":
         # Return minimal Dhcp4/Dhcp6 config so subnet views can parse it.
         if service and service[0] == "dhcp6":

--- a/tests/docker/docker-compose.override.yml
+++ b/tests/docker/docker-compose.override.yml
@@ -2,10 +2,13 @@
 # Kea 3.0 removed the Control Agent: each DHCP daemon exposes its own HTTP control
 # socket, so the plugin connects to kea-dhcp4 and kea-dhcp6 directly (dual-URL).
 # Images are ISC's official open-source builds (docker.cloudsmith.io/isc/docker).
+# -X: Kea 3.2.0 refuses to start with an unsecured HTTP control socket; -X downgrades
+# that policy check to a warning. The sockets are loopback-bound and nginx terminates
+# TLS/basic-auth in front, so an unauthenticated daemon socket is acceptable here.
 services:
   kea-dhcp4: &kea
-    image: docker.cloudsmith.io/isc/docker/kea-dhcp4:3.0.3
-    command: kea-dhcp4 -c /etc/kea/kea-dhcp4.conf
+    image: docker.cloudsmith.io/isc/docker/kea-dhcp4:3.2.0
+    command: kea-dhcp4 -X -c /etc/kea/kea-dhcp4.conf
     volumes:
       - ./kea_configs/:/etc/kea/:ro
     # Host-exposed for the test-side KeaClient (netbox->kea uses the service name).
@@ -14,8 +17,8 @@ services:
       - 127.0.0.1:8001:8000
   kea-dhcp6:
     <<: *kea
-    image: docker.cloudsmith.io/isc/docker/kea-dhcp6:3.0.3
-    command: kea-dhcp6 -c /etc/kea/kea-dhcp6.conf
+    image: docker.cloudsmith.io/isc/docker/kea-dhcp6:3.2.0
+    command: kea-dhcp6 -X -c /etc/kea/kea-dhcp6.conf
     ports:
       - 127.0.0.1:8003:8000
   nginx:


### PR DESCRIPTION
Bumps the integration-test harness from Kea 3.0.3 to 3.2.0. This is the last step of the A→C→B sequence: it depends on the plugin already omitting a `service` argument when it connects directly to a DHCP daemon (merged in #99), because 3.2.0 is the first release that **rejects** a `service` that does not match the directly-connected daemon (3.0.x silently ignored it).

## Changes
- **`tests/docker/docker-compose.override.yml`** — kea-dhcp4 / kea-dhcp6 images `3.0.3 → 3.2.0`. Both daemons now start with **`-X`**: 3.2.0 refuses to start with an unsecured HTTP control socket, and `-X` downgrades that policy check to a warning. The sockets are loopback-bound and nginx terminates TLS/basic-auth in front, so an unauthenticated daemon socket is acceptable in the harness.
- **`netbox_kea/tests/utils.py`, `netbox_kea/tests/test_views_server.py`** — `version-get` stubs report `3.2.0`.
- **`README.md`** — CI-version line `3.0.3 → 3.2.0`.

## Verified against a live 3.2.0 daemon
Smoke-tested the harness config against real `kea-dhcp4:3.2.0` / `kea-dhcp6:3.2.0` images:

| Request to a direct daemon control socket | 3.2.0 result |
|---|---|
| no `service` (plugin, direct mode) | accepted |
| `service:["dhcp4"]` matching (test-side dual-endpoint client) | accepted |
| `service:["dhcp6"]` mismatch | rejected — `unsupported service 'dhcp6', expected 'dhcp4'` |

The mismatch rejection is the 3.2.0 behavior change that the omit-`service` fix was built for. The test-side `_DualEndpointKeaClient` routes each service to its own daemon socket and sends a matching single-element `service`, so it needs no changes.

## Tests
- Full `netbox_kea/tests/` suite: 2294 passed, 2 subtests passed.
- ruff check + format + pre-commit hooks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated compatibility documentation to reference Kea 3.2.0.

- **Tests**
  - Updated test coverage and mocked responses for Kea 3.2.0.
  - Updated test environments to use Kea 3.2.0 for DHCPv4 and DHCPv6.
  - Improved test setup compatibility with authenticated control socket requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->