### PR TITLE
test(ui): make configure_table wait for column moves to land

### DIFF
--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -550,16 +550,32 @@ def _version_ge_43(page: Page) -> bool:
 def configure_table(page: Page, *selected_coumns: str) -> None:
     page.get_by_role("button", name=re.compile("Configure Table")).click()
 
-    # Clear all selected columns
-    remove_button = page.get_by_text("Remove")
+    # Clear all selected columns, then confirm the list actually emptied before
+    # adding (a raced Remove would otherwise leave a stale column behind).
+    remove_button = page.get_by_text("Remove", exact=True)
     selected_count = page.locator("#id_columns > option").count()
-    for i in range(selected_count):
+    for _ in range(selected_count):
         page.locator("#id_columns > option").first.click()
         remove_button.click()
+    expect(page.locator("#id_columns > option")).to_have_count(0)
 
+    # Add the requested columns. Clicking the <option> and then "Add" can race on a
+    # slow runner — the Add fires before the option selection registers, silently
+    # dropping the column (seen only on the slower v4.3 CI leg, where the header then
+    # read ["Subnet", ""] instead of ["Subnet", "Shared Network", ""]). Retry the
+    # select+Add until the column actually lands in the selected list.
+    add_button = page.get_by_text("Add", exact=True)
     for sc in selected_coumns:
-        page.locator(f'#id_available_columns > option[value="{sc}"]').click()
-        page.get_by_text("Add", exact=True).click()
+        landed = page.locator(f'#id_columns > option[value="{sc}"]')
+        for attempt in range(3):
+            page.locator(f'#id_available_columns > option[value="{sc}"]').click()
+            add_button.click()
+            try:
+                expect(landed).to_have_count(1, timeout=3000)
+                break
+            except AssertionError:
+                if attempt == 2:
+                    raise
 
     # Submit the column selection. NetBox <=4.5 labelled this button "Save"; 4.6 reworked the
     # table-config modal and renamed it "Apply" (id=apply_tableconfig). Both reload to


### PR DESCRIPTION
## Symptom
`test_dhcp_subnets_configure_table[chromium-4]` failed on the **v4.3** matrix leg only ([run 30106716792](https://github.com/marcinpsk/netbox-kea/actions/runs/30106716792)); v4.6, snapshot, and unit-test passed:

```
expect(header).to_have_text(["Subnet", "Shared Network", ""])   # timed out (5s)
```

## Root cause (from the uploaded Playwright trace)
The DOM snapshot at the failing assertion shows the header was still **`["Subnet", ""]`** — the second `configure_table()` call never added the `shared_network` column (the column *does* exist on v4.3).

The table-config modal is a `<select multiple>` with Add/Remove buttons. `configure_table()` clicked the `<option>` and immediately clicked **"Add" without waiting for the move to land**. On the slower v4.3 runner the "Add" fired before the option selection registered, so the column was silently dropped and the later `to_have_text` timed out. This is a Playwright interaction race, not a v4.3 incompatibility or a non-deterministic test.

## Fix (test helper only — no app code)
- **Add**: retry select-`<option>` + "Add" until the column actually lands in `#id_columns` (`expect(...).to_have_count(1)`, up to 3 attempts).
- **Remove**: assert `#id_columns` emptied (`to_have_count(0)`) before adding, so a raced Remove can't leave a stale column behind.

## Verification
This is a Playwright integration test that needs the full docker stack + NetBox v4.3, so CI is the verification path — the matrix (incl. the previously-failing v4.3 leg) exercises the hardened helper on this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved UI test reliability by adding verification and retries when removing and adding table columns.
  * Tests now confirm that column selections are applied successfully before continuing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->