### PR TITLE
Render and manage reservations that reserve no address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,6 +163,9 @@ cython_debug/
 
 tests/files/certs
 tests/docker/certs/
+tests/docker/kea_schema/
+tests/docker/*.whl
+test-results/
 .claude/
 core
 core.*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -305,7 +305,9 @@ resort, reserved for true external boundaries you cannot run locally.
 
 - **Commit messages**: Conventional Commits (feat, fix, docs, style, refactor, perf,
   test, build, ci, chore, revert) — enforced by a pre-commit hook.
-- **REUSE/SPDX**: every file needs licensing. Source files carry inline SPDX headers;
-  docs and generated files are annotated in `REUSE.toml`. `uv run reuse lint` must pass.
+- **REUSE/SPDX**: every file needs licensing; `uv run reuse lint` must pass. New source
+  files carry inline SPDX headers. Upstream-inherited trees (`netbox_kea/**`, `tests/**`)
+  and docs/config are bulk-annotated in `REUSE.toml` — a file covered there needs no
+  inline header, so don't flag e.g. `tests/*.py` for a missing one.
 - **Ruff**: line length 120, max complexity 15, migrations excluded, E501 ignored,
   docstrings required except in tests/migrations/`__init__.py`.

--- a/README.md
+++ b/README.md
@@ -34,8 +34,17 @@ NetBox plugin for the [Kea DHCP](https://www.isc.org/kea/) server. Manage your D
 **Host Reservations**
 - Full CRUD for DHCPv4 and DHCPv6 reservations via [`host_cmds`](https://kea.readthedocs.io/en/latest/arm/hooks.html#host-cmds) hook
 - Identifier types: hw-address (v4), DUID (v6), client-id, flex-id, circuit-id, remote-id
+- Reservations that reserve no address — an identifier-only host (hostname, options or
+  client classes only) and a DHCPv6 host that only delegates prefixes. Both are listed,
+  created, edited and deleted by client identifier instead of by IP, and the IPAM sync
+  reports them as *skipped*: there is no address to record in NetBox. Their **Lease**
+  column matches the client identifier against the leases of the reservation's own
+  subnet, there being no reserved address to match on
 - Per-reservation DHCP options
 - Journal entries on add/edit/delete
+- Bulk CSV import: columns are matched by header name in any order. Each row needs
+  `subnet-id` and exactly one identifier column; the address is optional, and DHCPv6
+  rows may carry a semicolon-separated `prefixes` column
 
 **Subnet Management**
 - Add, edit and delete subnets (requires [`subnet_cmds`](https://kea.readthedocs.io/en/latest/arm/hooks.html#subnet-cmds) or `config-set`)
@@ -241,6 +250,18 @@ The `Kea IPAM Sync` job runs automatically when `rqworker` is active:
 4. Cleans up stale IPs (configurable via `stale_ip_cleanup`)
 5. One server failing does not block others
 6. Summary logged per server and in total
+
+Each server's summary reports `synced`, `skipped`, `errors` and `conflicts`:
+
+- **skipped** — rows the sync deliberately did not write, chiefly reservations that
+  reserve no address. They are not errors and do not fail the job.
+- **errors** — rows that failed to sync. Any error fails the job; the per-row reason is
+  logged at warning level with the server, IP version, subnet id and identifier *type*
+  (never the identifier value, which can carry operator data).
+- **conflicts** — addresses already held in NetBox by something other than this Kea
+  server, deduplicated per server across the lease and reservation phases. Up to 20 of
+  them are named in the summary and the log, so the addresses to look at are visible
+  without trawling debug output.
 
 View job history, next scheduled time and logs under **System → Background Jobs → Kea IPAM Sync**.
 

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ The `Kea IPAM Sync` job runs automatically when `rqworker` is active:
 5. One server failing does not block others
 6. Summary logged per server and in total
 
-Each server's summary reports `synced`, `skipped`, `errors` and `conflicts`:
+Each server's summary reports `created`, `updated`, `errors`, `prefix_errors`, `conflicts` and `skipped`:
 
 - **skipped** — rows the sync deliberately did not write, chiefly reservations that
   reserve no address. They are not errors and do not fail the job.

--- a/netbox_kea/constants.py
+++ b/netbox_kea/constants.py
@@ -15,6 +15,46 @@ DUID_MIN_OCTETS = 1
 CLIENT_ID_MAX_OCTETS = DUID_MAX_OCTETS
 CLIENT_ID_MIN_OCTETS = 2
 
+# ---------------------------------------------------------------------------
+# Host-reservation client identifiers.
+# ---------------------------------------------------------------------------
+# One authoritative answer to "which identifier types may a reservation use",
+# shared by the forms, the CSV importer and the by-identifier URLs so a value one
+# of them accepts cannot be rejected by another. Preference order: the first key
+# a host actually carries is the one the UI addresses it by.
+RESERVATION_IDENTIFIER_TYPES: dict[int, tuple[str, ...]] = {
+    4: ("hw-address", "client-id", "circuit-id", "flex-id", "remote-id"),
+    6: ("duid", "hw-address", "client-id", "flex-id", "remote-id"),
+}
+
+RESERVATION_IDENTIFIER_LABELS: dict[str, str] = {
+    "hw-address": "Hardware Address",
+    "duid": "DUID",
+    "client-id": "Client ID",
+    "circuit-id": "Circuit ID",
+    "flex-id": "Flex ID",
+    "remote-id": "Remote ID",
+}
+
+# Kea sets no length limit on the opaque identifiers (circuit-id, flex-id,
+# remote-id). This only stops an absurd value reaching the Kea API.
+MAX_IDENTIFIER_LENGTH = 255
+
+# duid and client-id are bounded by their octet count, not by a character count: a
+# 128-octet DUID is 383 characters colon-delimited, so the 255 cap above rejected
+# valid values. Three characters per octet is the delimited worst case; is_hex_string()
+# does the real check. hw-address needs no entry — 6 octets is 17 characters.
+MAX_HEX_IDENTIFIER_LENGTH = 3 * DUID_MAX_OCTETS
+_HEX_IDENTIFIER_TYPES = frozenset({"duid", "client-id"})
+
+
+def max_identifier_length(identifier_type: str) -> int:
+    """Return the character cap that applies to *identifier_type*."""
+    if identifier_type in _HEX_IDENTIFIER_TYPES:
+        return MAX_HEX_IDENTIFIER_LENGTH
+    return MAX_IDENTIFIER_LENGTH
+
+
 # Kea lease state codes and human-readable labels.
 # https://kea.readthedocs.io/en/latest/arm/lease-db.html#lease-states
 LEASE_STATE_LABELS: dict[int, str] = {

--- a/netbox_kea/forms.py
+++ b/netbox_kea/forms.py
@@ -10,7 +10,7 @@ from utilities.forms.rendering import FieldSet
 
 from . import constants
 from .models import Server
-from .utilities import is_hex_string
+from .utilities import is_hex_string, parse_delegated_prefixes, validate_reservation_identifier
 
 
 def _validate_ip(value: str, version: int) -> str:
@@ -383,21 +383,17 @@ class Lease4DeleteForm(BaseLeaseDeleteForm):
 # Phase 2: Reservation Management forms
 # ─────────────────────────────────────────────────────────────────────────────
 
-_IDENTIFIER_TYPE_CHOICES_V4 = [
-    ("hw-address", "Hardware Address"),
-    ("client-id", "Client ID"),
-    ("circuit-id", "Circuit ID"),
-    ("flex-id", "Flex ID"),
-    ("remote-id", "Remote ID"),
-]
 
-_IDENTIFIER_TYPE_CHOICES_V6 = [
-    ("duid", "DUID"),
-    ("hw-address", "Hardware Address"),
-    ("client-id", "Client ID"),
-    ("flex-id", "Flex ID"),
-    ("remote-id", "Remote ID"),
-]
+def _identifier_type_choices(version: int) -> list[tuple[str, str]]:
+    """Offer exactly the identifier types the CSV importer and the URLs accept."""
+    return [
+        (name, constants.RESERVATION_IDENTIFIER_LABELS[name])
+        for name in constants.RESERVATION_IDENTIFIER_TYPES[version]
+    ]
+
+
+_IDENTIFIER_TYPE_CHOICES_V4 = _identifier_type_choices(4)
+_IDENTIFIER_TYPE_CHOICES_V6 = _identifier_type_choices(6)
 
 
 class Reservation4Form(forms.Form):
@@ -410,7 +406,11 @@ class Reservation4Form(forms.Form):
     )
     ip_address = forms.CharField(
         label="IP Address",
-        help_text="Fixed IPv4 address to assign to this reservation.",
+        required=False,
+        help_text=(
+            "Fixed IPv4 address to assign to this reservation. Leave blank to reserve"
+            " only a hostname, options or client classes for this client."
+        ),
     )
     identifier_type = forms.ChoiceField(
         label="Identifier Type",
@@ -433,28 +433,24 @@ class Reservation4Form(forms.Form):
     )
 
     def clean_ip_address(self) -> str:
-        """Validate that the value is a valid IPv4 address."""
-        return _validate_ip(self.cleaned_data["ip_address"], version=4)
+        """Validate the value is a valid IPv4 address, or blank for no fixed address."""
+        value = (self.cleaned_data.get("ip_address") or "").strip()
+        if not value:
+            return ""
+        return _validate_ip(value, version=4)
 
     def clean(self) -> dict[str, Any] | None:
         """Cross-validate identifier value against identifier_type."""
         cleaned = super().clean()
         if not cleaned:
             return cleaned
-        id_type = cleaned.get("identifier_type")
         identifier = cleaned.get("identifier", "").strip()
         if not identifier:
             return cleaned
-        if id_type == "hw-address":
-            try:
-                EUI(identifier, version=48)
-            except (AddrFormatError, ValueError):
-                self.add_error("identifier", "Enter a valid hardware address (e.g. aa:bb:cc:dd:ee:ff).")
-        elif id_type == "client-id":
-            if not is_hex_string(identifier, constants.CLIENT_ID_MIN_OCTETS, constants.CLIENT_ID_MAX_OCTETS):
-                self.add_error(
-                    "identifier", "Enter a valid client-id as colon-separated hex octets (e.g. 01:aa:bb:cc:dd:ee:ff)."
-                )
+        try:
+            validate_reservation_identifier(cleaned.get("identifier_type", ""), identifier)
+        except ValueError as exc:
+            self.add_error("identifier", str(exc))
         return cleaned
 
 
@@ -468,7 +464,16 @@ class Reservation6Form(forms.Form):
     )
     ip_addresses = forms.CharField(
         label="IPv6 Addresses",
-        help_text="Comma-separated list of IPv6 addresses to assign.",
+        required=False,
+        help_text="Comma-separated list of IPv6 addresses to assign. Leave blank to reserve none.",
+    )
+    prefixes = forms.CharField(
+        label="Delegated Prefixes",
+        required=False,
+        help_text=(
+            "Comma-separated IPv6 prefixes to delegate (e.g. <code>2001:db8:1::/64</code>)."
+            " Leave blank to remove any that are set."
+        ),
     )
     identifier_type = forms.ChoiceField(
         label="Identifier Type",
@@ -491,8 +496,8 @@ class Reservation6Form(forms.Form):
     )
 
     def clean_ip_addresses(self) -> str:
-        """Validate that all values are valid IPv6 addresses."""
-        val = self.cleaned_data["ip_addresses"]
+        """Validate every entry is a valid IPv6 address; blank reserves no address."""
+        val = self.cleaned_data.get("ip_addresses") or ""
         cleaned: list[str] = []
         for raw in val.split(","):
             raw = raw.strip()
@@ -505,32 +510,28 @@ class Reservation6Form(forms.Form):
             if addr.version != 6:
                 raise ValidationError(f"'{raw}' is not a valid IPv6 address.")
             cleaned.append(str(addr))
-        if not cleaned:
-            raise ValidationError("Enter at least one valid IPv6 address.")
         return ",".join(cleaned)
+
+    def clean_prefixes(self) -> str:
+        """Validate the delegated-prefix list with the validator the CSV importer uses."""
+        try:
+            prefixes = parse_delegated_prefixes(self.cleaned_data.get("prefixes") or "")
+        except ValueError as exc:
+            raise ValidationError(str(exc)) from exc
+        return ",".join(prefixes)
 
     def clean(self) -> dict[str, Any] | None:
         """Cross-validate identifier value against identifier_type."""
         cleaned = super().clean()
         if not cleaned:
             return cleaned
-        id_type = cleaned.get("identifier_type")
         identifier = cleaned.get("identifier", "").strip()
         if not identifier:
             return cleaned
-        if id_type == "duid":
-            if not is_hex_string(identifier, constants.DUID_MIN_OCTETS, constants.DUID_MAX_OCTETS):
-                self.add_error("identifier", "Enter a valid DUID as colon-separated hex octets.")
-        elif id_type == "hw-address":
-            try:
-                EUI(identifier, version=48)
-            except (AddrFormatError, ValueError):
-                self.add_error("identifier", "Enter a valid hardware address (e.g. aa:bb:cc:dd:ee:ff).")
-        elif id_type == "client-id":
-            if not is_hex_string(identifier, constants.CLIENT_ID_MIN_OCTETS, constants.CLIENT_ID_MAX_OCTETS):
-                self.add_error(
-                    "identifier", "Enter a valid client-id as colon-separated hex octets (e.g. 01:aa:bb:cc:dd:ee:ff)."
-                )
+        try:
+            validate_reservation_identifier(cleaned.get("identifier_type", ""), identifier)
+        except ValueError as exc:
+            self.add_error("identifier", str(exc))
         return cleaned
 
 
@@ -954,15 +955,21 @@ class _BaseBulkReservationImportForm(forms.Form):
 class Reservation4BulkImportForm(_BaseBulkReservationImportForm):
     """Bulk import form for DHCPv4 reservations.
 
-    Expected columns: ``ip-address``, ``hw-address``, ``hostname`` (optional), ``subnet-id``.
+    Required columns: ``subnet-id`` plus exactly one of ``hw-address``,
+    ``client-id``, ``circuit-id``, ``flex-id``, ``remote-id``.
+    Optional: ``ip-address``, ``hostname``.  See
+    :py:func:`~netbox_kea.utilities.parse_reservation_csv`.
     """
 
 
 class Reservation6BulkImportForm(_BaseBulkReservationImportForm):
     """Bulk import form for DHCPv6 reservations.
 
-    Expected columns: ``ip-addresses``, ``duid``, ``hostname`` (optional), ``subnet-id``.
-    Separate multiple IPv6 addresses per host with a semicolon inside the ``ip-addresses`` cell.
+    Required columns: ``subnet-id`` plus exactly one of ``duid``, ``hw-address``,
+    ``client-id``, ``flex-id``, ``remote-id``.
+    Optional: ``ip-addresses``, ``prefixes``, ``hostname`` — both address and prefix
+    cells take several semicolon-separated values.  See
+    :py:func:`~netbox_kea.utilities.parse_reservation_csv`.
     """
 
 

--- a/netbox_kea/jobs.py
+++ b/netbox_kea/jobs.py
@@ -28,6 +28,7 @@ Configuration knobs (all under ``PLUGINS_CONFIG["netbox_kea"]``):
 
 from __future__ import annotations
 
+import ipaddress
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -112,6 +113,39 @@ def _prefetch_reservation_ips(server: Server, version: int) -> frozenset[str] | 
     return frozenset(ips)
 
 
+#: Identifier keys a Kea host reservation may carry, in the order they are reported.
+_IDENTIFIER_KEYS = ("hw-address", "duid", "client-id", "circuit-id", "flex-id", "remote-id")
+
+#: How many per-row reservation sync failures to log in full per server/version
+#: before suppressing the rest.  The error count in the summary stays exact.
+_ROW_ERROR_LOG_LIMIT = 10
+
+#: How many conflicting IPs to name in the job summary and log line.  A bare count
+#: tells an operator nothing about which manually-curated IPs the sync left alone.
+_CONFLICT_SAMPLE_SIZE = 20
+
+
+def _identifier_type(reservation: dict) -> str:
+    """Return which identifier key *reservation* carries, for log lines.
+
+    Only the key name is returned — a ``flex-id`` value can hold operator-defined
+    client data and does not belong in the job log.
+    """
+    return next((key for key in _IDENTIFIER_KEYS if reservation.get(key)), "none")
+
+
+def _canonical_ip(ip_str: str) -> str:
+    """Return the canonical text form of *ip_str*, or the input when unparseable.
+
+    Conflict counts are deduplicated on this, so two spellings of the same IPv6
+    address (``2001:db8::1`` and ``2001:0db8::0001``) collapse to one entry.
+    """
+    try:
+        return str(ipaddress.ip_address(ip_str))
+    except ValueError:
+        return ip_str
+
+
 def _sync_server_leases(
     server: Server,
     version: int,
@@ -121,6 +155,7 @@ def _sync_server_leases(
     all_synced: list[dict],
     reservation_ips: frozenset[str] | None = None,
     subnet_prefix_map: dict[int, int] | None = None,
+    conflict_ips: set[str] | None = None,
 ) -> tuple[bool, frozenset[str]]:
     """Fetch all leases from *server* for *version* and upsert into NetBox IPAM.
 
@@ -183,7 +218,13 @@ def _sync_server_leases(
             stats["errors"] += 1
             had_errors = True
 
-    stats["conflicts"] = stats.get("conflicts", 0) + len(conflicts)
+    # Deduplicated across phases and versions by the caller's set; the accumulator
+    # itself stays a list because sync_lease_to_netbox appends to it.
+    if conflict_ips is not None:
+        conflict_ips.update(_canonical_ip(ip) for ip in conflicts)
+        stats["conflicts"] = len(conflict_ips)
+    else:
+        stats["conflicts"] = stats.get("conflicts", 0) + len(conflicts)
     return not truncated and not had_errors, frozenset(lease_ips)
 
 
@@ -195,8 +236,14 @@ def _sync_server_reservations(
     all_synced: list[dict],
     lease_ips: frozenset[str] | None = None,
     subnet_prefix_map: dict[int, int] | None = None,
+    conflict_ips: set[str] | None = None,
 ) -> bool:
     """Fetch all reservations from *server* for *version* and upsert into NetBox IPAM.
+
+    Reservations that reserve no address — an identifier-only DHCPv4 host, or a
+    DHCPv6 host that only delegates prefixes — are counted in ``stats["skipped"]``
+    and left out of *all_synced*.  They are legal Kea configuration with nothing to
+    write to IPAM, so treating them as errors failed the whole job (issue #110).
 
     Returns ``True`` when all reservation pages were fetched successfully,
     ``False`` when the sync was skipped (e.g. host_cmds not loaded) or failed.
@@ -208,6 +255,8 @@ def _sync_server_reservations(
 
     service = f"dhcp{version}"
     processed = 0
+    skipped = 0
+    row_errors_logged = 0
     had_errors = False
     # Foreign (manually-curated) NetBox IPs skipped to avoid overwriting them.
     conflicts: list[str] = []
@@ -215,6 +264,11 @@ def _sync_server_reservations(
     try:
         client = server.get_client(version=version)
         for reservation in iter_reservations(client, service):
+            # Mirrors the manual bulk-sync view, which already skips these rows.
+            if not reservation.get("ip-address") and not reservation.get("ip-addresses"):
+                skipped += 1
+                stats["skipped"] = stats.get("skipped", 0) + 1
+                continue
             try:
                 _ip, created, changed = sync_reservation_to_netbox(
                     reservation,
@@ -229,14 +283,34 @@ def _sync_server_reservations(
                     stats["created"] += 1
                 elif changed:
                     stats["updated"] += 1
-            except Exception:  # noqa: BLE001, PERF203
+            except Exception as exc:  # noqa: BLE001, PERF203
                 ip = reservation.get("ip-address") or (reservation.get("ip-addresses") or ["?"])[0] or "?"
-                logger.debug(
-                    "Failed to sync reservation %s from server %s",
-                    ip,
-                    server.name,
-                    exc_info=True,
-                )
+                # Warning, not debug: a per-row failure is the only thing standing
+                # between the operator and a job that fails with an opaque count.
+                # The identifier *type* is enough to locate the row — the value can
+                # be an operator-defined flex-id, so it is not logged.  Capped so a
+                # systematically broken source cannot flood the job log.
+                if row_errors_logged < _ROW_ERROR_LOG_LIMIT:
+                    row_errors_logged += 1
+                    logger.warning(
+                        "Failed to sync reservation %s (server %s, v%s, subnet-id %s, id-type %s): %s",
+                        ip,
+                        server.name,
+                        version,
+                        reservation.get("subnet-id", "?"),
+                        _identifier_type(reservation),
+                        type(exc).__name__,
+                    )
+                    logger.debug("Reservation sync traceback for %s", ip, exc_info=True)
+                elif row_errors_logged == _ROW_ERROR_LOG_LIMIT:
+                    row_errors_logged += 1
+                    logger.warning(
+                        "Server %s (v%s): further per-reservation sync failures suppressed"
+                        " (first %d logged); see the final error count.",
+                        server.name,
+                        version,
+                        _ROW_ERROR_LOG_LIMIT,
+                    )
                 stats["errors"] += 1
                 had_errors = True
     except KeaException as exc:
@@ -254,8 +328,25 @@ def _sync_server_reservations(
         logger.warning("Unexpected error fetching reservations from server %s (v%s): %s", server.name, version, exc)
         stats["errors"] += 1
         return False
+    finally:
+        # In a ``finally`` so a mid-pagination failure does not discard the rows
+        # already processed: the summary must not report zero conflicts for a page
+        # that was fetched and synced before page 2 failed.
+        if conflict_ips is not None:
+            conflict_ips.update(_canonical_ip(ip) for ip in conflicts)
+            # Keep the count consistent with the deduplicated set at every point,
+            # including when the caller aborts before its own bookkeeping runs.
+            stats["conflicts"] = len(conflict_ips)
+        else:
+            stats["conflicts"] = stats.get("conflicts", 0) + len(conflicts)
+        if skipped:
+            logger.info(
+                "Server %s (v%s): skipped %d reservation(s) with no address (nothing to sync to IPAM)",
+                server.name,
+                version,
+                skipped,
+            )
 
-    stats["conflicts"] = stats.get("conflicts", 0) + len(conflicts)
     logger.info("Server %s (v%s): synced %d reservations", server.name, version, processed)
     # Mirror the lease path: a per-row failure must not leave cleanup_safe=True,
     # or stale cleanup runs with an incomplete keep-set and may delete live IPs.
@@ -431,11 +522,22 @@ def _sync_one_server(
     sync_ip_ranges: bool,
     max_leases: int,
     stats: dict[str, int],
+    conflict_ips: set[str] | None = None,
 ) -> None:
-    """Sync a single server's leases, reservations, prefixes, and IP ranges."""
+    """Sync a single server's leases, reservations, prefixes, and IP ranges.
+
+    *conflict_ips* is an optional caller-owned set that collects the foreign NetBox
+    IPs this run refused to overwrite, so the caller can name them in the job
+    summary.  One set per server, shared by both phases and both IP versions: a
+    foreign IP that has *both* a lease and a reservation is one conflict for the
+    operator to resolve, not two.  Each phase still accumulates into its own list
+    because ``sync_{lease,reservation}_to_netbox`` append to it.
+    """
     from .sync import cleanup_stale_ips_batch
 
     all_synced: list[dict] = []
+    if conflict_ips is None:
+        conflict_ips = set()
     # Cleanup is only safe when both sources contributed, otherwise we risk
     # removing IPs that exist in the source we didn't sync.
     cleanup_safe = sync_leases and sync_reservations
@@ -483,6 +585,7 @@ def _sync_one_server(
                 all_synced=all_synced,
                 reservation_ips=pre_reservation_ips,
                 subnet_prefix_map=subnet_prefix_map,
+                conflict_ips=conflict_ips,
             )
             lease_phase_ok = sync_ok
             cleanup_safe &= sync_ok
@@ -497,6 +600,7 @@ def _sync_one_server(
                 all_synced=all_synced,
                 lease_ips=lease_ips_set if lease_phase_ok else None,
                 subnet_prefix_map=subnet_prefix_map,
+                conflict_ips=conflict_ips,
             )
 
         if sync_prefixes or sync_ip_ranges:
@@ -509,6 +613,20 @@ def _sync_one_server(
                 vrf=server.sync_vrf,
                 stats=stats,
             )
+
+    # Authoritative count: the per-phase increments above double-count an IP that is
+    # foreign to both a lease and a reservation, so the deduplicated set wins.
+    stats["conflicts"] = len(conflict_ips)
+    if conflict_ips:
+        sample = sorted(conflict_ips)[:_CONFLICT_SAMPLE_SIZE]
+        logger.warning(
+            "Server %s: %d NetBox IP(s) left untouched — not Kea-managed (description does not start"
+            " with 'Synced from Kea DHCP'); first %d: %s",
+            server.name,
+            len(conflict_ips),
+            len(sample),
+            ", ".join(sample),
+        )
 
     if all_synced and stats["errors"] == 0 and cleanup_safe:
         cleanup_stale_ips_batch(all_synced)
@@ -667,7 +785,14 @@ class KeaIpamSyncJob(JobRunner):
                 return
 
             self.logger.info(f"Starting Kea IPAM sync for {len(servers)} server(s).")
-            total: dict[str, int] = {"created": 0, "updated": 0, "errors": 0, "prefix_errors": 0, "conflicts": 0}
+            total: dict[str, int] = {
+                "created": 0,
+                "updated": 0,
+                "errors": 0,
+                "prefix_errors": 0,
+                "conflicts": 0,
+                "skipped": 0,
+            }
 
             for server in servers:
                 # In Run Now mode (server_pk provided), honour the explicit selection
@@ -689,7 +814,11 @@ class KeaIpamSyncJob(JobRunner):
                     "errors": 0,
                     "prefix_errors": 0,
                     "conflicts": 0,
+                    "skipped": 0,
                 }
+                # Foreign NetBox IPs this server refused to overwrite, deduplicated
+                # across the lease and reservation phases and both IP versions.
+                conflict_ips: set[str] = set()
 
                 try:
                     _sync_one_server(
@@ -700,6 +829,7 @@ class KeaIpamSyncJob(JobRunner):
                         effective_ip_ranges,
                         max_leases,
                         server_stats,
+                        conflict_ips=conflict_ips,
                     )
                 except Exception as exc:  # noqa: BLE001, PERF203
                     self.logger.error(f"Unhandled error syncing server {server.name}: {exc}", exc_info=True)
@@ -710,6 +840,7 @@ class KeaIpamSyncJob(JobRunner):
                     f" updated={server_stats['updated']} errors={server_stats['errors']}"
                     f" prefix_errors={server_stats['prefix_errors']}"
                     f" conflicts={server_stats['conflicts']}"
+                    f" skipped={server_stats['skipped']}"
                 )
                 for key in total:
                     total[key] += server_stats.get(key, 0)
@@ -723,6 +854,9 @@ class KeaIpamSyncJob(JobRunner):
                         "errors": server_stats["errors"],
                         "prefix_errors": server_stats["prefix_errors"],
                         "conflicts": server_stats["conflicts"],
+                        "conflict_sample": sorted(conflict_ips)[:_CONFLICT_SAMPLE_SIZE],
+                        "conflicts_truncated": max(0, len(conflict_ips) - _CONFLICT_SAMPLE_SIZE),
+                        "skipped": server_stats["skipped"],
                     }
                 )
 
@@ -730,7 +864,7 @@ class KeaIpamSyncJob(JobRunner):
                 f"Kea IPAM sync complete — servers={len(summary)}"
                 f" created={total['created']} updated={total['updated']}"
                 f" errors={total['errors']} prefix_errors={total['prefix_errors']}"
-                f" conflicts={total['conflicts']}"
+                f" conflicts={total['conflicts']} skipped={total['skipped']}"
             )
             if total["errors"] > 0 or total["prefix_errors"] > 0:
                 raise JobFailed()

--- a/netbox_kea/jobs.py
+++ b/netbox_kea/jobs.py
@@ -146,6 +146,20 @@ def _canonical_ip(ip_str: str) -> str:
         return ip_str
 
 
+def _record_conflicts(stats: dict[str, int], conflicts: list[str], conflict_ips: set[str] | None) -> None:
+    """Fold *conflicts* into *stats*, deduplicating through *conflict_ips* when given.
+
+    The accumulator stays a list because the sync helpers append to it; the caller's
+    set is what deduplicates across phases and versions, so the count is taken from
+    the set whenever there is one.
+    """
+    if conflict_ips is not None:
+        conflict_ips.update(_canonical_ip(ip) for ip in conflicts)
+        stats["conflicts"] = len(conflict_ips)
+    else:
+        stats["conflicts"] = stats.get("conflicts", 0) + len(conflicts)
+
+
 def _sync_server_leases(
     server: Server,
     version: int,
@@ -218,13 +232,7 @@ def _sync_server_leases(
             stats["errors"] += 1
             had_errors = True
 
-    # Deduplicated across phases and versions by the caller's set; the accumulator
-    # itself stays a list because sync_lease_to_netbox appends to it.
-    if conflict_ips is not None:
-        conflict_ips.update(_canonical_ip(ip) for ip in conflicts)
-        stats["conflicts"] = len(conflict_ips)
-    else:
-        stats["conflicts"] = stats.get("conflicts", 0) + len(conflicts)
+    _record_conflicts(stats, conflicts, conflict_ips)
     return not truncated and not had_errors, frozenset(lease_ips)
 
 
@@ -332,13 +340,7 @@ def _sync_server_reservations(
         # In a ``finally`` so a mid-pagination failure does not discard the rows
         # already processed: the summary must not report zero conflicts for a page
         # that was fetched and synced before page 2 failed.
-        if conflict_ips is not None:
-            conflict_ips.update(_canonical_ip(ip) for ip in conflicts)
-            # Keep the count consistent with the deduplicated set at every point,
-            # including when the caller aborts before its own bookkeeping runs.
-            stats["conflicts"] = len(conflict_ips)
-        else:
-            stats["conflicts"] = stats.get("conflicts", 0) + len(conflicts)
+        _record_conflicts(stats, conflicts, conflict_ips)
         if skipped:
             logger.info(
                 "Server %s (v%s): skipped %d reservation(s) with no address (nothing to sync to IPAM)",

--- a/netbox_kea/signals.py
+++ b/netbox_kea/signals.py
@@ -13,7 +13,9 @@ External consumers can connect to these signals to react to DHCP changes::
     lease_added.connect(on_lease_added)
 
 All signals are fired *after* the Kea API call succeeds, so receivers can
-safely assume the change is in effect. They are *not* fired on errors.
+safely assume the change is in effect. They are *not* fired when the call fails.
+They *are* fired when the change was applied but Kea could not write it to disk
+(``config-write`` failed) — it is live now and may not survive a restart.
 
 Signals
 -------
@@ -36,7 +38,13 @@ reservation_updated
 
 reservation_deleted
     Fired when a host reservation is deleted via the plugin UI.
-    kwargs: ``server``, ``ip_address``, ``dhcp_version``, ``request``
+    kwargs: ``server``, ``ip_address``, ``identifier_type``, ``identifier``,
+    ``dhcp_version``, ``request``
+
+    A reservation can be addressed either by its IP or, when it reserves no
+    address, by its client identifier. All three keys are sent on every delete
+    regardless of which route was used, each ``None`` where it does not apply, so
+    receivers never have to handle a route-dependent payload shape.
 """
 
 from django.dispatch import Signal

--- a/netbox_kea/tables.py
+++ b/netbox_kea/tables.py
@@ -525,11 +525,11 @@ RESERVATION_ACTIONS = """
 <span class="btn-group">
   {% if record.edit_url %}
   <a href="{{ record.edit_url }}"
-     class="btn btn-sm btn-warning" aria-label="Edit reservation {{ record.ip_address }}"><i class="mdi mdi-pencil" aria-hidden="true"></i></a>
+     class="btn btn-sm btn-warning" aria-label="Edit reservation {{ record.ip_address|default:record.identifier }}"><i class="mdi mdi-pencil" aria-hidden="true"></i></a>
   {% endif %}
   {% if record.delete_url %}
   <a href="{{ record.delete_url }}"
-     class="btn btn-sm btn-danger" aria-label="Delete reservation {{ record.ip_address }}"><i class="mdi mdi-trash-can-outline" aria-hidden="true"></i></a>
+     class="btn btn-sm btn-danger" aria-label="Delete reservation {{ record.ip_address|default:record.identifier }}"><i class="mdi mdi-trash-can-outline" aria-hidden="true"></i></a>
   {% endif %}
 </span>
 {% endif %}

--- a/netbox_kea/tables.py
+++ b/netbox_kea/tables.py
@@ -515,24 +515,22 @@ class LeaseDeleteTable(GenericTable):
 # Phase 2: Reservation tables
 # ─────────────────────────────────────────────────────────────────────────────
 
-RESERVATION_ACTIONS_V4 = """
-{% if record.can_change %}
+# Reservation edit/delete URLs are precomputed by the view
+# (``views.reservations._attach_reservation_action_urls``) rather than reversed here.
+# A reservation that reserves no address has no address-keyed URL, and ``{% url %}``
+# with an empty ``ip_address`` raised NoReverseMatch, taking the whole table down
+# (issue #110). ``can_change`` is already folded into the precomputed values.
+RESERVATION_ACTIONS = """
+{% if record.edit_url or record.delete_url %}
 <span class="btn-group">
-  <a href="{% url "plugins:netbox_kea:server_reservation4_edit" record.server_pk record.subnet_id record.ip_address %}"
+  {% if record.edit_url %}
+  <a href="{{ record.edit_url }}"
      class="btn btn-sm btn-warning" aria-label="Edit reservation {{ record.ip_address }}"><i class="mdi mdi-pencil" aria-hidden="true"></i></a>
-  <a href="{% url "plugins:netbox_kea:server_reservation4_delete" record.server_pk record.subnet_id record.ip_address %}"
+  {% endif %}
+  {% if record.delete_url %}
+  <a href="{{ record.delete_url }}"
      class="btn btn-sm btn-danger" aria-label="Delete reservation {{ record.ip_address }}"><i class="mdi mdi-trash-can-outline" aria-hidden="true"></i></a>
-</span>
-{% endif %}
-"""
-
-RESERVATION_ACTIONS_V6 = """
-{% if record.can_change %}
-<span class="btn-group">
-  <a href="{% url "plugins:netbox_kea:server_reservation6_edit" record.server_pk record.subnet_id record.ip_address %}"
-     class="btn btn-sm btn-warning" aria-label="Edit reservation {{ record.ip_address }}"><i class="mdi mdi-pencil" aria-hidden="true"></i></a>
-  <a href="{% url "plugins:netbox_kea:server_reservation6_delete" record.server_pk record.subnet_id record.ip_address %}"
-     class="btn btn-sm btn-danger" aria-label="Delete reservation {{ record.ip_address }}"><i class="mdi mdi-trash-can-outline" aria-hidden="true"></i></a>
+  {% endif %}
 </span>
 {% endif %}
 """
@@ -593,7 +591,7 @@ class ReservationTable4(GenericTable):
             "{% endif %}"
         ),
     )
-    actions = ActionsColumn(RESERVATION_ACTIONS_V4)
+    actions = ActionsColumn(RESERVATION_ACTIONS)
 
     class Meta(GenericTable.Meta):
         empty_text = "No reservations found."
@@ -633,7 +631,7 @@ class ReservationTable6(GenericTable):
             "{% endif %}"
         ),
     )
-    actions = ActionsColumn(RESERVATION_ACTIONS_V6)
+    actions = ActionsColumn(RESERVATION_ACTIONS)
 
     class Meta(GenericTable.Meta):
         empty_text = "No reservations found."

--- a/netbox_kea/tables.py
+++ b/netbox_kea/tables.py
@@ -559,12 +559,55 @@ _LEASE_STATUS_LINK_V6 = (
 )
 
 
+#: Identifier cell: the value plus the Kea key it came from.  Without the type a
+#: flex-id is indistinguishable from a hardware address.
+_IDENTIFIER_CELL = (
+    "{% if record.identifier %}"
+    '<span class="font-monospace">{{ record.identifier }}</span>'
+    '<br><span class="text-muted small">{{ record.identifier_type }}</span>'
+    "{% endif %}"
+)
+
+#: Address cell for reservations that may reserve no address at all.
+_RESERVATION_ADDRESS_CELL = (
+    "{% if record.ip_address %}"
+    "{{ record.ip_address }}"
+    "{% else %}"
+    '<span class="badge text-bg-secondary">No address</span>'
+    "{% endif %}"
+)
+
+#: DHCPv6 counterpart: the reserved addresses, or the same badge when there are none.
+_RESERVATION_ADDRESSES_CELL = (
+    "{% if value %}"
+    "{% for address in value %}{{ address }}{% if not forloop.last %}<br>{% endif %}{% endfor %}"
+    "{% else %}"
+    '<span class="badge text-bg-secondary">No address</span>'
+    "{% endif %}"
+)
+
+_RESERVATION_PREFIXES_CELL = (
+    "{% for prefix in record.prefixes %}"
+    '<span class="font-monospace">{{ prefix }}</span>{% if not forloop.last %}<br>{% endif %}'
+    "{% endfor %}"
+)
+
+
 class ReservationTable4(GenericTable):
     """Table for DHCPv4 host reservations returned from the Kea API."""
 
     subnet_id = tables.Column(verbose_name="Subnet ID", accessor="subnet-id")
     hw_address = MonospaceColumn(verbose_name="Hardware Address", accessor="hw-address")
-    ip_address = tables.Column(verbose_name="IP Address", accessor="ip-address", order_by="_ip_sort_key")
+    identifier = tables.TemplateColumn(
+        verbose_name="Identifier",
+        orderable=False,
+        template_code=_IDENTIFIER_CELL,
+    )
+    ip_address = tables.TemplateColumn(
+        verbose_name="IP Address",
+        order_by="_ip_sort_key",
+        template_code=_RESERVATION_ADDRESS_CELL,
+    )
     hostname = tables.Column(verbose_name="Hostname")
     lease_status = tables.TemplateColumn(
         verbose_name="Lease",
@@ -595,8 +638,27 @@ class ReservationTable4(GenericTable):
 
     class Meta(GenericTable.Meta):
         empty_text = "No reservations found."
-        fields = ("subnet_id", "hw_address", "ip_address", "hostname", "lease_status", "netbox_ip", "actions")
-        default_columns = ("subnet_id", "hw_address", "ip_address", "hostname", "lease_status", "netbox_ip", "actions")
+        fields = (
+            "subnet_id",
+            "hw_address",
+            "identifier",
+            "ip_address",
+            "hostname",
+            "lease_status",
+            "netbox_ip",
+            "actions",
+        )
+        # ``identifier`` replaces ``hw_address`` by default: it shows the same value
+        # for a MAC-keyed host and an actual value for every other identifier type.
+        default_columns = (
+            "subnet_id",
+            "identifier",
+            "ip_address",
+            "hostname",
+            "lease_status",
+            "netbox_ip",
+            "actions",
+        )
 
 
 class ReservationTable6(GenericTable):
@@ -604,7 +666,22 @@ class ReservationTable6(GenericTable):
 
     subnet_id = tables.Column(verbose_name="Subnet ID", accessor="subnet-id")
     duid = MonospaceColumn(verbose_name="DUID")
-    ip_addresses = tables.Column(verbose_name="IPv6 Addresses", accessor="ip-addresses")
+    identifier = tables.TemplateColumn(
+        verbose_name="Identifier",
+        orderable=False,
+        template_code=_IDENTIFIER_CELL,
+    )
+    ip_addresses = tables.TemplateColumn(
+        verbose_name="IPv6 Addresses",
+        accessor="ip-addresses",
+        order_by="_ip_sort_key",
+        template_code=_RESERVATION_ADDRESSES_CELL,
+    )
+    prefixes = tables.TemplateColumn(
+        verbose_name="Delegated Prefixes",
+        orderable=False,
+        template_code=_RESERVATION_PREFIXES_CELL,
+    )
     hostname = tables.Column(verbose_name="Hostname")
     lease_status = tables.TemplateColumn(
         verbose_name="Lease",
@@ -635,8 +712,29 @@ class ReservationTable6(GenericTable):
 
     class Meta(GenericTable.Meta):
         empty_text = "No reservations found."
-        fields = ("subnet_id", "duid", "ip_addresses", "hostname", "lease_status", "netbox_ip", "actions")
-        default_columns = ("subnet_id", "duid", "ip_addresses", "hostname", "lease_status", "netbox_ip", "actions")
+        fields = (
+            "subnet_id",
+            "duid",
+            "identifier",
+            "ip_addresses",
+            "prefixes",
+            "hostname",
+            "lease_status",
+            "netbox_ip",
+            "actions",
+        )
+        # ``identifier`` replaces ``duid`` by default for the same reason as v4, and
+        # ``prefixes`` is the only thing a prefix-delegation-only host reserves.
+        default_columns = (
+            "subnet_id",
+            "identifier",
+            "ip_addresses",
+            "prefixes",
+            "hostname",
+            "lease_status",
+            "netbox_ip",
+            "actions",
+        )
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/netbox_kea/templates/netbox_kea/server_reservation_bulk_import.html
+++ b/netbox_kea/templates/netbox_kea/server_reservation_bulk_import.html
@@ -16,18 +16,31 @@
           Lines starting with <code>#</code> are treated as comments and ignored.
         </p>
 
+        {# Columns are matched by header name, in any order. #}
         {% if dhcp_version == 4 %}
         <div class="alert alert-info" role="alert">
-          <strong>v4 column order:</strong>
-          <code>ip-address, hw-address, hostname (optional), subnet-id</code><br>
-          <small>Example: <code>192.168.1.100,aa:bb:cc:dd:ee:ff,host1.example.com,1</code></small>
+          <strong>v4 columns</strong> (matched by header name, any order):<br>
+          Required: <code>subnet-id</code> and exactly one identifier column —
+          <code>hw-address</code>, <code>client-id</code>, <code>circuit-id</code>,
+          <code>flex-id</code> or <code>remote-id</code>.<br>
+          Optional: <code>ip-address</code>, <code>hostname</code>.<br>
+          <small>Example: <code>subnet-id,hw-address,ip-address,hostname</code> →
+          <code>1,aa:bb:cc:dd:ee:ff,192.168.1.100,host1.example.com</code></small><br>
+          <small>Leave <code>ip-address</code> empty to reserve only a hostname, options or client classes.</small>
         </div>
         {% else %}
         <div class="alert alert-info" role="alert">
-          <strong>v6 column order:</strong>
-          <code>ip-addresses, duid, hostname (optional), subnet-id</code><br>
-          <small>Multiple IPv6 addresses per host: separate with semicolon inside the <code>ip-addresses</code> cell.</small><br>
-          <small>Example: <code>2001:db8::100,00:01:02:03:04:05,v6host.example.com,10</code></small>
+          <strong>v6 columns</strong> (matched by header name, any order):<br>
+          Required: <code>subnet-id</code> and exactly one identifier column —
+          <code>duid</code>, <code>hw-address</code>, <code>client-id</code>,
+          <code>flex-id</code> or <code>remote-id</code>.<br>
+          Optional: <code>ip-addresses</code>, <code>prefixes</code>, <code>hostname</code>.<br>
+          <small>Both <code>ip-addresses</code> and <code>prefixes</code> take several values per host:
+          separate them with a semicolon inside the cell.</small><br>
+          <small>Example: <code>subnet-id,duid,ip-addresses,hostname</code> →
+          <code>10,00:01:02:03:04:05,2001:db8::100;2001:db8::101,v6host.example.com</code></small><br>
+          <small>A host may delegate prefixes without reserving an address — fill in
+          <code>prefixes</code> and leave <code>ip-addresses</code> empty.</small>
         </div>
         {% endif %}
 

--- a/netbox_kea/templates/netbox_kea/server_reservation_delete.html
+++ b/netbox_kea/templates/netbox_kea/server_reservation_delete.html
@@ -10,12 +10,14 @@
       <div class="card-body">
         <p>
           Are you sure you want to delete the DHCPv{{ dhcp_version }} reservation for
-          <strong>{{ ip_address }}</strong> in subnet <strong>{{ subnet_id }}</strong>?
+          <strong>{{ reservation_label|default:ip_address }}</strong> in subnet <strong>{{ subnet_id }}</strong>?
         </p>
         <p class="text-danger">
           <i class="mdi mdi-alert-circle-outline"></i>
           This action <strong>cannot be undone</strong>.
         </p>
+        {# No action: posts back to this URL, keeping the identifier query string for #}
+        {# reservations addressed by client identifier rather than by IP. #}
         <form method="post">
           {% csrf_token %}
           <input type="hidden" name="confirm" value="true">

--- a/netbox_kea/templates/netbox_kea/server_reservation_form.html
+++ b/netbox_kea/templates/netbox_kea/server_reservation_form.html
@@ -26,13 +26,17 @@
         <strong>{{ action }} DHCPv{{ dhcp_version }} Reservation</strong>
       </div>
       <div class="card-body">
+        {# Both banners promise an IPAM record, which only holds for a reservation that #}
+        {# actually reserves an address. Identifier-only and prefix-only hosts have none. #}
         {% if object.sync_enabled and object.sync_reservations_enabled %}
         <div class="alert alert-info d-flex align-items-start mb-3" role="alert">
           <i class="mdi mdi-sync me-2 mt-1" aria-hidden="true"></i>
           <div>
             <strong>Automatic IPAM sync is enabled for this server.</strong>
-            This reservation will be synced to NetBox IPAM on the next scheduled sync run
-            (not instantly). You can also use the checkbox below to sync immediately.
+            A reservation with a fixed IP address will be synced to NetBox IPAM on the next
+            scheduled sync run (not instantly). You can also use the checkbox below to sync
+            immediately. Reservations that reserve no address are skipped — there is nothing
+            to record in IPAM.
           </div>
         </div>
         {% else %}
@@ -41,6 +45,7 @@
           <div>
             <strong>Automatic IPAM sync is disabled for this server.</strong>
             Use the checkbox below to sync this reservation to NetBox IPAM immediately.
+            A reservation that reserves no address has nothing to sync.
           </div>
         </div>
         {% endif %}

--- a/netbox_kea/tests/kea_stub.py
+++ b/netbox_kea/tests/kea_stub.py
@@ -174,6 +174,24 @@ def _subnet_get(version: int, pools: list[str] | None = None, subnet_id: int = 1
     }
 
 
+def _leases_per_subnet(leases_by_subnet: dict[Any, list[dict[str, Any]]]):
+    """A ``lease{v}-get-all`` responder that answers only for the subnets it was asked about.
+
+    Kea scopes ``lease{v}-get-all`` to ``arguments.subnets``, so a stub returning the same
+    leases whatever was requested cannot show whether the caller keeps per-subnet state.
+    Subnets with no leases get Kea's empty-result code 3.
+    """
+
+    def _respond(body: dict[str, Any]) -> dict[str, Any]:
+        requested = body.get("arguments", {}).get("subnets") or []
+        leases = [lease for sid in requested for lease in leases_by_subnet.get(sid, [])]
+        if not leases:
+            return {"result": 3}
+        return {"result": 0, "arguments": {"leases": leases}}
+
+    return _respond
+
+
 def _subnet_list(version: int, subnets: list[dict[str, Any]]) -> dict[str, Any]:  # noqa: ARG001 - version kept for call-site symmetry with _subnet_get
     """A ``subnet{v}-list`` payload (read by ``reservation_get_by_ip`` to find candidate subnets).
 

--- a/netbox_kea/tests/test_forms.py
+++ b/netbox_kea/tests/test_forms.py
@@ -5,6 +5,7 @@
 from django.core.exceptions import ValidationError
 from django.test import SimpleTestCase, TestCase
 
+from netbox_kea import constants
 from netbox_kea.forms import Leases4SearchForm, Leases6SearchForm, MultipleIPField, ServerForm
 
 
@@ -272,9 +273,21 @@ class TestReservationForm4(SimpleTestCase):
         self.assertFalse(form.is_valid())
         self.assertIn("subnet_id", form.errors)
 
-    def test_missing_ip_address_fails(self):
+    def test_missing_ip_address_is_allowed(self):
+        """A DHCPv4 host may reserve only a hostname, options or client classes.
+
+        Kea accepts such an identifier-only reservation and omits ``ip-address`` when
+        reporting it, so the form must not demand one.
+        """
         data = self._valid_data()
         del data["ip_address"]
+        form = self._form(data)
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertEqual(form.cleaned_data["ip_address"], "")
+
+    def test_invalid_ip_address_still_fails(self):
+        data = self._valid_data()
+        data["ip_address"] = "not-an-ip"
         form = self._form(data)
         self.assertFalse(form.is_valid())
         self.assertIn("ip_address", form.errors)
@@ -330,6 +343,23 @@ class TestReservationForm4(SimpleTestCase):
         self.assertFalse(form.is_valid())
         self.assertIn("identifier_type", form.errors)
 
+    def test_max_octet_client_id_is_accepted(self):
+        """A 128-octet client-id is 383 characters delimited — past the opaque 255-char cap."""
+        identifier = ":".join(["ab"] * constants.CLIENT_ID_MAX_OCTETS)
+        form = self._form(self._valid_data(identifier_type="client-id", identifier=identifier))
+        self.assertTrue(form.is_valid(), form.errors)
+
+    def test_client_id_past_its_octet_limit_is_rejected(self):
+        identifier = ":".join(["ab"] * (constants.CLIENT_ID_MAX_OCTETS + 1))
+        form = self._form(self._valid_data(identifier_type="client-id", identifier=identifier))
+        self.assertFalse(form.is_valid())
+        self.assertIn("identifier", form.errors)
+
+    def test_over_long_opaque_identifier_is_rejected(self):
+        form = self._form(self._valid_data(identifier_type="flex-id", identifier="a" * 256))
+        self.assertFalse(form.is_valid())
+        self.assertIn("identifier", form.errors)
+
 
 class TestReservationForm6(SimpleTestCase):
     """Tests for Reservation6Form (IPv6 reservation form validation)."""
@@ -380,12 +410,76 @@ class TestReservationForm6(SimpleTestCase):
         self.assertFalse(form.is_valid())
         self.assertIn("subnet_id", form.errors)
 
-    def test_missing_ip_addresses_fails(self):
+    def test_missing_ip_addresses_is_allowed(self):
+        """A DHCPv6 host may delegate only prefixes, or reserve only a hostname."""
         data = self._valid_data()
         del data["ip_addresses"]
         form = self._form(data)
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertEqual(form.cleaned_data["ip_addresses"], "")
+
+    def test_invalid_ip_addresses_still_fails(self):
+        data = self._valid_data()
+        data["ip_addresses"] = "2001:db8::1,not-an-ip"
+        form = self._form(data)
         self.assertFalse(form.is_valid())
         self.assertIn("ip_addresses", form.errors)
+
+    def test_delegated_prefixes_are_canonicalised_and_deduplicated(self):
+        data = self._valid_data()
+        data["prefixes"] = "2001:db8:1::/64, 2001:0db8:1::/64 ,2001:db8:2::/64"
+        form = self._form(data)
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertEqual(form.cleaned_data["prefixes"], "2001:db8:1::/64,2001:db8:2::/64")
+
+    def test_prefix_with_host_bits_set_fails(self):
+        """``2001:db8::1/64`` names a host inside a prefix, not the prefix itself."""
+        data = self._valid_data()
+        data["prefixes"] = "2001:db8::1/64"
+        form = self._form(data)
+        self.assertFalse(form.is_valid())
+        self.assertIn("prefixes", form.errors)
+
+    def test_ipv4_prefix_is_rejected(self):
+        data = self._valid_data()
+        data["prefixes"] = "10.0.0.0/24"
+        form = self._form(data)
+        self.assertFalse(form.is_valid())
+        self.assertIn("prefixes", form.errors)
+
+    def test_bare_address_without_length_is_rejected(self):
+        data = self._valid_data()
+        data["prefixes"] = "2001:db8:1::"
+        form = self._form(data)
+        self.assertFalse(form.is_valid())
+        self.assertIn("prefixes", form.errors)
+
+    def test_zero_length_prefix_is_rejected(self):
+        """``::/0`` is the whole address space, not a delegable prefix (length is 1–128)."""
+        data = self._valid_data()
+        data["prefixes"] = "::/0"
+        form = self._form(data)
+        self.assertFalse(form.is_valid())
+        self.assertIn("prefixes", form.errors)
+
+    def test_delegable_prefix_length_is_still_accepted(self):
+        data = self._valid_data()
+        data["prefixes"] = "2001:db8::/48"
+        form = self._form(data)
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertEqual(form.cleaned_data["prefixes"], "2001:db8::/48")
+
+    def test_max_octet_duid_is_accepted(self):
+        """A 128-octet DUID is 383 characters delimited — past the opaque 255-char cap."""
+        identifier = ":".join(["ab"] * constants.DUID_MAX_OCTETS)
+        form = self._form(self._valid_data(identifier=identifier))
+        self.assertTrue(form.is_valid(), form.errors)
+
+    def test_duid_past_its_octet_limit_is_rejected(self):
+        identifier = ":".join(["ab"] * (constants.DUID_MAX_OCTETS + 1))
+        form = self._form(self._valid_data(identifier=identifier))
+        self.assertFalse(form.is_valid())
+        self.assertIn("identifier", form.errors)
 
     def test_missing_identifier_type_fails(self):
         data = self._valid_data()

--- a/netbox_kea/tests/test_jobs.py
+++ b/netbox_kea/tests/test_jobs.py
@@ -1322,6 +1322,28 @@ class TestBuildSubnetPrefixMap(SimpleTestCase):
         self.assertEqual(_build_subnet_prefix_map(None), {})
 
 
+class TestRecordConflicts(SimpleTestCase):
+    """_record_conflicts folds one phase's conflicts into the job stats."""
+
+    def test_a_set_deduplicates_across_calls_and_spellings(self):
+        from netbox_kea.jobs import _record_conflicts
+
+        stats = {"conflicts": 0}
+        seen = set()
+        _record_conflicts(stats, ["2001:db8::1", "10.0.0.1"], seen)
+        _record_conflicts(stats, ["2001:0db8::0001"], seen)
+        self.assertEqual(seen, {"2001:db8::1", "10.0.0.1"})
+        self.assertEqual(stats["conflicts"], 2)
+
+    def test_without_a_set_the_counts_accumulate(self):
+        from netbox_kea.jobs import _record_conflicts
+
+        stats = {}
+        _record_conflicts(stats, ["10.0.0.1", "10.0.0.1"], None)
+        _record_conflicts(stats, ["10.0.0.2"], None)
+        self.assertEqual(stats["conflicts"], 3)
+
+
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestSyncServerReservationsReturnValue(TestCase):
     """_sync_server_reservations must report failure when any individual row fails.

--- a/netbox_kea/tests/test_jobs.py
+++ b/netbox_kea/tests/test_jobs.py
@@ -31,7 +31,7 @@ from netbox_kea.jobs import KeaIpamSyncJob
 from netbox_kea.kea import KeaClient
 from netbox_kea.models import Server, SyncConfig
 
-from .kea_stub import _res_page, stub_kea
+from .kea_stub import _res_page, queued, stub_kea
 
 _PLUGINS_CONFIG = {
     "netbox_kea": {
@@ -609,6 +609,47 @@ class TestKeaIpamSyncJobRun(TestCase):
         # Conflict surfaced in the per-server summary.
         entry = next(e for e in mock_job.data["summary"] if e["name"] == "kea-conflict")
         self.assertEqual(entry["conflicts"], 1)
+
+    def test_same_foreign_ip_in_both_phases_counts_once(self):
+        """One foreign IP seen by both the lease and reservation phase is ONE conflict.
+
+        The phases each appended to their own accumulator and added ``len()`` to the
+        same per-server counter, so a host that has both a lease and a reservation was
+        reported twice — inflating a number the operator cannot reconcile against
+        anything. The summary also names the addresses so the conflict is diagnosable.
+        """
+        from ipam.models import IPAddress
+
+        self._make_db_server(name="kea-dupe", dhcp6=False)
+        IPAddress.objects.create(address="10.0.0.100/32", status="active", description="Router loopback")
+        lease_for_same_ip = {**_LEASE4, "ip-address": "10.0.0.100", "hostname": "reserved1"}
+        with _patch_kea(leases4=[lease_for_same_ip], reservations=[_RESV4]):
+            mock_job = _make_job()
+            try:
+                KeaIpamSyncJob(mock_job).run()
+            except JobFailed:
+                pass
+
+        entry = next(e for e in mock_job.data["summary"] if e["name"] == "kea-dupe")
+        self.assertEqual(entry["conflicts"], 1)
+        self.assertEqual(entry["conflict_sample"], ["10.0.0.100"])
+
+    def test_address_less_reservation_reported_as_skipped_not_failed(self):
+        """An identifier-only reservation must not fail the nightly job (#110).
+
+        ``sync_reservation_to_netbox`` raises on a reservation with no address; counting
+        that as an error made ``run()`` raise ``JobFailed`` for a perfectly legal Kea
+        configuration, with the reason visible only at debug level.
+        """
+        self._make_db_server(name="kea-skip", dhcp6=False)
+        address_less = {"hw-address": "11:22:33:44:55:66", "hostname": "printer-1", "subnet-id": 1}
+        with _patch_kea(leases4=[], reservations=[address_less]):
+            mock_job = _make_job()
+            KeaIpamSyncJob(mock_job).run()  # must NOT raise JobFailed
+
+        entry = next(e for e in mock_job.data["summary"] if e["name"] == "kea-skip")
+        self.assertEqual(entry["errors"], 0)
+        self.assertEqual(entry["skipped"], 1)
 
     def test_config_get_failure_falls_back_to_prefix_match_and_logs(self):
         """When config-get fails, leases still sync (NetBox-prefix fallback) and it's logged.
@@ -1290,21 +1331,109 @@ class TestSyncServerReservationsReturnValue(TestCase):
     live IPs whose reservation failed to sync.
     """
 
+    @staticmethod
+    def _server(name="kea-fail"):
+        server = MagicMock(spec=Server)  # mock-ok: Server container (name/pk/get_client) for a job helper
+        server.name = name
+        server.pk = 1
+        server.get_client.return_value = KeaClient(url="https://kea.example.com")
+        return server
+
+    @staticmethod
+    def _stats():
+        return {"created": 0, "updated": 0, "errors": 0, "prefix_errors": 0, "conflicts": 0, "skipped": 0}
+
     def test_returns_false_when_a_row_fails(self):
         from netbox_kea.jobs import _sync_server_reservations
 
-        server = MagicMock(spec=Server)  # mock-ok: Server container (name/pk/get_client) for a job helper
-        server.name = "kea-fail"
-        server.pk = 1
-        server.get_client.return_value = KeaClient(url="https://kea.example.com")
-        # A reservation with no ip-address makes the REAL sync_reservation_to_netbox
-        # raise ValueError, which the loop catches and counts as an error.
-        stats = {"created": 0, "updated": 0, "errors": 0, "prefix_errors": 0, "conflicts": 0}
-        with stub_kea({"reservation-get-page": _res_page([{"hostname": "bad", "subnet-id": 1}])}):
-            ok = _sync_server_reservations(server, 4, stats=stats, all_synced=[])
+        # An unparseable address makes the REAL sync_reservation_to_netbox raise,
+        # which the loop catches and counts as an error.
+        stats = self._stats()
+        bad = {"ip-address": "999.999.999.999", "hw-address": "aa:bb:cc:dd:ee:ff", "subnet-id": 1}
+        with stub_kea({"reservation-get-page": _res_page([bad])}):
+            ok = _sync_server_reservations(self._server(), 4, stats=stats, all_synced=[])
 
         self.assertFalse(ok)
         self.assertEqual(stats["errors"], 1)
+        self.assertEqual(stats["skipped"], 0)
+
+    def test_address_less_reservation_is_skipped_not_an_error(self):
+        """A host that reserves no address is legal Kea config, not a sync failure (#110).
+
+        It has nothing to write to IPAM, so it must not count as an error — errors make
+        the whole job raise JobFailed — and must not enter ``all_synced``, whose IPs form
+        the stale-cleanup keep-set.
+        """
+        from netbox_kea.jobs import _sync_server_reservations
+
+        stats = self._stats()
+        all_synced: list[dict] = []
+        host = {"hostname": "printer-1", "hw-address": "aa:bb:cc:dd:ee:ff", "subnet-id": 1}
+        with stub_kea({"reservation-get-page": _res_page([host])}):
+            ok = _sync_server_reservations(self._server(), 4, stats=stats, all_synced=all_synced)
+
+        self.assertTrue(ok)
+        self.assertEqual(stats["errors"], 0)
+        self.assertEqual(stats["skipped"], 1)
+        self.assertEqual(all_synced, [])
+
+    def test_stats_survive_a_mid_pagination_failure(self):
+        """Rows from page 1 must still be accounted for when page 2 fails.
+
+        The counters used to be published only after the loop finished, so a
+        pagination error threw away everything already processed and the summary
+        reported zero skipped for a run that had skipped rows.
+        """
+        from netbox_kea.jobs import _sync_server_reservations
+
+        page1 = {
+            "result": 0,
+            "arguments": {
+                "hosts": [{"hostname": "printer-1", "hw-address": "aa:bb:cc:dd:ee:ff", "subnet-id": 1}],
+                "next": {"from": 1, "source-index": 0},  # not exhausted → page 2 is fetched
+            },
+        }
+        stats = self._stats()
+        with stub_kea({"reservation-get-page": queued(page1, {"result": 1, "text": "backend gone"})}):
+            ok = _sync_server_reservations(self._server(), 4, stats=stats, all_synced=[])
+
+        self.assertFalse(ok)
+        self.assertEqual(stats["skipped"], 1)
+
+    def test_conflicts_stay_consistent_with_the_deduplicated_set(self):
+        """``conflicts`` must equal the size of the caller's set, not a running sum.
+
+        The caller names the addresses in the job summary from that set, so a count
+        derived any other way can disagree with the sample beside it.
+        """
+        from ipam.models import IPAddress
+
+        from netbox_kea.jobs import _sync_server_reservations
+
+        IPAddress.objects.create(address="10.0.0.100/32", status="active", description="Router loopback")
+        conflict_ips: set[str] = set()
+        stats = self._stats()
+        host = {"ip-address": "10.0.0.100", "hw-address": "11:22:33:44:55:66", "subnet-id": 1}
+        with stub_kea({"reservation-get-page": _res_page([host])}):
+            _sync_server_reservations(self._server(), 4, stats=stats, all_synced=[], conflict_ips=conflict_ips)
+
+        self.assertEqual(conflict_ips, {"10.0.0.100"})
+        self.assertEqual(stats["conflicts"], len(conflict_ips))
+
+    def test_v6_prefix_only_reservation_is_skipped(self):
+        """A PD-only DHCPv6 host reserves prefixes, not addresses — same treatment."""
+        from netbox_kea.jobs import _sync_server_reservations
+
+        stats = self._stats()
+        all_synced: list[dict] = []
+        host = {"duid": "00:01:00:01:12:34", "subnet-id": 12, "prefixes": ["2001:db8:1::/64"]}
+        with stub_kea({"reservation-get-page": _res_page([host])}):
+            ok = _sync_server_reservations(self._server(), 6, stats=stats, all_synced=all_synced)
+
+        self.assertTrue(ok)
+        self.assertEqual(stats["errors"], 0)
+        self.assertEqual(stats["skipped"], 1)
+        self.assertEqual(all_synced, [])
 
 
 class TestSyncServerPrefixesAndRanges(SimpleTestCase):

--- a/netbox_kea/tests/test_utilities.py
+++ b/netbox_kea/tests/test_utilities.py
@@ -7,6 +7,7 @@ from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 from django.http import HttpResponse
+from django.test import SimpleTestCase
 
 from netbox_kea import constants
 from netbox_kea.models import Server
@@ -238,7 +239,7 @@ class TestIsHexString(TestCase):
         self.assertTrue(is_hex_string("AA:BB:CC:DD:EE:FF", 6, 6))
 
 
-class TestValidateReservationIdentifierLength(TestCase):
+class TestValidateReservationIdentifierLength(SimpleTestCase):
     """The character cap must not reject an identifier its octet limit allows.
 
     A DUID may be 128 octets (RFC 8415), which is 383 characters colon-delimited —

--- a/netbox_kea/tests/test_utilities.py
+++ b/netbox_kea/tests/test_utilities.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 
 from django.http import HttpResponse
 
+from netbox_kea import constants
 from netbox_kea.models import Server
 from netbox_kea.utilities import (
     _enrich_lease,
@@ -235,6 +236,52 @@ class TestIsHexString(TestCase):
 
     def test_mixed_case_accepted(self):
         self.assertTrue(is_hex_string("AA:BB:CC:DD:EE:FF", 6, 6))
+
+
+class TestValidateReservationIdentifierLength(TestCase):
+    """The character cap must not reject an identifier its octet limit allows.
+
+    A DUID may be 128 octets (RFC 8415), which is 383 characters colon-delimited —
+    far past the 255-character cap that only exists to keep an absurd *opaque*
+    identifier (circuit-id / flex-id / remote-id) out of the Kea API.
+    """
+
+    def _hex(self, octets: int) -> str:
+        return ":".join(["ab"] * octets)
+
+    def _validate(self, identifier_type: str, value: str) -> str:
+        from netbox_kea.utilities import validate_reservation_identifier
+
+        return validate_reservation_identifier(identifier_type, value)
+
+    def test_max_octet_duid_is_accepted(self):
+        value = self._hex(constants.DUID_MAX_OCTETS)
+        self.assertGreater(len(value), constants.MAX_IDENTIFIER_LENGTH)
+        self.assertEqual(self._validate("duid", value), value)
+
+    def test_duid_past_its_octet_limit_is_rejected(self):
+        with self.assertRaises(ValueError):
+            self._validate("duid", self._hex(constants.DUID_MAX_OCTETS + 1))
+
+    def test_max_octet_client_id_is_accepted(self):
+        value = self._hex(constants.CLIENT_ID_MAX_OCTETS)
+        self.assertEqual(self._validate("client-id", value), value)
+
+    def test_client_id_past_its_octet_limit_is_rejected(self):
+        with self.assertRaises(ValueError):
+            self._validate("client-id", self._hex(constants.CLIENT_ID_MAX_OCTETS + 1))
+
+    def test_opaque_identifier_past_the_character_cap_is_rejected(self):
+        """circuit-id / flex-id / remote-id are opaque, so length is the only check."""
+        for name in ("circuit-id", "flex-id", "remote-id"):
+            with self.subTest(identifier_type=name):
+                with self.assertRaises(ValueError) as ctx:
+                    self._validate(name, "a" * (constants.MAX_IDENTIFIER_LENGTH + 1))
+                self.assertIn("too long", str(ctx.exception))
+
+    def test_opaque_identifier_at_the_character_cap_is_accepted(self):
+        value = "a" * constants.MAX_IDENTIFIER_LENGTH
+        self.assertEqual(self._validate("flex-id", value), value)
 
 
 class TestCheckDhcpEnabled(TestCase):
@@ -663,16 +710,129 @@ class TestParseReservationCsv(TestCase):
         self.assertEqual(rows[0]["duid"], "00:01:02:03:04:05")
         self.assertEqual(rows[0]["subnet-id"], 10)
 
-    # error cases
+    def test_v6_prefixes_column_is_parsed_and_canonicalised(self):
+        """Delegated prefixes are semicolon-separated and share the form's validator."""
+        csv = "subnet-id,duid,prefixes\n10,00:01:02:03:04:05,2001:0db8:1::/64 ; 2001:db8:2::/56\n"
+        rows = self._parse(csv, version=6)
+        self.assertEqual(rows[0]["prefixes"], ["2001:db8:1::/64", "2001:db8:2::/56"])
 
-    def test_missing_required_field_raises_value_error(self):
-        """Row missing a required field raises ValueError with the row number."""
-        from netbox_kea.utilities import parse_reservation_csv
-
-        csv = "ip-address,hw-address,hostname,subnet-id\n,aa:bb:cc:00:00:01,host1,1\n"
+    def test_v6_zero_length_prefix_column_is_rejected(self):
+        """``::/0`` is the whole address space; a delegated prefix length is 1–128."""
         with self.assertRaises(ValueError) as ctx:
-            parse_reservation_csv(csv, version=4)
-        self.assertIn("2", str(ctx.exception))  # row 2 (1-indexed, header = row 1)
+            self._parse("subnet-id,duid,prefixes\n10,00:01:02:03:04:05,::/0\n", version=6)
+        message = str(ctx.exception)
+        self.assertIn("Row 2", message)
+        self.assertIn("::/0", message)
+
+    # address-less reservations
+
+    def test_v4_identifier_only_row_omits_the_address(self):
+        """A v4 host may reserve only a hostname — Kea accepts it, so the importer must."""
+        rows = self._parse("subnet-id,hw-address,hostname\n1,aa:bb:cc:dd:ee:ff,host1.example.com\n")
+        self.assertNotIn("ip-address", rows[0])
+        self.assertEqual(rows[0], {"subnet-id": 1, "hw-address": "aa:bb:cc:dd:ee:ff", "hostname": "host1.example.com"})
+
+    def test_v6_prefix_delegation_only_row_omits_the_addresses(self):
+        csv = "subnet-id,duid,prefixes\n10,00:01:02:03:04:05,2001:db8:1::/64\n"
+        rows = self._parse(csv, version=6)
+        self.assertNotIn("ip-addresses", rows[0])
+        self.assertEqual(rows[0]["prefixes"], ["2001:db8:1::/64"])
+
+    def test_v4_row_with_neither_address_nor_identifier_is_rejected(self):
+        """The message must name the columns that would satisfy the row."""
+        with self.assertRaises(ValueError) as ctx:
+            self._parse("subnet-id,hostname\n1,host1.example.com\n")
+        message = str(ctx.exception)
+        self.assertIn("Row 2", message)
+        for name in ("hw-address", "client-id", "circuit-id", "flex-id", "remote-id"):
+            self.assertIn(name, message)
+
+    def test_row_without_subnet_id_is_rejected(self):
+        with self.assertRaises(ValueError) as ctx:
+            self._parse("subnet-id,hw-address\n,aa:bb:cc:dd:ee:ff\n")
+        self.assertIn("subnet-id", str(ctx.exception))
+
+    # identifier columns
+
+    def test_every_v4_identifier_type_is_accepted(self):
+        for name, value in (
+            ("hw-address", "aa:bb:cc:dd:ee:ff"),
+            ("client-id", "01:aa:bb:cc:dd:ee:ff"),
+            ("circuit-id", "0a:1b:2c"),
+            ("flex-id", "somevendor-42"),
+            ("remote-id", "01:02:03:04"),
+        ):
+            with self.subTest(identifier_type=name):
+                rows = self._parse(f"subnet-id,{name}\n1,{value}\n")
+                self.assertEqual(rows[0][name], value)
+
+    def test_v6_duid_column_is_accepted_and_circuit_id_is_not(self):
+        """Kea has no circuit-id for DHCPv6, so that column is unknown there."""
+        self.assertEqual(self._parse("subnet-id,duid\n1,00:01:02:03\n", version=6)[0]["duid"], "00:01:02:03")
+        with self.assertRaises(ValueError) as ctx:
+            self._parse("subnet-id,circuit-id\n1,0a:1b\n", version=6)
+        self.assertIn("circuit-id", str(ctx.exception))
+
+    def test_two_identifiers_are_rejected_as_ambiguous(self):
+        """The edit view writes one identifier key, so a two-identifier host cannot round-trip."""
+        csv = "subnet-id,hw-address,flex-id\n1,aa:bb:cc:dd:ee:ff,vendor-42\n"
+        with self.assertRaises(ValueError) as ctx:
+            self._parse(csv)
+        message = str(ctx.exception)
+        self.assertIn("hw-address", message)
+        self.assertIn("flex-id", message)
+
+    def test_whitespace_only_identifier_counts_as_absent(self):
+        with self.assertRaises(ValueError) as ctx:
+            self._parse("subnet-id,hw-address\n1,   \n")
+        self.assertIn("no client identifier", str(ctx.exception))
+
+    def test_identifier_syntax_is_shared_with_the_form(self):
+        """A short MAC parses in netaddr but is not a hardware address."""
+        with self.assertRaises(ValueError) as ctx:
+            self._parse("subnet-id,hw-address\n1,aa:bb:cc\n")
+        self.assertIn("hardware address", str(ctx.exception))
+
+    def test_over_long_opaque_identifier_is_rejected(self):
+        with self.assertRaises(ValueError) as ctx:
+            self._parse(f"subnet-id,flex-id\n1,{'a' * 256}\n")
+        self.assertIn("too long", str(ctx.exception))
+
+    def test_max_octet_duid_column_is_accepted(self):
+        """383 characters delimited — the importer must not be stricter than the DUID limit."""
+        duid = ":".join(["ab"] * constants.DUID_MAX_OCTETS)
+        rows = self._parse(f"subnet-id,duid\n10,{duid}\n", version=6)
+        self.assertEqual(rows[0]["duid"], duid)
+
+    def test_duid_column_past_its_octet_limit_is_rejected(self):
+        duid = ":".join(["ab"] * (constants.DUID_MAX_OCTETS + 1))
+        with self.assertRaises(ValueError) as ctx:
+            self._parse(f"subnet-id,duid\n10,{duid}\n", version=6)
+        self.assertIn("Row 2", str(ctx.exception))
+
+    # unknown input
+
+    def test_unknown_column_carrying_a_value_is_rejected(self):
+        """Silently dropping a column the operator filled in loses their intent."""
+        csv = "subnet-id,hw-address,boot-file-name\n1,aa:bb:cc:dd:ee:ff,pxelinux.0\n"
+        with self.assertRaises(ValueError) as ctx:
+            self._parse(csv)
+        self.assertIn("boot-file-name", str(ctx.exception))
+
+    def test_unknown_column_left_empty_is_ignored(self):
+        rows = self._parse("subnet-id,hw-address,boot-file-name\n1,aa:bb:cc:dd:ee:ff,\n")
+        self.assertEqual(rows[0], {"subnet-id": 1, "hw-address": "aa:bb:cc:dd:ee:ff"})
+
+    def test_row_with_more_cells_than_headers_is_rejected(self):
+        with self.assertRaises(ValueError) as ctx:
+            self._parse("subnet-id,hw-address\n1,aa:bb:cc:dd:ee:ff,surplus\n")
+        self.assertIn("more values", str(ctx.exception))
+
+    def test_unsupported_version_raises(self):
+        """Anything but 4 or 6 used to fall through to the v6 branch."""
+        with self.assertRaises(ValueError) as ctx:
+            self._parse("subnet-id,duid\n1,00:01\n", version=5)
+        self.assertIn("expected 4 or 6", str(ctx.exception))
 
 
 # ---------------------------------------------------------------------------
@@ -1129,18 +1289,25 @@ class TestParseReservationCsvValidationPaths(TestCase):
         self.assertIn("IPv4", str(ctx.exception))
 
     def test_v4_invalid_mac_raises(self):
-        """Invalid MAC address format raises ValueError."""
+        """Invalid MAC address format raises ValueError naming the offending column."""
         csv = "ip-address,hw-address,subnet-id\n10.0.0.1,zz:zz:zz:zz:zz:zz,1"
         with self.assertRaises(ValueError) as ctx:
             self._parse(csv, version=4)
-        self.assertIn("MAC", str(ctx.exception))
+        self.assertIn("hw-address", str(ctx.exception))
 
-    def test_v6_empty_ip_addresses_raises(self):
-        """ip-addresses with only semicolons/spaces raises ValueError."""
+    def test_v6_empty_ip_addresses_is_allowed(self):
+        """An empty address cell reserves no address; only the identifier is required."""
         csv = "ip-addresses,duid,subnet-id\n  ;  ,00:01:02:03:04:05,1"
+        rows = self._parse(csv, version=6)
+        self.assertNotIn("ip-addresses", rows[0])
+        self.assertEqual(rows[0]["duid"], "00:01:02:03:04:05")
+
+    def test_v6_invalid_prefix_raises(self):
+        """A prefix with host bits set names a host, not a network."""
+        csv = "subnet-id,duid,prefixes\n1,00:01:02:03:04:05,2001:db8::1/64"
         with self.assertRaises(ValueError) as ctx:
             self._parse(csv, version=6)
-        self.assertIn("ip-addresses", str(ctx.exception))
+        self.assertIn("Row 2", str(ctx.exception))
 
     def test_v6_invalid_ipv6_raises(self):
         """Non-parseable string in ip-addresses raises ValueError."""

--- a/netbox_kea/tests/test_utilities.py
+++ b/netbox_kea/tests/test_utilities.py
@@ -828,6 +828,16 @@ class TestParseReservationCsv(TestCase):
             self._parse("subnet-id,hw-address\n1,aa:bb:cc:dd:ee:ff,surplus\n")
         self.assertIn("more values", str(ctx.exception))
 
+    def test_row_with_a_trailing_comma_is_accepted(self):
+        """A trailing comma yields one empty surplus cell, which carries no data to lose."""
+        rows = self._parse("subnet-id,hw-address\n1,aa:bb:cc:dd:ee:ff,\n")
+        self.assertEqual(rows[0], {"subnet-id": 1, "hw-address": "aa:bb:cc:dd:ee:ff"})
+
+    def test_row_with_a_blank_and_a_filled_surplus_cell_is_rejected(self):
+        with self.assertRaises(ValueError) as ctx:
+            self._parse("subnet-id,hw-address\n1,aa:bb:cc:dd:ee:ff,,surplus\n")
+        self.assertIn("more values", str(ctx.exception))
+
     def test_unsupported_version_raises(self):
         """Anything but 4 or 6 used to fall through to the v6 branch."""
         with self.assertRaises(ValueError) as ctx:

--- a/netbox_kea/tests/test_views_combined.py
+++ b/netbox_kea/tests/test_views_combined.py
@@ -14,7 +14,7 @@ real request/response path.
 from django.test import override_settings
 from django.urls import reverse
 
-from .kea_stub import queued, stub_kea
+from .kea_stub import _res_page, queued, stub_kea
 from .utils import _PLUGINS_CONFIG, _ViewTestBase
 
 
@@ -126,26 +126,14 @@ class TestCombinedReservationsWithoutAddress(_ViewTestBase):
         return reverse(f"plugins:netbox_kea:combined_reservations{version}") + f"?server={self.server.pk}"
 
     def test_v4_identifier_only_reservation_renders(self):
-        page = {
-            "result": 0,
-            "arguments": {
-                "hosts": [{"subnet-id": 3742, "hw-address": "aa:bb:cc:dd:ee:ff", "hostname": "printer-1"}],
-                "next": {"from": 0, "source-index": 0},
-            },
-        }
+        page = _res_page([{"subnet-id": 3742, "hw-address": "aa:bb:cc:dd:ee:ff", "hostname": "printer-1"}])
         with stub_kea({"reservation-get-page": page, "lease4-get-all": {"result": 0, "arguments": {"leases": []}}}):
             response = self.client.get(self._url(4))
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"printer-1", response.content)
 
     def test_v6_prefix_only_reservation_renders(self):
-        page = {
-            "result": 0,
-            "arguments": {
-                "hosts": [{"subnet-id": 12, "duid": "00:01:00:01:12:34", "prefixes": ["2001:db8:1::/64"]}],
-                "next": {"from": 0, "source-index": 0},
-            },
-        }
+        page = _res_page([{"subnet-id": 12, "duid": "00:01:00:01:12:34", "prefixes": ["2001:db8:1::/64"]}])
         with stub_kea({"reservation-get-page": page, "lease6-get-all": {"result": 0, "arguments": {"leases": []}}}):
             response = self.client.get(self._url(6))
         self.assertEqual(response.status_code, 200)
@@ -163,13 +151,9 @@ class TestCombinedReservationsShowWhatIsReserved(_ViewTestBase):
         base = reverse(f"plugins:netbox_kea:combined_reservations{version}") + f"?server={self.server.pk}"
         return base + query
 
-    @staticmethod
-    def _page(hosts):
-        return {"result": 0, "arguments": {"hosts": hosts, "next": {"from": 0, "source-index": 0}}}
-
     def _stub(self, hosts, version=4):
         return {
-            "reservation-get-page": self._page(hosts),
+            "reservation-get-page": _res_page(hosts),
             f"lease{version}-get-all": {"result": 0, "arguments": {"leases": []}},
         }
 

--- a/netbox_kea/tests/test_views_combined.py
+++ b/netbox_kea/tests/test_views_combined.py
@@ -116,3 +116,36 @@ class TestCombinedReservationsMultiPage(_ViewTestBase):
         self.assertEqual(len(kea.bodies("reservation-get-page")), 2)
         self.assertIn(b"10.0.0.1", response.content)
         self.assertIn(b"10.0.0.2", response.content)
+
+
+@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
+class TestCombinedReservationsWithoutAddress(_ViewTestBase):
+    """The global reservations tab hits the same address-less crash as the per-server tab (#110)."""
+
+    def _url(self, version=4):
+        return reverse(f"plugins:netbox_kea:combined_reservations{version}") + f"?server={self.server.pk}"
+
+    def test_v4_identifier_only_reservation_renders(self):
+        page = {
+            "result": 0,
+            "arguments": {
+                "hosts": [{"subnet-id": 3742, "hw-address": "aa:bb:cc:dd:ee:ff", "hostname": "printer-1"}],
+                "next": {"from": 0, "source-index": 0},
+            },
+        }
+        with stub_kea({"reservation-get-page": page, "lease4-get-all": {"result": 0, "arguments": {"leases": []}}}):
+            response = self.client.get(self._url(4))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"printer-1", response.content)
+
+    def test_v6_prefix_only_reservation_renders(self):
+        page = {
+            "result": 0,
+            "arguments": {
+                "hosts": [{"subnet-id": 12, "duid": "00:01:00:01:12:34", "prefixes": ["2001:db8:1::/64"]}],
+                "next": {"from": 0, "source-index": 0},
+            },
+        }
+        with stub_kea({"reservation-get-page": page, "lease6-get-all": {"result": 0, "arguments": {"leases": []}}}):
+            response = self.client.get(self._url(6))
+        self.assertEqual(response.status_code, 200)

--- a/netbox_kea/tests/test_views_combined.py
+++ b/netbox_kea/tests/test_views_combined.py
@@ -149,3 +149,63 @@ class TestCombinedReservationsWithoutAddress(_ViewTestBase):
         with stub_kea({"reservation-get-page": page, "lease6-get-all": {"result": 0, "arguments": {"leases": []}}}):
             response = self.client.get(self._url(6))
         self.assertEqual(response.status_code, 200)
+
+
+@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
+class TestCombinedReservationsShowWhatIsReserved(_ViewTestBase):
+    """The global tab shows the identifier and prefixes an address-less host reserves.
+
+    Rendering 200 only proves the crash is gone; these assert the row actually says
+    what the reservation is, which is the point of showing it at all.
+    """
+
+    def _url(self, version=4, query=""):
+        base = reverse(f"plugins:netbox_kea:combined_reservations{version}") + f"?server={self.server.pk}"
+        return base + query
+
+    @staticmethod
+    def _page(hosts):
+        return {"result": 0, "arguments": {"hosts": hosts, "next": {"from": 0, "source-index": 0}}}
+
+    def _stub(self, hosts, version=4):
+        return {
+            "reservation-get-page": self._page(hosts),
+            f"lease{version}-get-all": {"result": 0, "arguments": {"leases": []}},
+        }
+
+    def test_v4_flex_id_row_shows_the_identifier_and_its_type(self):
+        hosts = [{"subnet-id": 1, "flex-id": "vendor-42", "hostname": "kiosk"}]
+        with stub_kea(self._stub(hosts)):
+            response = self.client.get(self._url(4))
+        body = response.content.decode()
+        self.assertIn("vendor-42", body)
+        self.assertIn("flex-id", body)
+
+    def test_v6_prefix_only_row_shows_its_prefixes_and_no_address(self):
+        hosts = [{"subnet-id": 12, "duid": "00:01:00:01:12:34", "prefixes": ["2001:db8:1::/64"]}]
+        with stub_kea(self._stub(hosts, version=6)):
+            response = self.client.get(self._url(6))
+        body = response.content.decode()
+        self.assertIn("2001:db8:1::/64", body)
+        self.assertIn("No address", body)
+
+    def test_csv_export_renders_every_row(self):
+        """Export goes through the real ?export path, so a missing accessor would raise."""
+        hosts = [
+            {"subnet-id": 1, "hw-address": "aa:bb:cc:dd:ee:01", "ip-address": "10.0.0.1"},
+            {"subnet-id": 1, "flex-id": "vendor-42", "hostname": "kiosk"},
+        ]
+        with stub_kea(self._stub(hosts)):
+            response = self.client.get(self._url(4, "&export"))
+        self.assertEqual(response.status_code, 200)
+        body = response.content.decode()
+        self.assertIn("10.0.0.1", body)
+        self.assertIn("vendor-42", body)
+        self.assertEqual(len([line for line in body.splitlines() if line.strip()]), 3)  # header + 2 rows
+
+    def test_v6_csv_export_carries_prefixes(self):
+        hosts = [{"subnet-id": 12, "duid": "00:01:00:01:12:34", "prefixes": ["2001:db8:1::/64"]}]
+        with stub_kea(self._stub(hosts, version=6)):
+            response = self.client.get(self._url(6, "&export"))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("2001:db8:1::/64", response.content.decode())

--- a/netbox_kea/tests/test_views_reservations.py
+++ b/netbox_kea/tests/test_views_reservations.py
@@ -37,6 +37,7 @@ persisting-write guarantee is covered by the pool/subnet PartialPersist cases in
 
 import unittest as _unittest  # alias to avoid pytest collection confusion
 from unittest.mock import patch
+from urllib.parse import quote_plus, urlencode
 
 import requests as req
 from django.contrib import messages as django_messages
@@ -44,10 +45,12 @@ from django.test import override_settings
 from django.urls import reverse
 from ipam.models import IPAddress as NbIP
 
+from netbox_kea import constants
 from netbox_kea.kea import KeaClient
+from netbox_kea.signals import reservation_deleted
 from netbox_kea.views import _get_reservation_identifier as _extract_identifier
 
-from .kea_stub import _res_get, _res_page, _subnet_get, stub_kea
+from .kea_stub import _leases_per_subnet, _res_get, _res_page, _subnet_get, stub_kea
 from .utils import _PLUGINS_CONFIG, _make_db_server, _ViewTestBase
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -72,6 +75,9 @@ _RES_EMPTY_PAGE = {"result": 3}
 #: ``reservation-get`` / ``lease{v}-get`` with result 3 = no such record.
 _RES_NOT_FOUND = {"result": 3}
 _LEASE_NOT_FOUND = {"result": 3}
+
+#: Commands the reservation list issues, for POSTs that redirect back to it.
+_RES_LIST_STUB = {"reservation-get-page": _RES_EMPTY_PAGE, "lease4-get-all": _LEASE_NOT_FOUND}
 
 #: Existing-reservation payloads used to seed the edit POST reload.
 _EDIT4_EXISTING = {"hw-address": "aa:bb:cc:dd:ee:ff", "ip-address": "10.0.0.55", "subnet-id": 1}
@@ -118,11 +124,14 @@ class TestReservationListWithoutAddress(_ViewTestBase):
             response = self.client.get(self._url6())
         self.assertEqual(response.status_code, 200)
 
-    def test_address_less_row_offers_no_edit_or_delete_action(self):
-        """No address means no address-keyed URL can be built — offer no action at all."""
+    def test_address_less_row_is_actionable_by_identifier(self):
+        """No address to key on, so the actions address the row by its identifier."""
         with stub_kea({"reservation-get-page": _res_page([self.ADDRESSLESS_V4]), "lease4-get-all": _LEASE_NOT_FOUND}):
             response = self.client.get(self._url4())
-        self.assertNotContains(response, "/reservations4/3742/")
+        self.assertContains(response, "/reservations4/3742/edit-by-identifier/")
+        self.assertContains(response, "identifier_type=hw-address")
+        # ...and never through the address-keyed route, which cannot express this row.
+        self.assertNotContains(response, "/reservations4/3742/edit/")
 
     def test_addressed_row_keeps_its_edit_and_delete_links(self):
         """Regression guard: moving URL construction into the view must not drop the links."""
@@ -195,6 +204,292 @@ class TestReservationListWithoutAddress(_ViewTestBase):
         # object-edit links are unrelated, hence matching on the row route prefix).
         self.assertNotContains(response, f"/servers/{self.server.pk}/reservations4/1/")
         self.assertNotContains(response, f"/servers/{self.server.pk}/reservations4/-5/")
+
+
+@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
+class TestReservationByIdentifierRoutes(_ViewTestBase):
+    """Edit and delete a reservation that has no address to key on.
+
+    The identifier travels in the query string, so these routes reverse from integers
+    alone and no reservation value can make them fail to reverse.
+    """
+
+    V4_HOST = {"subnet-id": 1, "hw-address": "aa:bb:cc:dd:ee:ff", "hostname": "printer-1"}
+    V6_HOST = {"subnet-id": 12, "duid": "00:01:00:01:12:34", "prefixes": ["2001:db8:1::/64"]}
+    QUERY_V4 = {"identifier_type": "hw-address", "identifier": "aa:bb:cc:dd:ee:ff"}
+    QUERY_V6 = {"identifier_type": "duid", "identifier": "00:01:00:01:12:34"}
+
+    def _edit_url(self, version=4, subnet_id=1):
+        return reverse(
+            f"plugins:netbox_kea:server_reservation{version}_edit_by_identifier", args=[self.server.pk, subnet_id]
+        )
+
+    def _delete_url(self, version=4, subnet_id=1):
+        return reverse(
+            f"plugins:netbox_kea:server_reservation{version}_delete_by_identifier", args=[self.server.pk, subnet_id]
+        )
+
+    # ── lookup ────────────────────────────────────────────────────────────
+
+    def test_edit_get_looks_the_reservation_up_by_identifier(self):
+        with stub_kea({"reservation-get": _res_get(self.V4_HOST), "lease4-get": _LEASE_NOT_FOUND}) as kea:
+            response = self.client.get(self._edit_url(), self.QUERY_V4)
+        self.assertEqual(response.status_code, 200)
+        body = kea.bodies("reservation-get")[0]
+        self.assertEqual(body["arguments"]["identifier-type"], "hw-address")
+        self.assertEqual(body["arguments"]["identifier"], "aa:bb:cc:dd:ee:ff")
+        self.assertNotIn("ip-address", body["arguments"])
+
+    def test_edit_get_leaves_the_address_editable(self):
+        """The IP is not part of the key here, so it can be added or removed."""
+        with stub_kea({"reservation-get": _res_get(self.V4_HOST), "lease4-get": _LEASE_NOT_FOUND}):
+            response = self.client.get(self._edit_url(), self.QUERY_V4)
+        form = response.context["form"]
+        self.assertFalse(form.fields["ip_address"].disabled)
+        self.assertTrue(form.fields["identifier"].disabled)
+        self.assertTrue(form.fields["identifier_type"].disabled)
+        self.assertTrue(form.fields["subnet_id"].disabled)
+
+    def test_missing_reservation_is_404(self):
+        with stub_kea({"reservation-get": _RES_NOT_FOUND}):
+            response = self.client.get(self._edit_url(), self.QUERY_V4)
+        self.assertEqual(response.status_code, 404)
+
+    # ── update ────────────────────────────────────────────────────────────
+
+    def test_edit_post_without_an_address_sends_no_ip_address_key(self):
+        post = {"hostname": "printer-2", "ip_address": "", **_FORMSET_MGMT}
+        with stub_kea(
+            {"reservation-get": _res_get(self.V4_HOST), "reservation-update": {"result": 0}, **_RES_LIST_STUB}
+        ) as kea:
+            response = self.client.post(self._edit_url(), {**post}, QUERY_STRING=urlencode(self.QUERY_V4))
+        self.assertIn(response.status_code, (200, 302))
+        sent = kea.bodies("reservation-update")[0]["arguments"]["reservation"]
+        self.assertNotIn("ip-address", sent)
+        self.assertEqual(sent["hostname"], "printer-2")
+        self.assertEqual(sent["hw-address"], "aa:bb:cc:dd:ee:ff")
+
+    def test_edit_post_can_give_the_reservation_an_address(self):
+        """Kea's reservation-update replaces the host keyed by identifier, so this works."""
+        post = {"hostname": "printer-1", "ip_address": "10.0.0.55", **_FORMSET_MGMT}
+        with stub_kea(
+            {"reservation-get": _res_get(self.V4_HOST), "reservation-update": {"result": 0}, **_RES_LIST_STUB}
+        ) as kea:
+            self.client.post(self._edit_url(), {**post}, QUERY_STRING=urlencode(self.QUERY_V4))
+        sent = kea.bodies("reservation-update")[0]["arguments"]["reservation"]
+        self.assertEqual(sent["ip-address"], "10.0.0.55")
+
+    def test_edit_post_keeps_option_data_it_did_not_touch(self):
+        existing = {**self.V4_HOST, "option-data": [{"name": "domain-name-servers", "data": "10.0.0.1"}]}
+        post = {"hostname": "printer-1", "ip_address": "", **_FORMSET_MGMT}
+        with stub_kea(
+            {"reservation-get": _res_get(existing), "reservation-update": {"result": 0}, **_RES_LIST_STUB}
+        ) as kea:
+            self.client.post(self._edit_url(), {**post}, QUERY_STRING=urlencode(self.QUERY_V4))
+        sent = kea.bodies("reservation-update")[0]["arguments"]["reservation"]
+        self.assertEqual(sent["option-data"], [{"name": "domain-name-servers", "data": "10.0.0.1"}])
+
+    def test_edit_post_still_clears_option_data_the_user_deleted(self):
+        """A submitted formset stays authoritative — "untouched" must not mean "unclearable"."""
+        existing = {**self.V4_HOST, "option-data": [{"name": "domain-name-servers", "data": "10.0.0.1"}]}
+        post = {
+            "hostname": "printer-1",
+            "ip_address": "",
+            "options-TOTAL_FORMS": "1",
+            "options-INITIAL_FORMS": "1",
+            "options-MIN_NUM_FORMS": "0",
+            "options-MAX_NUM_FORMS": "1000",
+            "options-0-name": "domain-name-servers",
+            "options-0-data": "10.0.0.1",
+            "options-0-DELETE": "on",
+        }
+        with stub_kea(
+            {"reservation-get": _res_get(existing), "reservation-update": {"result": 0}, **_RES_LIST_STUB}
+        ) as kea:
+            self.client.post(self._edit_url(), post, QUERY_STRING=urlencode(self.QUERY_V4))
+        sent = kea.bodies("reservation-update")[0]["arguments"]["reservation"]
+        self.assertNotIn("option-data", sent)
+
+    def test_v6_edit_post_replaces_prefixes(self):
+        post = {"hostname": "", "ip_addresses": "", "prefixes": "2001:db8:9::/64", **_FORMSET_MGMT}
+        with stub_kea(
+            {
+                "reservation-get": _res_get(self.V6_HOST),
+                "reservation-update": {"result": 0},
+                "reservation-get-page": _RES_EMPTY_PAGE,
+            }
+        ) as kea:
+            self.client.post(self._edit_url(6, 12), {**post}, QUERY_STRING=urlencode(self.QUERY_V6))
+        sent = kea.bodies("reservation-update")[0]["arguments"]["reservation"]
+        self.assertEqual(sent["prefixes"], ["2001:db8:9::/64"])
+        self.assertNotIn("ip-addresses", sent)
+
+    def test_v6_edit_post_with_blank_prefixes_removes_them(self):
+        post = {"hostname": "", "ip_addresses": "2001:db8::5", "prefixes": "", **_FORMSET_MGMT}
+        with stub_kea(
+            {
+                "reservation-get": _res_get(self.V6_HOST),
+                "reservation-update": {"result": 0},
+                "reservation-get-page": _RES_EMPTY_PAGE,
+            }
+        ) as kea:
+            self.client.post(self._edit_url(6, 12), {**post}, QUERY_STRING=urlencode(self.QUERY_V6))
+        sent = kea.bodies("reservation-update")[0]["arguments"]["reservation"]
+        self.assertNotIn("prefixes", sent)
+        self.assertEqual(sent["ip-addresses"], ["2001:db8::5"])
+
+    def test_v6_edit_post_with_an_invalid_prefix_sends_nothing(self):
+        post = {"hostname": "", "ip_addresses": "", "prefixes": "2001:db8::1/64", **_FORMSET_MGMT}
+        with stub_kea({"reservation-get": _res_get(self.V6_HOST), "reservation-update": {"result": 0}}) as kea:
+            response = self.client.post(self._edit_url(6, 12), {**post}, QUERY_STRING=urlencode(self.QUERY_V6))
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("reservation-update", kea.commands())
+
+    # ── delete ────────────────────────────────────────────────────────────
+
+    def test_delete_post_keys_on_the_identifier(self):
+        with stub_kea({"reservation-del": {"result": 0}, **_RES_LIST_STUB}) as kea:
+            response = self.client.post(self._delete_url(), {"confirm": "true"}, QUERY_STRING=urlencode(self.QUERY_V4))
+        self.assertIn(response.status_code, (200, 302))
+        args = kea.bodies("reservation-del")[0]["arguments"]
+        self.assertEqual(args["identifier-type"], "hw-address")
+        self.assertEqual(args["identifier"], "aa:bb:cc:dd:ee:ff")
+        self.assertNotIn("ip-address", args)
+
+    def test_delete_signal_carries_the_identifier_and_a_null_address(self):
+        received = []
+
+        def _receiver(sender, **kwargs):
+            received.append(kwargs)
+
+        reservation_deleted.connect(_receiver)
+        try:
+            with stub_kea({"reservation-del": {"result": 0}, **_RES_LIST_STUB}):
+                self.client.post(self._delete_url(), {"confirm": "true"}, QUERY_STRING=urlencode(self.QUERY_V4))
+        finally:
+            reservation_deleted.disconnect(_receiver)
+        self.assertEqual(len(received), 1)
+        self.assertIsNone(received[0]["ip_address"])
+        self.assertEqual(received[0]["identifier_type"], "hw-address")
+        self.assertEqual(received[0]["identifier"], "aa:bb:cc:dd:ee:ff")
+
+    def test_address_keyed_delete_signal_keeps_the_same_kwargs(self):
+        """Receivers must see one payload shape, whichever route was used."""
+        received = []
+
+        def _receiver(sender, **kwargs):
+            received.append(kwargs)
+
+        reservation_deleted.connect(_receiver)
+        try:
+            url = reverse("plugins:netbox_kea:server_reservation4_delete", args=[self.server.pk, 1, "10.0.0.5"])
+            with stub_kea({"reservation-del": {"result": 0}, **_RES_LIST_STUB}):
+                self.client.post(url, {"confirm": "true"})
+        finally:
+            reservation_deleted.disconnect(_receiver)
+        self.assertEqual(received[0]["ip_address"], "10.0.0.5")
+        self.assertIsNone(received[0]["identifier_type"])
+        self.assertIsNone(received[0]["identifier"])
+
+    # ── long identifiers ──────────────────────────────────────────────────
+
+    def test_max_octet_duid_survives_the_whole_by_identifier_path(self):
+        """A 128-octet DUID is 383 characters — the routes must carry it, not reject it.
+
+        The list builds the row's action URL, so this walks the same path the operator
+        does: render the tab, take the ``edit-by-identifier`` link it produced, and
+        follow it.
+        """
+        duid = ":".join(["ab"] * constants.DUID_MAX_OCTETS)
+        host = {"subnet-id": 12, "duid": duid, "prefixes": ["2001:db8:1::/64"]}
+        with stub_kea({"reservation-get-page": _res_page([host]), "lease6-get-all": _LEASE_NOT_FOUND}):
+            listing = self.client.get(reverse("plugins:netbox_kea:server_reservations6", args=[self.server.pk]))
+        self.assertEqual(listing.status_code, 200)
+        edit_url = listing.context["table"].data.data[0]["edit_url"]
+        self.assertIn(quote_plus(duid), edit_url)
+
+        with stub_kea({"reservation-get": _res_get(host), "lease6-get": _LEASE_NOT_FOUND}) as kea:
+            response = self.client.get(edit_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(kea.bodies("reservation-get")[0]["arguments"]["identifier"], duid)
+
+    def test_duid_past_its_octet_limit_is_still_rejected_by_the_route(self):
+        query = urlencode({"identifier_type": "duid", "identifier": ":".join(["ab"] * 200)})
+        response = self.client.get(f"{self._edit_url(6, 12)}?{query}")
+        self.assertEqual(response.status_code, 400)
+
+    # ── malformed lookups ─────────────────────────────────────────────────
+
+    def test_malformed_lookups_are_rejected(self):
+        cases = {
+            "missing both": "",
+            "missing value": "identifier_type=hw-address",
+            "empty value": "identifier_type=hw-address&identifier=",
+            "unknown type": "identifier_type=nonsense&identifier=aa:bb",
+            "wrong version type": "identifier_type=duid&identifier=00:01",
+            "repeated": "identifier_type=hw-address&identifier=aa:bb&identifier=cc:dd",
+            "too long": f"identifier_type=hw-address&identifier={'a' * 300}",
+        }
+        for label, query in cases.items():
+            with self.subTest(case=label):
+                response = self.client.get(f"{self._edit_url()}?{query}")
+                self.assertEqual(response.status_code, 400)
+                response = self.client.post(f"{self._delete_url()}?{query}", {"confirm": "true"})
+                self.assertEqual(response.status_code, 400)
+
+
+@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
+class TestReservationListShowsWhatIsReserved(_ViewTestBase):
+    """A reservation row must show what it identifies and what it reserves.
+
+    The v4 table only had a Hardware Address column and the v6 table only a DUID
+    column, so a host identified by client-id, circuit-id, flex-id or remote-id
+    rendered as a blank cell — and a DHCPv6 host that only delegates prefixes showed
+    nothing at all about what it reserves.
+    """
+
+    def _url(self, version=4):
+        return reverse(f"plugins:netbox_kea:server_reservations{version}", args=[self.server.pk])
+
+    def test_v4_non_mac_identifier_is_shown_with_its_type(self):
+        host = {"subnet-id": 1, "client-id": "01:aa:bb:cc:dd:ee:ff", "hostname": "kiosk"}
+        with stub_kea({"reservation-get-page": _res_page([host]), "lease4-get-all": _LEASE_NOT_FOUND}):
+            response = self.client.get(self._url(4))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "01:aa:bb:cc:dd:ee:ff")
+        self.assertContains(response, "client-id")
+
+    def test_v6_non_duid_identifier_is_shown_with_its_type(self):
+        host = {"subnet-id": 1, "flex-id": "hostname-router-1", "ip-addresses": ["2001:db8::5"]}
+        with stub_kea({"reservation-get-page": _res_page([host]), "lease6-get-all": _LEASE_NOT_FOUND}):
+            response = self.client.get(self._url(6))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "hostname-router-1")
+        self.assertContains(response, "flex-id")
+
+    def test_v6_delegated_prefixes_are_shown(self):
+        host = {
+            "subnet-id": 12,
+            "duid": "00:01:00:01:12:34",
+            "prefixes": ["2001:db8:1::/64", "2001:db8:2::/64"],
+        }
+        with stub_kea({"reservation-get-page": _res_page([host]), "lease6-get-all": _LEASE_NOT_FOUND}):
+            response = self.client.get(self._url(6))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "2001:db8:1::/64")
+        self.assertContains(response, "2001:db8:2::/64")
+
+    def test_address_less_row_says_so(self):
+        host = {"subnet-id": 1, "hw-address": "aa:bb:cc:dd:ee:ff", "hostname": "printer-1"}
+        with stub_kea({"reservation-get-page": _res_page([host]), "lease4-get-all": _LEASE_NOT_FOUND}):
+            response = self.client.get(self._url(4))
+        self.assertContains(response, "No address")
+
+    def test_v6_prefix_only_row_says_it_has_no_address(self):
+        host = {"subnet-id": 12, "duid": "00:01:00:01:12:34", "prefixes": ["2001:db8:1::/64"]}
+        with stub_kea({"reservation-get-page": _res_page([host]), "lease6-get-all": _LEASE_NOT_FOUND}):
+            response = self.client.get(self._url(6))
+        self.assertContains(response, "No address")
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
@@ -893,6 +1188,14 @@ class TestReservation6EditOptionDataAndSync(_ViewTestBase):
         self.assertIsNotNone(ntp_entry, "ntp-servers option not found in reservation option-data")
         self.assertEqual(ntp_entry["data"], "2001:db8::1:1")
 
+    def test_post_without_an_options_formset_keeps_existing_option_data(self):
+        """The address-keyed route merges too: a submission that omits the options section keeps them."""
+        existing = {**self._EXISTING, "option-data": [{"name": "ntp-servers", "data": "2001:db8::99"}]}
+        with stub_kea({"reservation-get": _res_get(existing), "reservation-update": {"result": 0}}) as kea:
+            self.client.post(self._url(), dict(_VALID_RESERVATION6_EDIT_POST))
+        reservation_dict = kea.bodies("reservation-update")[0]["arguments"]["reservation"]
+        self.assertEqual(reservation_dict["option-data"], [{"name": "ntp-servers", "data": "2001:db8::99"}])
+
     def test_post_sync_success(self):
         """sync_to_netbox=on runs the real sync → info message queued."""
         post_data = {**_VALID_RESERVATION6_EDIT_POST, "sync_to_netbox": "on"}
@@ -998,6 +1301,112 @@ class TestEnrichReservationsLeaseStatusCoverage(_ViewTestBase):
         # as_completed must have been reached (executor submitted tasks)
         mock_as_completed.assert_called_once()
         # outer except returns early — has_active_lease stays unset
+        self.assertNotIn("has_active_lease", reservations[0])
+
+
+# ---------------------------------------------------------------------------
+# Lease status for reservations that reserve no address
+# ---------------------------------------------------------------------------
+
+
+@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
+class TestAddressLessReservationLeaseStatus(_ViewTestBase):
+    """A reservation with no address still has a lease state — match on the identifier.
+
+    ``has_active_lease`` was derived purely from the reserved addresses, so an
+    address-less host could only ever report "No Lease", even while its client held an
+    active lease.  Kea's leases carry the client identifier (``hw-address`` /
+    ``client-id`` on v4, ``duid`` on v6), so that is what these rows match on — inside
+    their own subnet only, since the same client leasing elsewhere is a different row.
+    """
+
+    ADDRESSLESS_V4 = {"subnet-id": 42, "hw-address": "aa:bb:cc:dd:ee:ff", "hostname": "printer-1"}
+
+    def _enrich(self, reservations, leases_by_subnet, version=4):
+        from netbox_kea.views import _enrich_reservations_with_lease_status
+
+        with stub_kea({f"lease{version}-get-all": _leases_per_subnet(leases_by_subnet)}):
+            client = KeaClient(url="https://kea.example.com")
+            _enrich_reservations_with_lease_status(client, reservations, version)
+        return reservations
+
+    def test_list_shows_an_active_lease_for_an_address_less_row(self):
+        """End to end: the tab renders "Active Lease" for a host that reserves no address.
+
+        The lease's hardware address is written dash-delimited and upper-case — the same
+        identifier, spelled the other way Kea and operators write it.
+        """
+        lease = {"ip-address": "10.0.0.77", "hw-address": "AA-BB-CC-DD-EE-FF", "subnet-id": 42, "state": 0}
+        with stub_kea(
+            {
+                "reservation-get-page": _res_page([self.ADDRESSLESS_V4]),
+                "lease4-get-all": _leases_per_subnet({42: [lease]}),
+            }
+        ):
+            response = self.client.get(reverse("plugins:netbox_kea:server_reservations4", args=[self.server.pk]))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Active Lease")
+        self.assertNotContains(response, "No Lease")
+
+    def test_a_lease_in_another_subnet_does_not_light_up_the_row(self):
+        """Same client, different subnet: that lease belongs to the other reservation."""
+        elsewhere = {"subnet-id": 7, "hw-address": "11:22:33:44:55:66", "hostname": "elsewhere"}
+        lease = {"ip-address": "10.0.7.9", "hw-address": "aa:bb:cc:dd:ee:ff", "subnet-id": 7, "state": 0}
+        reservations = [dict(self.ADDRESSLESS_V4), elsewhere]
+        self._enrich(reservations, {7: [lease]})
+        self.assertFalse(reservations[0]["has_active_lease"])
+
+    def test_no_matching_lease_is_no_lease(self):
+        lease = {"ip-address": "10.0.0.77", "hw-address": "11:22:33:44:55:66", "subnet-id": 42, "state": 0}
+        reservations = [dict(self.ADDRESSLESS_V4)]
+        self._enrich(reservations, {42: [lease]})
+        self.assertFalse(reservations[0]["has_active_lease"])
+
+    def test_v4_client_id_row_matches_the_lease_client_id(self):
+        host = {"subnet-id": 42, "client-id": "01:aa:bb:cc:dd:ee:ff"}
+        lease = {"ip-address": "10.0.0.77", "client-id": "01:AA:BB:CC:DD:EE:FF", "subnet-id": 42, "state": 0}
+        reservations = [dict(host)]
+        self._enrich(reservations, {42: [lease]})
+        self.assertTrue(reservations[0]["has_active_lease"])
+
+    def test_v6_address_less_row_matches_the_lease_duid(self):
+        host = {"subnet-id": 12, "duid": "00:01:00:01:12:34:56:78", "prefixes": ["2001:db8:1::/64"]}
+        lease = {"ip-address": "2001:db8::5", "duid": "00:01:00:01:12:34:56:78", "subnet-id": 12, "state": 0}
+        reservations = [dict(host)]
+        self._enrich(reservations, {12: [lease]}, version=6)
+        self.assertTrue(reservations[0]["has_active_lease"])
+
+    def test_opaque_identifier_row_has_nothing_to_match_on(self):
+        """Kea leases carry no flex-id, so such a row cannot be matched by identifier."""
+        lease = {"ip-address": "10.0.0.77", "hw-address": "aa:bb:cc:dd:ee:ff", "subnet-id": 42, "state": 0}
+        reservations = [{"subnet-id": 42, "flex-id": "vendor-42"}]
+        self._enrich(reservations, {42: [lease]})
+        self.assertFalse(reservations[0]["has_active_lease"])
+
+    def test_addressed_row_still_matches_on_its_address(self):
+        """Regression guard: a row that does reserve an address keeps the IP match."""
+        host = {"subnet-id": 42, "hw-address": "11:22:33:44:55:66", "ip-address": "10.0.0.5"}
+        lease = {"ip-address": "10.0.0.5", "hw-address": "99:99:99:99:99:99", "subnet-id": 42, "state": 0}
+        reservations = [dict(host)]
+        self._enrich(reservations, {42: [lease]})
+        self.assertTrue(reservations[0]["has_active_lease"])
+
+    def test_addressed_row_is_not_lit_up_by_its_clients_other_lease(self):
+        """The reserved address is what an addressed row reports on, not the client."""
+        host = {"subnet-id": 42, "hw-address": "aa:bb:cc:dd:ee:ff", "ip-address": "10.0.0.5"}
+        lease = {"ip-address": "10.0.0.77", "hw-address": "aa:bb:cc:dd:ee:ff", "subnet-id": 42, "state": 0}
+        reservations = [dict(host)]
+        self._enrich(reservations, {42: [lease]})
+        self.assertFalse(reservations[0]["has_active_lease"])
+
+    def test_indeterminate_subnet_leaves_the_flag_unset(self):
+        """An address-less row must not report "No Lease" when the subnet could not be read."""
+        reservations = [dict(self.ADDRESSLESS_V4)]
+        with stub_kea({"lease4-get-all": {"result": 1, "text": "error"}}):
+            from netbox_kea.views import _enrich_reservations_with_lease_status
+
+            client = KeaClient(url="https://kea.example.com")
+            _enrich_reservations_with_lease_status(client, reservations, 4)
         self.assertNotIn("has_active_lease", reservations[0])
 
 

--- a/netbox_kea/tests/test_views_reservations.py
+++ b/netbox_kea/tests/test_views_reservations.py
@@ -148,6 +148,20 @@ class TestReservationListWithoutAddress(_ViewTestBase):
             reverse("plugins:netbox_kea:server_reservation4_delete", args=[self.server.pk, 1, "10.0.0.5"]),
         )
 
+    def test_address_less_row_labels_its_actions_with_the_identifier(self):
+        """The labels named the address, so an address-less row got "Edit reservation "."""
+        with stub_kea({"reservation-get-page": _res_page([self.ADDRESSLESS_V4]), "lease4-get-all": _LEASE_NOT_FOUND}):
+            response = self.client.get(self._url4())
+        self.assertContains(response, 'aria-label="Edit reservation aa:bb:cc:dd:ee:ff"')
+        self.assertContains(response, 'aria-label="Delete reservation aa:bb:cc:dd:ee:ff"')
+
+    def test_addressed_row_still_labels_its_actions_with_the_address(self):
+        host = {"subnet-id": 1, "ip-address": "10.0.0.5", "hw-address": "aa:bb:cc:dd:ee:ff"}
+        with stub_kea({"reservation-get-page": _res_page([host]), "lease4-get-all": _LEASE_NOT_FOUND}):
+            response = self.client.get(self._url4())
+        self.assertContains(response, 'aria-label="Edit reservation 10.0.0.5"')
+        self.assertContains(response, 'aria-label="Delete reservation 10.0.0.5"')
+
     def test_mixed_rows_sort_by_ip_column(self):
         """django-tables2 orders on ``_ip_sort_key``, which address-less rows do not have.
 
@@ -344,6 +358,28 @@ class TestReservationByIdentifierRoutes(_ViewTestBase):
             response = self.client.post(self._edit_url(6, 12), {**post}, QUERY_STRING=urlencode(self.QUERY_V6))
         self.assertEqual(response.status_code, 200)
         self.assertNotIn("reservation-update", kea.commands())
+
+    # ── logging ───────────────────────────────────────────────────────────
+
+    def test_v6_update_failure_logs_the_identifier(self):
+        """The v6 log calls named the (empty) address, so the message had no subject."""
+        post = {"hostname": "", "ip_addresses": "", "prefixes": "2001:db8:9::/64", **_FORMSET_MGMT}
+        with (
+            stub_kea({"reservation-get": _res_get(self.V6_HOST), "reservation-update": {"result": 1, "text": "boom"}}),
+            self.assertLogs("netbox_kea.views.reservations", level="ERROR") as logs,
+        ):
+            response = self.client.post(self._edit_url(6, 12), {**post}, QUERY_STRING=urlencode(self.QUERY_V6))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("duid 00:01:00:01:12:34", "\n".join(logs.output))
+
+    def test_v6_fetch_failure_logs_the_identifier(self):
+        with (
+            stub_kea({"reservation-get": {"result": 1, "text": "boom"}}),
+            self.assertLogs("netbox_kea.views.reservations", level="ERROR") as logs,
+        ):
+            response = self.client.get(self._edit_url(6, 12), self.QUERY_V6)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("duid 00:01:00:01:12:34", "\n".join(logs.output))
 
     # ── delete ────────────────────────────────────────────────────────────
 

--- a/netbox_kea/tests/test_views_reservations.py
+++ b/netbox_kea/tests/test_views_reservations.py
@@ -83,6 +83,121 @@ _EDIT6_EXISTING = {
 
 
 @override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
+class TestReservationListWithoutAddress(_ViewTestBase):
+    """Reservations that reserve no address must not break the list (issue #110).
+
+    Kea omits ``ip-address`` for identifier-only DHCPv4 hosts (hostname / option-data /
+    client-classes only) and omits ``ip-addresses`` for prefix-delegation-only DHCPv6
+    hosts.  The actions column used to reverse an address-keyed route with an empty
+    string, which ``<str:ip_address>`` (``[^/]+``) cannot match — a single such row
+    raised ``NoReverseMatch`` and 500'd the whole tab.
+
+    The test user is a superuser, so ``can_change`` is True: the reversal lived inside
+    ``{% if record.can_change %}`` and a read-only user never reached it.
+    """
+
+    #: Identifier-only DHCPv4 host: legal in Kea, reserves a hostname but no address.
+    ADDRESSLESS_V4 = {"subnet-id": 3742, "hw-address": "aa:bb:cc:dd:ee:ff", "hostname": "printer-1"}
+    #: Prefix-delegation-only DHCPv6 host: reserves a prefix, no addresses.
+    PD_ONLY_V6 = {"subnet-id": 12, "duid": "00:01:00:01:12:34:56:78:aa:bb", "prefixes": ["2001:db8:1::/64"]}
+
+    def _url4(self):
+        return reverse("plugins:netbox_kea:server_reservations4", args=[self.server.pk])
+
+    def _url6(self):
+        return reverse("plugins:netbox_kea:server_reservations6", args=[self.server.pk])
+
+    def test_v4_reservation_without_ip_address_renders(self):
+        with stub_kea({"reservation-get-page": _res_page([self.ADDRESSLESS_V4]), "lease4-get-all": _LEASE_NOT_FOUND}):
+            response = self.client.get(self._url4())
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "printer-1")
+
+    def test_v6_reservation_with_only_prefixes_renders(self):
+        with stub_kea({"reservation-get-page": _res_page([self.PD_ONLY_V6]), "lease6-get-all": _LEASE_NOT_FOUND}):
+            response = self.client.get(self._url6())
+        self.assertEqual(response.status_code, 200)
+
+    def test_address_less_row_offers_no_edit_or_delete_action(self):
+        """No address means no address-keyed URL can be built — offer no action at all."""
+        with stub_kea({"reservation-get-page": _res_page([self.ADDRESSLESS_V4]), "lease4-get-all": _LEASE_NOT_FOUND}):
+            response = self.client.get(self._url4())
+        self.assertNotContains(response, "/reservations4/3742/")
+
+    def test_addressed_row_keeps_its_edit_and_delete_links(self):
+        """Regression guard: moving URL construction into the view must not drop the links."""
+        host = {"subnet-id": 1, "ip-address": "10.0.0.5", "hw-address": "aa:bb:cc:dd:ee:ff"}
+        with stub_kea({"reservation-get-page": _res_page([host]), "lease4-get-all": _LEASE_NOT_FOUND}):
+            response = self.client.get(self._url4())
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            reverse("plugins:netbox_kea:server_reservation4_edit", args=[self.server.pk, 1, "10.0.0.5"]),
+        )
+        self.assertContains(
+            response,
+            reverse("plugins:netbox_kea:server_reservation4_delete", args=[self.server.pk, 1, "10.0.0.5"]),
+        )
+
+    def test_mixed_rows_sort_by_ip_column(self):
+        """django-tables2 orders on ``_ip_sort_key``, which address-less rows do not have.
+
+        Driven through the real view + real table so ordering and row rendering actually
+        run; sorting the dicts by hand would not exercise the missing accessor.
+        """
+        addressed = {"subnet-id": 1, "ip-address": "10.0.0.5", "hw-address": "aa:bb:cc:dd:ee:01"}
+        hosts = [self.ADDRESSLESS_V4, addressed]
+        with stub_kea({"reservation-get-page": _res_page(hosts), "lease4-get-all": _LEASE_NOT_FOUND}):
+            response = self.client.get(self._url4(), {"sort": "ip_address"})
+        self.assertEqual(response.status_code, 200)
+        with stub_kea({"reservation-get-page": _res_page(hosts), "lease4-get-all": _LEASE_NOT_FOUND}):
+            response = self.client.get(self._url4(), {"sort": "-ip_address"})
+        self.assertEqual(response.status_code, 200)
+
+    def test_row_with_neither_address_nor_identifier_renders(self):
+        """A host with no address and no identifier still must not invent a URL."""
+        host = {"subnet-id": 7, "hostname": "ghost"}
+        with stub_kea({"reservation-get-page": _res_page([host]), "lease4-get-all": _LEASE_NOT_FOUND}):
+            response = self.client.get(self._url4())
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "ghost")
+
+    def test_string_subnet_id_still_gets_action_links(self):
+        """``<int:subnet_id>`` reverses a decimal *string* fine — don't reject one.
+
+        Pre-validating the value type in Python instead of asking the route would
+        silently drop working buttons for a payload the old template handled.
+        """
+        host = {"subnet-id": "1", "ip-address": "10.0.0.5", "hw-address": "aa:bb:cc:dd:ee:ff"}
+        with stub_kea({"reservation-get-page": _res_page([host]), "lease4-get-all": _LEASE_NOT_FOUND}):
+            response = self.client.get(self._url4())
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            reverse("plugins:netbox_kea:server_reservation4_edit", args=[self.server.pk, 1, "10.0.0.5"]),
+        )
+
+    def test_values_the_route_cannot_reverse_do_not_break_the_page(self):
+        """Anything the converters reject costs that row its buttons, not the tab.
+
+        A negative subnet id fails ``<int:subnet_id>`` (``[0-9]+``) and an address
+        containing a slash fails ``<str:ip_address>`` (``[^/]+``) — neither may raise
+        NoReverseMatch out of the table.
+        """
+        hosts = [
+            {"subnet-id": -5, "ip-address": "10.0.0.5", "hw-address": "aa:bb:cc:dd:ee:01"},
+            {"subnet-id": 1, "ip-address": "2001:db8::/64", "hw-address": "aa:bb:cc:dd:ee:02"},
+        ]
+        with stub_kea({"reservation-get-page": _res_page(hosts), "lease4-get-all": _LEASE_NOT_FOUND}):
+            response = self.client.get(self._url4())
+        self.assertEqual(response.status_code, 200)
+        # No per-row reservation action URL for either host (the page's own
+        # object-edit links are unrelated, hence matching on the row route prefix).
+        self.assertNotContains(response, f"/servers/{self.server.pk}/reservations4/1/")
+        self.assertNotContains(response, f"/servers/{self.server.pk}/reservations4/-5/")
+
+
+@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
 class TestReservations4V6OnlyRedirect(_ViewTestBase):
     """A v6-only server's /reservations4/ redirects to the merged tab's v6 route."""
 

--- a/netbox_kea/tests/test_views_sync.py
+++ b/netbox_kea/tests/test_views_sync.py
@@ -982,6 +982,7 @@ class TestBulkImportAddressLessReservations(_ViewTestBase):
         with stub_kea({}) as kea:
             response = self.client.post(self._url(), {"csv_file": upload})
         self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "parsing failed")
         self.assertEqual(kea.commands(), [])
 
     def test_import_requires_change_permission(self):

--- a/netbox_kea/tests/test_views_sync.py
+++ b/netbox_kea/tests/test_views_sync.py
@@ -904,3 +904,118 @@ class TestBulkImportPerRowExceptionTypes(_ViewTestBase):
         self.assertEqual(result["skipped"], 1)
         self.assertEqual(result["errors"], 1)
         self.assertEqual(result["total"], 3)
+
+
+# ---------------------------------------------------------------------------
+# Bulk import of reservations that reserve no address
+# ---------------------------------------------------------------------------
+
+
+@override_settings(PLUGINS_CONFIG=_PLUGINS_CONFIG)
+class TestBulkImportAddressLessReservations(_ViewTestBase):
+    """CSV import through the real view for hosts that reserve no address.
+
+    The assertions read the recorded ``reservation-add`` payload rather than the
+    parser's return value, so they cover the whole seam: upload → parse → the
+    arguments the view actually sends to Kea.
+    """
+
+    def _url(self, version=4):
+        return reverse(f"plugins:netbox_kea:server_reservation{version}_bulk_import", args=[self.server.pk])
+
+    @staticmethod
+    def _upload(content: bytes):
+        csv_file = io.BytesIO(content)
+        csv_file.name = "reservations.csv"
+        return csv_file
+
+    def test_identifier_only_v4_row_omits_ip_address(self):
+        upload = self._upload(b"subnet-id,hw-address,hostname\n1,aa:bb:cc:dd:ee:ff,host1.example.com\n")
+        with stub_kea({"reservation-add": {"result": 0}}) as kea:
+            response = self.client.post(self._url(), {"csv_file": upload})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["result"]["created"], 1)
+        sent = kea.bodies("reservation-add")[0]["arguments"]["reservation"]
+        self.assertNotIn("ip-address", sent)
+        self.assertEqual(sent, {"subnet-id": 1, "hw-address": "aa:bb:cc:dd:ee:ff", "hostname": "host1.example.com"})
+
+    def test_prefix_delegation_only_v6_row_omits_addresses_and_sends_prefixes(self):
+        upload = self._upload(b"subnet-id,duid,prefixes\n10,00:01:02:03:04:05,2001:0db8:1::/64;2001:db8:2::/56\n")
+        with stub_kea({"reservation-add": {"result": 0}}) as kea:
+            response = self.client.post(self._url(version=6), {"csv_file": upload})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["result"]["created"], 1)
+        sent = kea.bodies("reservation-add")[0]["arguments"]["reservation"]
+        self.assertNotIn("ip-addresses", sent)
+        self.assertEqual(sent["prefixes"], ["2001:db8:1::/64", "2001:db8:2::/56"])
+
+    def test_non_default_identifier_column_is_imported(self):
+        """A flex-id host imports as a flex-id host, not silently as something else."""
+        upload = self._upload(b"subnet-id,flex-id,ip-address\n1,vendor-42,10.0.0.7\n")
+        with stub_kea({"reservation-add": {"result": 0}}) as kea:
+            self.client.post(self._url(), {"csv_file": upload})
+        sent = kea.bodies("reservation-add")[0]["arguments"]["reservation"]
+        self.assertEqual(sent, {"subnet-id": 1, "flex-id": "vendor-42", "ip-address": "10.0.0.7"})
+
+    def test_invalid_prefix_issues_no_kea_command(self):
+        """Parsing fails before a client is built, so nothing reaches Kea."""
+        upload = self._upload(b"subnet-id,duid,prefixes\n10,00:01:02:03:04:05,2001:db8::1/64\n")
+        with stub_kea({}) as kea:
+            response = self.client.post(self._url(version=6), {"csv_file": upload})
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "parsing failed")
+        self.assertEqual(kea.commands(), [])
+
+    def test_row_with_two_identifiers_issues_no_kea_command(self):
+        upload = self._upload(b"subnet-id,hw-address,flex-id\n1,aa:bb:cc:dd:ee:ff,vendor-42\n")
+        with stub_kea({}) as kea:
+            response = self.client.post(self._url(), {"csv_file": upload})
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "parsing failed")
+        self.assertEqual(kea.commands(), [])
+
+    def test_one_bad_row_rejects_the_whole_file(self):
+        """The parser runs before any write, so a later bad row cannot half-import a file."""
+        upload = self._upload(
+            b"subnet-id,hw-address\n1,aa:bb:cc:dd:ee:ff\n1,not-a-mac\n",
+        )
+        with stub_kea({}) as kea:
+            response = self.client.post(self._url(), {"csv_file": upload})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(kea.commands(), [])
+
+    def test_import_requires_change_permission(self):
+        """A user who may view the server but not change it cannot import."""
+        from django.contrib.contenttypes.models import ContentType
+        from users.models import ObjectPermission
+
+        from netbox_kea.models import Server
+
+        restricted = User.objects.create_user(
+            username="noperms_import",
+            email="noperms_import@example.com",
+            password="pass",
+        )
+        perm = ObjectPermission.objects.create(name="view-server-noperms-import", actions=["view"])
+        perm.object_types.add(ContentType.objects.get_for_model(Server))
+        perm.users.add(restricted)
+        self.client.force_login(restricted)
+        upload = self._upload(b"subnet-id,hw-address\n1,aa:bb:cc:dd:ee:ff\n")
+        with stub_kea({}) as kea:
+            response = self.client.post(self._url(), {"csv_file": upload})
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(kea.commands(), [])
+
+    def test_import_hides_the_server_without_view_permission(self):
+        """No view permission must 404 rather than 403, so the server's existence stays hidden."""
+        restricted = User.objects.create_user(
+            username="noview_import",
+            email="noview_import@example.com",
+            password="pass",
+        )
+        self.client.force_login(restricted)
+        upload = self._upload(b"subnet-id,hw-address\n1,aa:bb:cc:dd:ee:ff\n")
+        with stub_kea({}) as kea:
+            response = self.client.post(self._url(), {"csv_file": upload})
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(kea.commands(), [])

--- a/netbox_kea/urls.py
+++ b/netbox_kea/urls.py
@@ -99,6 +99,21 @@ urlpatterns = (
         views.ServerReservation4DeleteView.as_view(),
         name="server_reservation4_delete",
     ),
+    # Identifier-keyed variants, for reservations that reserve no address and
+    # therefore cannot be addressed by one.  The identifier travels in the query
+    # string (?identifier_type=&identifier=) so these reverse from integers alone —
+    # no reservation value can make the URL fail to reverse — and urlencode handles
+    # identifiers a <str:> segment would mangle (Django treats '/' as safe).
+    path(
+        "servers/<int:pk>/reservations4/<int:subnet_id>/edit-by-identifier/",
+        views.ServerReservation4EditByIdentifierView.as_view(),
+        name="server_reservation4_edit_by_identifier",
+    ),
+    path(
+        "servers/<int:pk>/reservations4/<int:subnet_id>/delete-by-identifier/",
+        views.ServerReservation4DeleteByIdentifierView.as_view(),
+        name="server_reservation4_delete_by_identifier",
+    ),
     path(
         "servers/<int:pk>/reservations6/add/",
         views.ServerReservation6AddView.as_view(),
@@ -113,6 +128,16 @@ urlpatterns = (
         "servers/<int:pk>/reservations6/<int:subnet_id>/<str:ip_address>/delete/",
         views.ServerReservation6DeleteView.as_view(),
         name="server_reservation6_delete",
+    ),
+    path(
+        "servers/<int:pk>/reservations6/<int:subnet_id>/edit-by-identifier/",
+        views.ServerReservation6EditByIdentifierView.as_view(),
+        name="server_reservation6_edit_by_identifier",
+    ),
+    path(
+        "servers/<int:pk>/reservations6/<int:subnet_id>/delete-by-identifier/",
+        views.ServerReservation6DeleteByIdentifierView.as_view(),
+        name="server_reservation6_delete_by_identifier",
     ),
     path(
         "servers/<int:pk>/leases4/sync/",

--- a/netbox_kea/utilities.py
+++ b/netbox_kea/utilities.py
@@ -481,9 +481,10 @@ def parse_reservation_csv(content: str, version: int) -> list[dict[str, Any]]:
 
     rows: list[dict[str, Any]] = []
     for row_num, raw in enumerate(reader, start=2):  # header is row 1
-        # DictReader files cells with no header under the None key.  They carry data
-        # this parser never reads, so reject the row rather than drop them.
-        if raw.get(None):
+        # DictReader files cells with no header under the None key.  A filled one carries
+        # data this parser never reads, so reject the row; an empty one (trailing comma)
+        # loses nothing.
+        if any((v or "").strip() for v in raw.get(None) or []):
             raise ValueError(f"Row {row_num}: more values than the header has columns")
         row = {k.strip(): (v or "").strip() for k, v in raw.items() if k is not None}
 

--- a/netbox_kea/utilities.py
+++ b/netbox_kea/utilities.py
@@ -11,6 +11,7 @@ from django.http import HttpResponse
 from django.shortcuts import redirect
 from django_tables2 import Table
 from django_tables2.export import TableExport
+from netaddr import EUI, AddrFormatError
 from utilities.views import ViewTab
 
 from . import constants
@@ -121,6 +122,93 @@ def is_hex_string(s: str, min_octets: int, max_octets: int):
 
     octets = len(s.replace(":", "").replace("-", "")) / 2
     return octets >= min_octets and octets <= max_octets
+
+
+def validate_reservation_identifier(identifier_type: str, value: str) -> str:
+    """Validate one client identifier against the syntax its type requires.
+
+    Shared by the reservation forms and the CSV importer so an identifier the
+    interactive form rejects cannot be imported through a file instead.  Returns the
+    stripped value; the type is assumed to already be valid for the DHCP version.
+
+    Raises:
+        ValueError: With a message written for the operator.
+
+    """
+    value = value.strip()
+    if not value:
+        raise ValueError("Enter an identifier value.")
+    # Type-aware: a hex identifier's real bound is its octet count, checked below.
+    max_length = constants.max_identifier_length(identifier_type)
+    if len(value) > max_length:
+        raise ValueError(f"Identifier is too long (limit {max_length} characters).")
+    if identifier_type == "hw-address":
+        try:
+            EUI(value, version=48)
+        except (AddrFormatError, ValueError) as exc:
+            raise ValueError("Enter a valid hardware address (e.g. aa:bb:cc:dd:ee:ff).") from exc
+        # netaddr widens a short value instead of rejecting it — 'aa:bb:cc' parses as
+        # 00-AA-00-BB-00-CC — so check the operator actually typed 48 bits.
+        if len(re.sub(r"[:.-]", "", value)) != 12:
+            raise ValueError("Enter a valid hardware address (e.g. aa:bb:cc:dd:ee:ff).")
+    elif identifier_type == "duid":
+        if not is_hex_string(value, constants.DUID_MIN_OCTETS, constants.DUID_MAX_OCTETS):
+            raise ValueError("Enter a valid DUID as colon-separated hex octets.")
+    elif identifier_type == "client-id":
+        if not is_hex_string(value, constants.CLIENT_ID_MIN_OCTETS, constants.CLIENT_ID_MAX_OCTETS):
+            raise ValueError("Enter a valid client-id as colon-separated hex octets (e.g. 01:aa:bb:cc:dd:ee:ff).")
+    # circuit-id, flex-id and remote-id are opaque to Kea — length is the only check.
+    return value
+
+
+#: Bounds on a DHCPv6 reservation's delegated-prefix list.  Kea imposes no count
+#: limit of its own; these keep a pasted blob from reaching the Kea API as one host.
+MAX_DELEGATED_PREFIXES = 16
+MAX_PREFIX_INPUT_LENGTH = 1024
+
+
+def parse_delegated_prefixes(value: str, separator: str = ",") -> list[str]:
+    """Parse and validate a delimited list of DHCPv6 delegated prefixes.
+
+    Shared by the reservation form (comma-separated) and the CSV importer
+    (semicolon-separated) so both accept exactly the same thing.  Entries are
+    canonicalised and de-duplicated, keeping first-seen order.
+
+    Whether a prefix actually belongs to the subnet or one of its PD pools is left to
+    Kea: only the subnet *id* is known here, not its configuration, and Kea rejects a
+    mismatch with a usable error.
+
+    Raises:
+        ValueError: On an entry that is not a canonical IPv6 network of length 1–128,
+            or when the input exceeds the length/count bounds above.
+
+    """
+    if len(value) > MAX_PREFIX_INPUT_LENGTH:
+        raise ValueError(f"Prefix list is too long (limit {MAX_PREFIX_INPUT_LENGTH} characters).")
+
+    prefixes: list[str] = []
+    for raw in value.split(separator):
+        entry = raw.strip()
+        if not entry:
+            continue
+        if "/" not in entry:
+            raise ValueError(f"'{entry}' is not a prefix — expected an IPv6 network such as 2001:db8:1::/64.")
+        try:
+            # strict=True rejects a prefix with host bits set, e.g. 2001:db8::1/64.
+            network = ipaddress.ip_network(entry, strict=True)
+        except ValueError as exc:
+            raise ValueError(f"'{entry}' is not a valid IPv6 prefix: {exc}") from exc
+        if network.version != 6:
+            raise ValueError(f"'{entry}' is not an IPv6 prefix.")
+        if network.prefixlen == 0:
+            # ::/0 is the whole address space, not something Kea can delegate.
+            raise ValueError(f"'{entry}' has no prefix length — a delegated prefix is /1 to /128.")
+        canonical = str(network)
+        if canonical not in prefixes:
+            prefixes.append(canonical)
+    if len(prefixes) > MAX_DELEGATED_PREFIXES:
+        raise ValueError(f"At most {MAX_DELEGATED_PREFIXES} delegated prefixes per reservation.")
+    return prefixes
 
 
 _KNOWN_CODES_V4: dict[int, str] = {
@@ -279,17 +367,93 @@ def _parse_int_row_field(row: dict, field: str, row_num: int) -> int:
         raise ValueError(f"Row {row_num}: '{field}' must be an integer, got '{row.get(field, '')}'") from None
 
 
+#: Reservation CSV columns that are not identifier columns, per DHCP version.
+_RESERVATION_CSV_COLUMNS: dict[int, frozenset[str]] = {
+    4: frozenset({"subnet-id", "hostname", "ip-address"}),
+    6: frozenset({"subnet-id", "hostname", "ip-addresses", "prefixes"}),
+}
+
+
+def _reservation_csv_identifier(
+    row: dict[str, str], row_num: int, identifier_types: tuple[str, ...]
+) -> tuple[str, str]:
+    """Return the one identifier a reservation row supplies, validated."""
+    supplied = [name for name in identifier_types if row.get(name)]
+    if not supplied:
+        raise ValueError(f"Row {row_num}: no client identifier — supply exactly one of {', '.join(identifier_types)}")
+    if len(supplied) > 1:
+        # The edit view writes a single identifier key, so importing two would
+        # create a host the UI cannot round-trip.
+        raise ValueError(
+            f"Row {row_num}: ambiguous identifier — {' and '.join(supplied)} were both given, "
+            "but a reservation carries exactly one"
+        )
+    identifier_type = supplied[0]
+    try:
+        return identifier_type, validate_reservation_identifier(identifier_type, row[identifier_type])
+    except ValueError as exc:
+        raise ValueError(f"Row {row_num}: invalid {identifier_type} '{row[identifier_type]}': {exc}") from exc
+
+
+def _reservation_csv_reserved(row: dict[str, str], row_num: int, version: int) -> dict[str, Any]:
+    """Return the address/prefix keys a reservation row reserves, if any.
+
+    Empty when the row reserves nothing but a hostname, options or client classes;
+    the caller omits the keys rather than sending Kea an empty value.
+    """
+    if version == 4:
+        if not row.get("ip-address"):
+            return {}
+        try:
+            addr = ipaddress.ip_address(row["ip-address"])
+        except ValueError:
+            raise ValueError(f"Row {row_num}: invalid IPv4 address '{row['ip-address']}'") from None
+        if addr.version != 4:
+            raise ValueError(f"Row {row_num}: '{row['ip-address']}' is not an IPv4 address")
+        return {"ip-address": row["ip-address"]}
+
+    reserved: dict[str, Any] = {}
+    ip_addresses = [entry.strip() for entry in row.get("ip-addresses", "").split(";") if entry.strip()]
+    for raw_addr in ip_addresses:
+        try:
+            addr = ipaddress.ip_address(raw_addr)
+        except ValueError:
+            raise ValueError(f"Row {row_num}: invalid IPv6 address '{raw_addr}'") from None
+        if addr.version != 6:
+            raise ValueError(f"Row {row_num}: '{raw_addr}' is not an IPv6 address")
+    if ip_addresses:
+        reserved["ip-addresses"] = ip_addresses
+    try:
+        prefixes = parse_delegated_prefixes(row.get("prefixes", ""), separator=";")
+    except ValueError as exc:
+        raise ValueError(f"Row {row_num}: {exc}") from exc
+    if prefixes:
+        reserved["prefixes"] = prefixes
+    return reserved
+
+
 def parse_reservation_csv(content: str, version: int) -> list[dict[str, Any]]:
     """Parse a CSV string into a list of reservation dicts ready for ``reservation_add``.
 
-    Strips UTF-8 BOM, skips blank lines and lines starting with ``#``.
-    Raises ``ValueError`` on missing required fields (message includes 1-indexed row number).
+    Strips UTF-8 BOM, skips blank lines and lines starting with ``#``.  Every error
+    message names the 1-indexed row it came from.
 
-    **v4 required columns**: ``ip-address``, ``hw-address``, ``subnet-id``
-    (``hostname`` is optional)
+    Each row needs ``subnet-id`` and **exactly one** identifier column from the set
+    its DHCP version supports (``hw-address``, ``client-id``, ``circuit-id``,
+    ``flex-id``, ``remote-id`` for v4; ``duid`` in place of ``circuit-id`` for v6).
+    Exactly one, not at least one: the edit view strips every other identifier key
+    before writing, so a multi-identifier host would import into a shape the UI
+    cannot round-trip.
 
-    **v6 required columns**: ``ip-addresses``, ``duid``, ``subnet-id``
-    (``hostname`` is optional)
+    The address is optional.  A v4 host may reserve only a hostname, options or
+    client classes, and a v6 host may delegate prefixes without reserving an
+    address — Kea accepts both, and demanding one here would make the importer
+    stricter than the server it writes to.
+
+    Optional columns: ``hostname``; ``ip-address`` (v4); ``ip-addresses`` and
+    ``prefixes`` (v6, both semicolon-separated).  Identifier and prefix validation
+    are shared with the interactive forms, so a file cannot import what the form
+    would reject.
 
     Args:
         content: Raw CSV text (may include BOM).
@@ -299,13 +463,16 @@ def parse_reservation_csv(content: str, version: int) -> list[dict[str, Any]]:
         List of dicts suitable for passing to :py:meth:`KeaClient.reservation_add`.
 
     Raises:
-        ValueError: If a required field is missing or empty for any row.
+        ValueError: On an unsupported version, or any row that is missing
+            ``subnet-id``, does not carry exactly one identifier, fails validation,
+            or supplies a column this parser does not understand.
 
     """
-    if version == 4:
-        required = {"ip-address", "hw-address", "subnet-id"}
-    else:
-        required = {"ip-addresses", "duid", "subnet-id"}
+    if version not in _RESERVATION_CSV_COLUMNS:
+        raise ValueError(f"Unsupported DHCP version {version!r} — expected 4 or 6.")
+
+    identifier_types = constants.RESERVATION_IDENTIFIER_TYPES[version]
+    known_columns = _RESERVATION_CSV_COLUMNS[version] | set(identifier_types)
 
     content = content.lstrip("\ufeff")  # strip UTF-8 BOM
     reader = csv.DictReader(
@@ -314,40 +481,26 @@ def parse_reservation_csv(content: str, version: int) -> list[dict[str, Any]]:
 
     rows: list[dict[str, Any]] = []
     for row_num, raw in enumerate(reader, start=2):  # header is row 1
+        # DictReader files cells with no header under the None key.  They carry data
+        # this parser never reads, so reject the row rather than drop them.
+        if raw.get(None):
+            raise ValueError(f"Row {row_num}: more values than the header has columns")
         row = {k.strip(): (v or "").strip() for k, v in raw.items() if k is not None}
 
-        for field in required:
-            if not row.get(field):
-                raise ValueError(f"Row {row_num}: missing required field '{field}'")
+        unknown = sorted(name for name, value in row.items() if value and name not in known_columns)
+        if unknown:
+            raise ValueError(
+                f"Row {row_num}: unrecognised column(s) {', '.join(unknown)} — "
+                f"accepted: {', '.join(sorted(known_columns))}"
+            )
 
+        if not row.get("subnet-id"):
+            raise ValueError(f"Row {row_num}: missing required field 'subnet-id'")
         result: dict[str, Any] = {"subnet-id": _parse_int_row_field(row, "subnet-id", row_num)}
 
-        if version == 4:
-            try:
-                addr = ipaddress.ip_address(row["ip-address"])
-            except ValueError:
-                raise ValueError(f"Row {row_num}: invalid IPv4 address '{row['ip-address']}'")
-            if addr.version != 4:
-                raise ValueError(f"Row {row_num}: '{row['ip-address']}' is not an IPv4 address")
-            result["ip-address"] = row["ip-address"]
-            if not is_hex_string(row["hw-address"], 6, 6):
-                raise ValueError(f"Row {row_num}: invalid MAC address '{row['hw-address']}'")
-            result["hw-address"] = row["hw-address"]
-        else:
-            ip_addresses = [addr.strip() for addr in row["ip-addresses"].split(";") if addr.strip()]
-            if not ip_addresses:
-                raise ValueError(f"Row {row_num}: 'ip-addresses' must contain at least one valid address")
-            for raw_addr in ip_addresses:
-                try:
-                    addr = ipaddress.ip_address(raw_addr)
-                except ValueError:
-                    raise ValueError(f"Row {row_num}: invalid IPv6 address '{raw_addr}'")
-                if addr.version != 6:
-                    raise ValueError(f"Row {row_num}: '{raw_addr}' is not an IPv6 address")
-            result["ip-addresses"] = ip_addresses
-            if not is_hex_string(row["duid"], constants.DUID_MIN_OCTETS, constants.DUID_MAX_OCTETS):
-                raise ValueError(f"Row {row_num}: invalid DUID '{row['duid']}'")
-            result["duid"] = row["duid"]
+        identifier_type, identifier = _reservation_csv_identifier(row, row_num, identifier_types)
+        result[identifier_type] = identifier
+        result.update(_reservation_csv_reserved(row, row_num, version))
 
         if row.get("hostname"):
             result["hostname"] = row["hostname"]

--- a/netbox_kea/views/__init__.py
+++ b/netbox_kea/views/__init__.py
@@ -75,10 +75,14 @@ from .options import (  # noqa: F401
 # Reservation list/add/edit/delete views + helpers
 from .reservations import (  # noqa: F401
     ServerReservation4AddView,
+    ServerReservation4DeleteByIdentifierView,
     ServerReservation4DeleteView,
+    ServerReservation4EditByIdentifierView,
     ServerReservation4EditView,
     ServerReservation6AddView,
+    ServerReservation6DeleteByIdentifierView,
     ServerReservation6DeleteView,
+    ServerReservation6EditByIdentifierView,
     ServerReservation6EditView,
     ServerReservations4View,
     ServerReservations6View,

--- a/netbox_kea/views/combined.py
+++ b/netbox_kea/views/combined.py
@@ -25,6 +25,8 @@ from .reservations import (
     _attach_reservation_action_urls,
     _enrich_reservations_with_badges,
     _filter_reservations,
+    _normalise_reservation_identifier,
+    _normalise_reservation_prefixes,
 )
 
 logger = logging.getLogger(__name__)
@@ -484,6 +486,9 @@ def _fetch_reservations_from_server(server: "Server", version: int) -> list[dict
         r.setdefault("ip_address", r.get("ip-address", r.get("ip-addresses", [""])[0] if r.get("ip-addresses") else ""))
         r["server_name"] = server.name
         r["server_pk"] = server.pk
+        _normalise_reservation_identifier(r, version)
+        if version == 6:
+            _normalise_reservation_prefixes(r)
         _enrich_reservation_sort_key(r)
         reservations.append(r)
     return reservations

--- a/netbox_kea/views/combined.py
+++ b/netbox_kea/views/combined.py
@@ -21,7 +21,11 @@ from ..utilities import (
 )
 from ._base import ConditionalLoginRequiredMixin
 from .leases import _enrich_leases_with_badges
-from .reservations import _enrich_reservations_with_badges, _filter_reservations
+from .reservations import (
+    _attach_reservation_action_urls,
+    _enrich_reservations_with_badges,
+    _filter_reservations,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -525,6 +529,8 @@ class _CombinedReservationsView(_CombinedViewMixin):
                 can_change = server_pk in writable_pks
                 for r in server_records:
                     r["can_change"] = can_change
+                # Per-server so a row can never be given another server's URL.
+                _attach_reservation_action_urls(server_records, server_pk, self.dhcp_version, can_change=can_change)
 
         search_form = forms.ReservationSearchForm(request.GET or None)
         if search_form.is_valid():

--- a/netbox_kea/views/reservations.py
+++ b/netbox_kea/views/reservations.py
@@ -10,7 +10,7 @@ from django.db.utils import OperationalError, ProgrammingError
 from django.http import Http404, HttpResponse
 from django.http.request import HttpRequest
 from django.shortcuts import redirect, render
-from django.urls import reverse
+from django.urls import NoReverseMatch, reverse
 from netbox.views import generic
 from utilities.views import register_model_view
 
@@ -402,6 +402,7 @@ class ServerReservations4View(generic.ObjectView):
         _enrich_reservations_with_badges(reservations, server, 4, can_change=can_change)
         for r in reservations:
             r["can_change"] = can_change
+        _attach_reservation_action_urls(reservations, server.pk, 4, can_change=can_change)
 
         table = tables.ReservationTable4(reservations, user=request.user)
         table.configure(request)
@@ -477,6 +478,7 @@ class ServerReservations6View(generic.ObjectView):
         _enrich_reservations_with_badges(reservations, server, 6, can_change=can_change)
         for r in reservations:
             r["can_change"] = can_change
+        _attach_reservation_action_urls(reservations, server.pk, 6, can_change=can_change)
 
         table = tables.ReservationTable6(reservations, user=request.user)
         table.configure(request)
@@ -1198,6 +1200,55 @@ def _get_reservation_identifier(
         if reservation.get(itype):
             return itype, reservation[itype]
     return "hw-address", ""
+
+
+def _attach_reservation_action_urls(
+    reservations: list[dict[str, Any]],
+    server_pk: int,
+    version: int,
+    *,
+    can_change: bool,
+) -> None:
+    """In-place: set ``edit_url`` / ``delete_url`` on each reservation row.
+
+    These URLs are built here rather than with ``{% url %}`` in the table's actions
+    column on purpose.  Kea omits ``ip-address`` for a reservation that reserves no
+    address (an identifier-only host, or a DHCPv6 prefix-delegation-only host), which
+    normalises to ``ip_address=""``.  The address-keyed route takes ``<str:ip_address>``
+    (``[^/]+``) and cannot reverse an empty string, so the template tag raised
+    ``NoReverseMatch`` and a single such row 500'd the whole table (issue #110).  In
+    Python the guard is an ordinary conditional and a row that cannot be addressed
+    simply gets no action buttons.
+
+    Both keys are always assigned: these dicts come straight from Kea and are mutated
+    in place, so leaving them unset would let an unrelated value reach the template.
+    *server_pk* is passed by the caller rather than read from the row so the combined
+    (multi-server) view cannot mint a URL pointing at the wrong server.
+
+    The reversal is attempted rather than pre-validated: the route converters
+    (``<int:subnet_id>``, ``<str:ip_address>``) are the authority on what fits, and
+    guessing at them in Python both rejects values they accept (a decimal *string*
+    subnet id reverses fine) and misses ones they reject (a negative subnet id, an
+    address containing ``/``). A row whose values do not fit the route loses its
+    buttons instead of taking the page down with it.
+    """
+    for r in reservations:
+        r["edit_url"] = None
+        r["delete_url"] = None
+        if not can_change:
+            continue
+        ip_address = r.get("ip_address") or ""
+        if not ip_address:
+            continue
+        args = [server_pk, r.get("subnet_id", r.get("subnet-id")), ip_address]
+        try:
+            edit_url = reverse(f"plugins:netbox_kea:server_reservation{version}_edit", args=args)
+            delete_url = reverse(f"plugins:netbox_kea:server_reservation{version}_delete", args=args)
+        except NoReverseMatch:
+            logger.debug("No reservation action URL for subnet-id=%r ip=%r", args[1], ip_address)
+            continue
+        r["edit_url"] = edit_url
+        r["delete_url"] = delete_url
 
 
 def _enrich_reservations_with_badges(

--- a/netbox_kea/views/reservations.py
+++ b/netbox_kea/views/reservations.py
@@ -1,10 +1,12 @@
 import concurrent.futures
 import logging
+from dataclasses import dataclass
 from typing import Any
+from urllib.parse import urlencode
 
 import requests
 from django.contrib import messages
-from django.core.exceptions import ValidationError
+from django.core.exceptions import BadRequest, ValidationError
 from django.db import DatabaseError
 from django.db.utils import OperationalError, ProgrammingError
 from django.http import Http404, HttpResponse
@@ -14,7 +16,7 @@ from django.urls import NoReverseMatch, reverse
 from netbox.views import generic
 from utilities.views import register_model_view
 
-from .. import forms, tables
+from .. import constants, forms, tables
 from ..kea import KeaClient, KeaException, PartialPersistError, iter_reservations
 from ..models import Server
 from ..signals import reservation_created, reservation_deleted, reservation_updated
@@ -43,11 +45,174 @@ _ALL_IDENTIFIER_KEYS: tuple[str, ...] = (
     "remote-id",
 )
 
-#: Identifier types supported for DHCPv4 reservations (preference order).
-_V4_IDENTIFIER_TYPES: list[str] = ["hw-address", "client-id", "circuit-id", "flex-id", "remote-id"]
+#: Identifier types supported per DHCP version, in preference order.  Shared with the
+#: forms and the CSV importer so all three accept the same set.
+_V4_IDENTIFIER_TYPES: tuple[str, ...] = constants.RESERVATION_IDENTIFIER_TYPES[4]
+_V6_IDENTIFIER_TYPES: tuple[str, ...] = constants.RESERVATION_IDENTIFIER_TYPES[6]
 
-#: Identifier types supported for DHCPv6 reservations (preference order).
-_V6_IDENTIFIER_TYPES: list[str] = ["duid", "hw-address", "client-id", "flex-id", "remote-id"]
+
+@dataclass(frozen=True)
+class _ReservationLookup:
+    """How to address one reservation in Kea: by IP, or by client identifier.
+
+    A host reservation that reserves no address cannot be keyed by IP — the whole
+    reason issue #110 existed — so edit and delete additionally accept an identifier
+    key.  ``KeaClient.reservation_get``/``reservation_del`` already accept either.
+    """
+
+    subnet_id: int
+    ip_address: str = ""
+    identifier_type: str = ""
+    identifier: str = ""
+
+    @property
+    def by_identifier(self) -> bool:
+        """True when this lookup keys on the client identifier rather than an address."""
+        return not self.ip_address
+
+    @property
+    def label(self) -> str:
+        """Human-readable subject for messages and confirmation pages."""
+        if self.ip_address:
+            return self.ip_address
+        return f"{self.identifier_type} {self.identifier}"
+
+    def to_kwargs(self) -> dict[str, Any]:
+        """Return the ``reservation_get`` / ``reservation_del`` keyword arguments."""
+        if self.ip_address:
+            return {"subnet_id": self.subnet_id, "ip_address": self.ip_address}
+        return {
+            "subnet_id": self.subnet_id,
+            "identifier_type": self.identifier_type,
+            "identifier": self.identifier,
+        }
+
+
+def _identifier_lookup_from_request(request: HttpRequest, subnet_id: int, version: int) -> _ReservationLookup:
+    """Build an identifier-keyed lookup from the query string, or raise ``BadRequest``.
+
+    The identifier travels as a query parameter rather than a path segment: reversing
+    then takes only integers (so the route can never fail to reverse, which is what
+    took the reservations tab down), and ``urlencode`` handles values a ``<str:>``
+    segment would mangle — Django treats ``/`` as safe when reversing, so a ``flex-id``
+    containing one would silently produce a broken URL.
+
+    Everything the view will forward to Kea is validated here so all four routes
+    behave identically on malformed input.
+    """
+    allowed = _V6_IDENTIFIER_TYPES if version == 6 else _V4_IDENTIFIER_TYPES
+    types = request.GET.getlist("identifier_type")
+    values = request.GET.getlist("identifier")
+    if len(types) != 1 or len(values) != 1:
+        raise BadRequest("Exactly one identifier_type and one identifier query parameter are required.")
+    identifier_type, identifier = types[0].strip(), values[0].strip()
+    if not identifier_type or not identifier:
+        raise BadRequest("identifier_type and identifier must not be empty.")
+    if identifier_type not in allowed:
+        raise BadRequest(f"Unsupported identifier type for DHCPv{version}.")
+    if len(identifier) > constants.max_identifier_length(identifier_type):
+        raise BadRequest("Identifier is too long.")
+    return _ReservationLookup(subnet_id=subnet_id, identifier_type=identifier_type, identifier=identifier)
+
+
+def _apply_v6_addresses_and_prefixes(reservation: dict[str, Any], cleaned_data: dict[str, Any]) -> None:
+    """Write the submitted addresses and delegated prefixes onto *reservation*.
+
+    A blank field removes the key rather than writing an empty list, so a DHCPv6
+    reservation can drop its addresses (becoming prefix-only) or its prefixes without
+    Kea being sent an empty collection.  Disabled fields resolve to their initial
+    value, so on the IP-keyed route this writes back what was reloaded from Kea.
+    """
+    addresses = [ip.strip() for ip in (cleaned_data.get("ip_addresses") or "").split(",") if ip.strip()]
+    if addresses:
+        reservation["ip-addresses"] = addresses
+    else:
+        reservation.pop("ip-addresses", None)
+    prefixes = [prefix.strip() for prefix in (cleaned_data.get("prefixes") or "").split(",") if prefix.strip()]
+    if prefixes:
+        reservation["prefixes"] = prefixes
+    else:
+        reservation.pop("prefixes", None)
+
+
+def _deleted_journal_entry(lookup: _ReservationLookup) -> dict[str, Any]:
+    """Journal payload describing which reservation was deleted.
+
+    An identifier-keyed delete has no address to record, so the identifier goes in
+    instead — otherwise the entry would not say what was removed.
+    """
+    entry: dict[str, Any] = {"subnet-id": lookup.subnet_id}
+    if lookup.ip_address:
+        entry["ip-address"] = lookup.ip_address
+    if lookup.identifier:
+        entry[lookup.identifier_type] = lookup.identifier
+    return entry
+
+
+def _send_reservation_deleted(
+    server: "Server",
+    lookup: _ReservationLookup,
+    version: int,
+    request: HttpRequest,
+) -> None:
+    """Fire ``reservation_deleted`` with the same kwargs regardless of route.
+
+    Receivers get ``ip_address``, ``identifier_type`` and ``identifier`` on every
+    delete, each ``None`` where it does not apply, rather than a payload whose shape
+    depends on which URL the operator happened to use.
+    """
+    reservation_deleted.send_robust(
+        sender=None,
+        server=server,
+        ip_address=lookup.ip_address or None,
+        identifier_type=lookup.identifier_type or None,
+        identifier=lookup.identifier or None,
+        dhcp_version=version,
+        request=request,
+    )
+
+
+class _ReservationLookupMixin:
+    """Shared addressing and field-freezing policy for the edit/delete views.
+
+    Routes differ only in how they address a reservation and which form fields that
+    makes immutable, so both are class attributes rather than branches:
+
+    - IP-keyed routes freeze the address along with the subnet and identifier, as
+      they always have.
+    - Identifier-keyed routes freeze the subnet and identifier only, leaving the
+      address editable — Kea's ``reservation-update`` replaces the whole host keyed
+      by identifier, so a reservation can gain or lose its fixed address without the
+      URL that addresses it changing.
+    """
+
+    #: 4 or 6; set by each concrete view.
+    dhcp_version: int = 4
+    #: Form fields this route fixes and the user may not change.  Empty on the delete
+    #: views, which have no form.
+    immutable_fields: frozenset[str] = frozenset()
+    #: Identifier-keyed subclasses flip this; the base routes key on the address.
+    lookup_by_identifier: bool = False
+
+    def get_lookup(self, request: HttpRequest, subnet_id: int, **kwargs) -> _ReservationLookup:
+        """Return how this route addresses the reservation."""
+        if self.lookup_by_identifier:
+            return _identifier_lookup_from_request(request, subnet_id, self.dhcp_version)
+        return _ReservationLookup(subnet_id=subnet_id, ip_address=kwargs["ip_address"])
+
+    def apply_immutable_fields(self, form) -> None:
+        """Disable the fields this route fixes.
+
+        Django resolves a disabled field to its ``initial`` value and ignores what the
+        browser submitted, which is what stops a hand-crafted POST from changing the
+        key the URL addresses.  Callers must seed ``initial`` first.
+        """
+        for name in self.immutable_fields:
+            # A stale name here would silently stop freezing a key field.
+            if name not in form.fields:
+                raise KeyError(f"{type(self).__name__}.immutable_fields names unknown form field {name!r}")
+            form.fields[name].disabled = True
+
 
 #: All known identifier keys (hyphen and underscore variants) for journal
 #: log extraction — includes normalised forms that Kea may return after
@@ -89,6 +254,26 @@ def _build_reservation_options_formset(post_data: Any) -> tuple[Any, bool]:
         fs.is_valid()  # populate errors so the template can show management-form error
         return fs, False
     return forms.ReservationOptionsFormSet(prefix="options"), True
+
+
+def _merge_reservation_option_data(reservation: dict[str, Any], options_formset: Any) -> None:
+    """Apply the submitted options formset onto *reservation* in place.
+
+    An unbound formset, or a bound one reporting no initial and no submitted forms, means the
+    options section was not part of this submission, so existing ``option-data`` is left alone.
+    """
+    option_data = [
+        {"name": f["name"], "data": f["data"], **({"always-send": True} if f.get("always_send") else {})}
+        for f in (getattr(options_formset, "cleaned_data", []) or [])
+        if f and f.get("name") and not f.get("DELETE")
+    ]
+    submitted = bool(options_formset.is_bound) and bool(
+        options_formset.total_form_count() or options_formset.initial_form_count()
+    )
+    if option_data:
+        reservation["option-data"] = option_data
+    elif submitted or not reservation.get("option-data"):
+        reservation.pop("option-data", None)
 
 
 def _add_reservation_journal(server: "Server", user: Any, action: str, reservation: dict) -> None:
@@ -164,7 +349,14 @@ def _run_reservation_success_side_effects(
         dhcp_version=dhcp_version,
         request=request,
     )
-    if sync_to_netbox and not (
+    _v4_ip = reservation.get("ip-address") or ""
+    _v6_ips = reservation.get("ip-addresses")
+    has_address = bool(_v4_ip) or bool(isinstance(_v6_ips, list) and _v6_ips)
+    if sync_to_netbox and not has_address:
+        # Checked before the permission test: there is nothing to write to IPAM, so
+        # "requires IPAM permission" would be a misleading reason to report.
+        messages.info(request, f"Reservation {action}. Nothing to sync to NetBox — it reserves no IP address.")
+    elif sync_to_netbox and not (
         request.user.has_perm("ipam.add_ipaddress") and request.user.has_perm("ipam.change_ipaddress")
     ):
         # The sync below uses force=True, overriding the foreign-IP guard and
@@ -173,8 +365,6 @@ def _run_reservation_success_side_effects(
         logger.warning("User %r ticked sync-to-NetBox without IPAM write permission — sync skipped", request.user)
         messages.warning(request, f"Reservation {action}, but it was not synced to NetBox (requires IPAM permission).")
     elif sync_to_netbox:
-        _v4_ip = reservation.get("ip-address") or ""
-        _v6_ips = reservation.get("ip-addresses")
         if isinstance(_v6_ips, list) and len(_v6_ips) > 1:
             ip_label = f"{len(_v6_ips)} addresses"
         else:
@@ -192,6 +382,50 @@ def _run_reservation_success_side_effects(
         messages.warning(request, "Change applied but may not survive a Kea restart (config-write failed).")
 
 
+#: Lease keys that carry a client identifier, per DHCP version.  A DHCPv4 lease reports
+#: ``hw-address`` and ``client-id``; a DHCPv6 lease reports ``duid`` and, when Kea could
+#: derive one, ``hw-address``.  The opaque identifiers (circuit-id, flex-id, remote-id)
+#: appear on no lease, so a reservation keyed by one has nothing to match on.
+_LEASE_IDENTIFIER_KEYS: dict[int, tuple[str, ...]] = {
+    4: ("hw-address", "client-id"),
+    6: ("duid", "hw-address"),
+}
+
+_HEX_DIGITS = frozenset("0123456789abcdef")
+
+
+def _normalise_identifier_value(value: Any) -> str:
+    """Return *value* as lower-case colon-delimited hex octets, or ``""`` if it is not hex.
+
+    Kea and the operator write the same identifier several ways ("AA-BB-CC", "aabbcc"),
+    so both sides of an identifier match go through this.
+    """
+    if not isinstance(value, str):
+        return ""
+    compact = value.replace(":", "").replace("-", "").lower()
+    if not compact or len(compact) % 2 or not set(compact) <= _HEX_DIGITS:
+        return ""
+    return ":".join(compact[i : i + 2] for i in range(0, len(compact), 2))
+
+
+def _lease_identifiers(lease: dict[str, Any], version: int) -> set[str]:
+    """Return the normalised client identifiers *lease* carries."""
+    found = {_normalise_identifier_value(lease.get(key)) for key in _LEASE_IDENTIFIER_KEYS[version]}
+    found.discard("")
+    return found
+
+
+def _reservation_lease_identifier(reservation: dict[str, Any], version: int) -> str:
+    """Return the normalised identifier this reservation can be matched to a lease by.
+
+    Empty when the reservation is keyed by something no lease reports.
+    """
+    identifier_type, identifier = _get_reservation_identifier(reservation, version)
+    if identifier_type not in _LEASE_IDENTIFIER_KEYS[version]:
+        return ""
+    return _normalise_identifier_value(identifier)
+
+
 def _enrich_reservations_with_lease_status(client: "KeaClient", reservations: list[dict], version: int) -> None:  # noqa: C901
     """Enrich each reservation dict with ``has_active_lease`` (bool | None).
 
@@ -200,6 +434,10 @@ def _enrich_reservations_with_lease_status(client: "KeaClient", reservations: li
     reservation.  Leaves ``has_active_lease`` unset (None) if the ``lease_cmds``
     hook is unavailable or an unexpected error occurs, so the template can
     distinguish "unknown" from "no lease".
+
+    A reservation that reserves no address has no IP to match a lease on, so it is
+    matched by client identifier instead — within its own subnet only, since the same
+    client holding a lease in another subnet is a different reservation's row.
 
     Args:
         client: Connected KeaClient for the server.
@@ -215,10 +453,12 @@ def _enrich_reservations_with_lease_status(client: "KeaClient", reservations: li
     unique_subnet_ids = {r.get("subnet-id") for r in reservations if isinstance(r.get("subnet-id"), (int, str))}
 
     active_lease_ips: set[str] = set()
+    # Normalised lease identifiers per subnet, for the address-less rows.
+    subnet_lease_identifiers: dict[Any, set[str]] = {}
     hook_unavailable = False
 
-    def _fetch_leases_for_subnet(sid: int) -> list[str] | None | bool:
-        """Return list of lease IPs, None if the lease_cmds hook is not loaded, or False on error."""
+    def _fetch_leases_for_subnet(sid: int) -> tuple[list[str], set[str]] | None | bool:
+        """Return (lease IPs, client identifiers), None if the lease_cmds hook is not loaded, or False on error."""
         with client.clone() as worker_client:  # requests.Session is not thread-safe
             try:
                 resp = worker_client.command(
@@ -237,8 +477,12 @@ def _enrich_reservations_with_lease_status(client: "KeaClient", reservations: li
                     leases = args.get("leases") or []
                     if not isinstance(leases, list):
                         return False  # malformed payload — indeterminate state
-                    return [lease.get("ip-address", "") for lease in leases if isinstance(lease, dict)]
-                return []
+                    valid = [lease for lease in leases if isinstance(lease, dict)]
+                    identifiers: set[str] = set()
+                    for lease in valid:
+                        identifiers |= _lease_identifiers(lease, version)
+                    return [lease.get("ip-address", "") for lease in valid], identifiers
+                return [], set()
             except KeaException as exc:
                 if exc.response.get("result") == 2:
                     return None  # hook not loaded
@@ -263,8 +507,9 @@ def _enrich_reservations_with_lease_status(client: "KeaClient", reservations: li
                 elif result is False:
                     indeterminate_subnet_ids.add(sid)
                 else:
-                    for ip in result:
-                        active_lease_ips.add(ip)
+                    ips, identifiers = result
+                    active_lease_ips.update(ips)
+                    subnet_lease_identifiers.setdefault(sid, set()).update(identifiers)
     except Exception:  # noqa: BLE001
         logger.debug("Enrichment task failed", exc_info=True)
         return
@@ -286,7 +531,12 @@ def _enrich_reservations_with_lease_status(client: "KeaClient", reservations: li
         raw_ips = r.get("ip-addresses")
         if isinstance(raw_ips, list):
             addrs.extend(raw_ips)
-        r["has_active_lease"] = any(a in active_lease_ips for a in addrs)
+        if addrs:
+            r["has_active_lease"] = any(a in active_lease_ips for a in addrs)
+            continue
+        identifier = _reservation_lease_identifier(r, version)
+        in_own_subnet = subnet_lease_identifiers.get(subnet_id_r) or frozenset()
+        r["has_active_lease"] = bool(identifier) and identifier in in_own_subnet
 
 
 def _filter_reservations(
@@ -385,6 +635,7 @@ class ServerReservations4View(generic.ObjectView):
             r["server_pk"] = server.pk
             r.setdefault("ip_address", r.get("ip-address", ""))
             r.setdefault("subnet_id", r.get("subnet-id", 0))
+            _normalise_reservation_identifier(r, 4)
             _enrich_reservation_sort_key(r)
 
         # Apply search filter before enrichment to avoid unnecessary Kea API calls.
@@ -461,6 +712,8 @@ class ServerReservations6View(generic.ObjectView):
             r["ip_address"] = ip_addrs[0] if ip_addrs else ""
             r["extra_ips"] = ip_addrs[1:]
             r.setdefault("subnet_id", r.get("subnet-id", 0))
+            _normalise_reservation_identifier(r, 6)
+            _normalise_reservation_prefixes(r)
             _enrich_reservation_sort_key(r)
 
         # Apply search filter before enrichment to avoid unnecessary Kea API calls.
@@ -537,9 +790,12 @@ class ServerReservation4AddView(_KeaChangeMixin, generic.ObjectView):
             cd = form.cleaned_data
             reservation = {
                 "subnet-id": cd["subnet_id"],
-                "ip-address": cd["ip_address"],
                 cd["identifier_type"]: cd["identifier"],
             }
+            # Omit the key entirely rather than sending an empty address: a host may
+            # legally reserve only a hostname, options or client classes.
+            if cd.get("ip_address"):
+                reservation["ip-address"] = cd["ip_address"]
             if cd.get("hostname"):
                 reservation["hostname"] = cd["hostname"]
             option_data = [
@@ -567,14 +823,17 @@ class ServerReservation4AddView(_KeaChangeMixin, generic.ObjectView):
                         "tab": self.tab,
                     },
                 )
-            # Advisory warning when the reservation IP is inside an existing pool (non-fatal)
-            try:
-                _warn_reservation_pool_overlap(request, client, 4, cd["subnet_id"], cd["ip_address"])
-            except Exception:  # noqa: BLE001
-                logger.debug("Pool overlap check failed for %s", cd.get("ip_address"), exc_info=True)
+            # Advisory warning when the reservation IP is inside an existing pool (non-fatal).
+            # Nothing to check when the reservation has no address.
+            if cd.get("ip_address"):
+                try:
+                    _warn_reservation_pool_overlap(request, client, 4, cd["subnet_id"], cd["ip_address"])
+                except Exception:  # noqa: BLE001
+                    logger.debug("Pool overlap check failed for %s", cd.get("ip_address"), exc_info=True)
+            subject = cd.get("ip_address") or f"{cd['identifier_type']} {cd['identifier']}"
             try:
                 client.reservation_add("dhcp4", reservation)
-                messages.success(request, f"Reservation for {cd['ip_address']} created.")
+                messages.success(request, f"Reservation for {subject} created.")
                 _run_reservation_success_side_effects(
                     request, server, reservation, 4, "created", bool(cd.get("sync_to_netbox"))
                 )
@@ -620,7 +879,7 @@ class ServerReservation6AddView(_KeaChangeMixin, generic.ObjectView):
         server = self.get_object(pk=pk)
         initial = {
             k: request.GET.get(k, "")
-            for k in ("subnet_id", "ip_addresses", "identifier_type", "identifier", "hostname")
+            for k in ("subnet_id", "ip_addresses", "prefixes", "identifier_type", "identifier", "hostname")
         }
         initial = {k: v for k, v in initial.items() if v}
         return render(
@@ -647,9 +906,11 @@ class ServerReservation6AddView(_KeaChangeMixin, generic.ObjectView):
             cd = form.cleaned_data
             reservation: dict[str, Any] = {
                 "subnet-id": cd["subnet_id"],
-                "ip-addresses": [ip.strip() for ip in cd["ip_addresses"].split(",") if ip.strip()],
                 cd["identifier_type"]: cd["identifier"],
             }
+            # Omit empty collections rather than sending them: a DHCPv6 host may
+            # reserve only delegated prefixes, or only a hostname and options.
+            _apply_v6_addresses_and_prefixes(reservation, cd)
             if cd.get("hostname"):
                 reservation["hostname"] = cd["hostname"]
             option_data = [
@@ -720,33 +981,37 @@ class ServerReservation6AddView(_KeaChangeMixin, generic.ObjectView):
         )
 
 
-class ServerReservation4EditView(_KeaChangeMixin, generic.ObjectView):
-    """Edit an existing DHCPv4 host reservation."""
+class ServerReservation4EditView(_ReservationLookupMixin, _KeaChangeMixin, generic.ObjectView):
+    """Edit an existing DHCPv4 host reservation, addressed by IP."""
 
     queryset = Server.objects.all()
     template_name = "netbox_kea/server_reservation_form.html"
     tab = _RESERVATIONS_TAB
+    dhcp_version = 4
+    immutable_fields = frozenset({"subnet_id", "ip_address", "identifier_type", "identifier"})
 
-    def _get_reservation(self, server: Server, subnet_id: int, ip_address: str) -> dict | None:
+    def _get_reservation(self, server: Server, lookup: _ReservationLookup) -> dict | None:
         client = server.get_client(version=4)
-        return client.reservation_get("dhcp4", subnet_id=subnet_id, ip_address=ip_address)
+        return client.reservation_get("dhcp4", **lookup.to_kwargs())
 
-    def get(self, request: HttpRequest, pk: int, subnet_id: int, ip_address: str) -> HttpResponse:
+    def get(self, request: HttpRequest, pk: int, subnet_id: int, **kwargs) -> HttpResponse:
         """Pre-populate form with existing reservation data."""
         server = self.get_object(pk=pk)
+        lookup = self.get_lookup(request, subnet_id, **kwargs)
+        ip_address = lookup.ip_address
         return_url = reverse("plugins:netbox_kea:server_reservations4", args=[pk])
         try:
-            reservation = self._get_reservation(server, subnet_id, ip_address)
+            reservation = self._get_reservation(server, lookup)
         except KeaException as exc:
-            logger.exception("Failed to fetch DHCPv4 reservation %s in subnet %s", ip_address, subnet_id)
+            logger.exception("Failed to fetch DHCPv4 reservation %s in subnet %s", lookup.label, subnet_id)
             messages.error(request, kea_error_hint(exc))
             return redirect(return_url)
         except (requests.RequestException, ValueError):
-            logger.exception("Failed to fetch DHCPv4 reservation %s in subnet %s", ip_address, subnet_id)
+            logger.exception("Failed to fetch DHCPv4 reservation %s in subnet %s", lookup.label, subnet_id)
             messages.error(request, "Failed to retrieve reservation: see server logs for details.")
             return redirect(return_url)
         if reservation is None:
-            raise Http404(f"Reservation {ip_address} not found in subnet {subnet_id}")
+            raise Http404(f"Reservation {lookup.label} not found in subnet {subnet_id}")
         identifier_type, identifier = _get_reservation_identifier(reservation, 4)
         initial = {
             "subnet_id": reservation.get("subnet-id", subnet_id),
@@ -772,54 +1037,57 @@ class ServerReservation4EditView(_KeaChangeMixin, generic.ObjectView):
             "return_url": return_url,
             "tab": self.tab,
         }
-        # Key fields are URL-derived — disable so browsers render them read-only.
-        for field_name in ("subnet_id", "ip_address", "identifier_type", "identifier"):
-            context["form"].fields[field_name].disabled = True
-        try:
-            lease = server.get_client(version=4).lease_get_by_ip(4, ip_address)
-            if lease and lease.get("hostname") and lease.get("hostname") != reservation.get("hostname", ""):
-                context["lease_diff"] = {"hostname": lease["hostname"]}
-        except (KeaException, requests.RequestException, ValueError):
-            logger.debug("Could not fetch lease for reservation edit diff (ip=%s)", ip_address, exc_info=True)
+        self.apply_immutable_fields(context["form"])
+        if ip_address:
+            try:
+                lease = server.get_client(version=4).lease_get_by_ip(4, ip_address)
+                if lease and lease.get("hostname") and lease.get("hostname") != reservation.get("hostname", ""):
+                    context["lease_diff"] = {"hostname": lease["hostname"]}
+            except (KeaException, requests.RequestException, ValueError):
+                logger.debug("Could not fetch lease for reservation edit diff (ip=%s)", ip_address, exc_info=True)
         return render(request, self.template_name, context)
 
-    def post(self, request: HttpRequest, pk: int, subnet_id: int, ip_address: str) -> HttpResponse:
+    def post(self, request: HttpRequest, pk: int, subnet_id: int, **kwargs) -> HttpResponse:
         """Validate and submit updated reservation to Kea."""
         server = self.get_object(pk=pk)
+        lookup = self.get_lookup(request, subnet_id, **kwargs)
+        ip_address = lookup.ip_address
         return_url = reverse("plugins:netbox_kea:server_reservations4", args=[pk])
         # Fetch existing before form construction so identifier fields can be seeded and disabled,
         # preventing browser-omitted disabled fields from failing form validation.
         try:
-            existing = self._get_reservation(server, subnet_id, ip_address)
+            existing = self._get_reservation(server, lookup)
         except (KeaException, requests.RequestException, ValueError):
-            logger.exception("Could not fetch existing DHCPv4 reservation for edit (ip=%s)", ip_address)
+            logger.exception("Could not fetch existing DHCPv4 reservation for edit (%s)", lookup.label)
             messages.error(request, "Failed to reload the existing reservation. Edit aborted.")
             return redirect(return_url)
         if existing is None:
-            messages.error(request, f"Reservation {ip_address} no longer exists in subnet {subnet_id}.")
+            messages.error(request, f"Reservation {lookup.label} no longer exists in subnet {subnet_id}.")
             return redirect(return_url)
         existing_id_type, existing_id_value = _get_reservation_identifier(existing, 4)
         form = forms.Reservation4Form(
             data=request.POST,
             initial={
                 "subnet_id": subnet_id,
-                "ip_address": ip_address,
+                "ip_address": existing.get("ip-address", ip_address),
                 "identifier_type": existing_id_type,
                 "identifier": existing_id_value,
             },
         )
-        # Mark key fields as disabled — Django uses initial values for validation and rendering.
-        form.fields["subnet_id"].disabled = True
-        form.fields["ip_address"].disabled = True
-        form.fields["identifier_type"].disabled = True
-        form.fields["identifier"].disabled = True
+        # Django takes a disabled field's value from initial, so seeding must precede this.
+        self.apply_immutable_fields(form)
         options_formset, options_valid = _build_reservation_options_formset(request.POST)
         if form.is_valid() and options_valid:
             cd = form.cleaned_data
             # Start from existing data and overwrite user-editable fields (merge not replace).
             reservation: dict[str, Any] = dict(existing)
             reservation["subnet-id"] = subnet_id
-            reservation["ip-address"] = ip_address
+            # Disabled fields resolve to their initial value, so this is the URL-derived
+            # address on the IP-keyed route and the submitted one where it is editable.
+            if cd.get("ip_address"):
+                reservation["ip-address"] = cd["ip_address"]
+            else:
+                reservation.pop("ip-address", None)
             # Replace identifier — remove all known identifier keys first.
             for _id_key in _ALL_IDENTIFIER_KEYS:
                 reservation.pop(_id_key, None)
@@ -828,19 +1096,11 @@ class ServerReservation4EditView(_KeaChangeMixin, generic.ObjectView):
                 reservation["hostname"] = cd["hostname"]
             else:
                 reservation.pop("hostname", None)
-            option_data = [
-                {"name": f["name"], "data": f["data"], **({"always-send": True} if f.get("always_send") else {})}
-                for f in (getattr(options_formset, "cleaned_data", []) or [])
-                if f and f.get("name") and not f.get("DELETE")
-            ]
-            if option_data:
-                reservation["option-data"] = option_data
-            else:
-                reservation.pop("option-data", None)
+            _merge_reservation_option_data(reservation, options_formset)
             try:
                 client = server.get_client(version=4)
                 client.reservation_update("dhcp4", reservation)
-                messages.success(request, f"Reservation for {ip_address} updated.")
+                messages.success(request, f"Reservation for {lookup.label} updated.")
                 _run_reservation_success_side_effects(
                     request, server, reservation, 4, "updated", bool(cd.get("sync_to_netbox"))
                 )
@@ -851,13 +1111,13 @@ class ServerReservation4EditView(_KeaChangeMixin, generic.ObjectView):
                 )
                 return redirect(return_url)
             except KeaException as exc:
-                logger.exception("Failed to update DHCPv4 reservation for %s", ip_address)
+                logger.exception("Failed to update DHCPv4 reservation for %s", lookup.label)
                 messages.error(request, kea_error_hint(exc))
             except requests.RequestException:
-                logger.exception("Network error updating DHCPv4 reservation for %s", ip_address)
+                logger.exception("Network error updating DHCPv4 reservation for %s", lookup.label)
                 messages.error(request, "Network error communicating with Kea: see server logs.")
             except ValueError:
-                logger.exception("Invalid Kea response when updating DHCPv4 reservation for %s", ip_address)
+                logger.exception("Invalid Kea response when updating DHCPv4 reservation for %s", lookup.label)
                 messages.error(request, "Invalid response from Kea: see server logs.")
         return render(
             request,
@@ -874,23 +1134,27 @@ class ServerReservation4EditView(_KeaChangeMixin, generic.ObjectView):
         )
 
 
-class ServerReservation6EditView(_KeaChangeMixin, generic.ObjectView):
-    """Edit an existing DHCPv6 host reservation."""
+class ServerReservation6EditView(_ReservationLookupMixin, _KeaChangeMixin, generic.ObjectView):
+    """Edit an existing DHCPv6 host reservation, addressed by IP."""
 
     queryset = Server.objects.all()
     template_name = "netbox_kea/server_reservation_form.html"
     tab = _RESERVATIONS_TAB
+    dhcp_version = 6
+    immutable_fields = frozenset({"subnet_id", "ip_addresses", "identifier_type", "identifier"})
 
-    def _get_reservation(self, server: Server, subnet_id: int, ip_address: str) -> dict | None:
+    def _get_reservation(self, server: Server, lookup: _ReservationLookup) -> dict | None:
         client = server.get_client(version=6)
-        return client.reservation_get("dhcp6", subnet_id=subnet_id, ip_address=ip_address)
+        return client.reservation_get("dhcp6", **lookup.to_kwargs())
 
-    def get(self, request: HttpRequest, pk: int, subnet_id: int, ip_address: str) -> HttpResponse:
+    def get(self, request: HttpRequest, pk: int, subnet_id: int, **kwargs) -> HttpResponse:
         """Pre-populate form with existing DHCPv6 reservation data."""
         server = self.get_object(pk=pk)
+        lookup = self.get_lookup(request, subnet_id, **kwargs)
+        ip_address = lookup.ip_address
         return_url = reverse("plugins:netbox_kea:server_reservations6", args=[pk])
         try:
-            reservation = self._get_reservation(server, subnet_id, ip_address)
+            reservation = self._get_reservation(server, lookup)
         except KeaException as exc:
             logger.exception("Failed to fetch DHCPv6 reservation %s in subnet %s", ip_address, subnet_id)
             messages.error(request, kea_error_hint(exc))
@@ -900,7 +1164,7 @@ class ServerReservation6EditView(_KeaChangeMixin, generic.ObjectView):
             messages.error(request, "Failed to retrieve reservation: see server logs for details.")
             return redirect(return_url)
         if reservation is None:
-            raise Http404(f"Reservation {ip_address} not found in subnet {subnet_id}")
+            raise Http404(f"Reservation {lookup.label} not found in subnet {subnet_id}")
         identifier_type, identifier = _get_reservation_identifier(reservation, 6)
         raw_ip_list = reservation.get("ip-addresses")
         if isinstance(raw_ip_list, list):
@@ -908,10 +1172,12 @@ class ServerReservation6EditView(_KeaChangeMixin, generic.ObjectView):
         elif isinstance(raw_ip_list, str) and raw_ip_list:
             ip_list = [raw_ip_list]
         else:
-            ip_list = [ip_address]
+            # A prefix-delegation-only reservation has no addresses at all.
+            ip_list = [ip_address] if ip_address else []
         initial = {
             "subnet_id": reservation.get("subnet-id", subnet_id),
             "ip_addresses": ",".join(ip_list),
+            "prefixes": ",".join(_reservation_prefix_list(reservation)),
             "identifier_type": identifier_type,
             "identifier": identifier,
             "hostname": reservation.get("hostname", ""),
@@ -933,33 +1199,34 @@ class ServerReservation6EditView(_KeaChangeMixin, generic.ObjectView):
             "return_url": return_url,
             "tab": self.tab,
         }
-        # Key fields are URL-derived — disable so browsers render them read-only.
-        for field_name in ("subnet_id", "ip_addresses", "identifier_type", "identifier"):
-            context["form"].fields[field_name].disabled = True
-        try:
-            lease = server.get_client(version=6).lease_get_by_ip(6, ip_address)
-            if lease and lease.get("hostname") and lease.get("hostname") != reservation.get("hostname", ""):
-                context["lease_diff"] = {"hostname": lease["hostname"]}
-        except (KeaException, requests.RequestException, ValueError):
-            logger.debug("Could not fetch lease for reservation edit diff (ip=%s)", ip_address, exc_info=True)
+        self.apply_immutable_fields(context["form"])
+        if ip_address:
+            try:
+                lease = server.get_client(version=6).lease_get_by_ip(6, ip_address)
+                if lease and lease.get("hostname") and lease.get("hostname") != reservation.get("hostname", ""):
+                    context["lease_diff"] = {"hostname": lease["hostname"]}
+            except (KeaException, requests.RequestException, ValueError):
+                logger.debug("Could not fetch lease for reservation edit diff (ip=%s)", ip_address, exc_info=True)
         return render(request, self.template_name, context)
 
-    def post(self, request: HttpRequest, pk: int, subnet_id: int, ip_address: str) -> HttpResponse:
+    def post(self, request: HttpRequest, pk: int, subnet_id: int, **kwargs) -> HttpResponse:
         """Validate and submit updated DHCPv6 reservation to Kea."""
         server = self.get_object(pk=pk)
+        lookup = self.get_lookup(request, subnet_id, **kwargs)
+        ip_address = lookup.ip_address
         return_url = reverse("plugins:netbox_kea:server_reservations6", args=[pk])
         # Fetch existing reservation before form construction (#51) so ip_addresses initial is
         # accurate on re-render, and to enable merge-not-replace for all reservation keys (#52).
         try:
-            existing = self._get_reservation(server, subnet_id, ip_address)
+            existing = self._get_reservation(server, lookup)
         except (KeaException, requests.RequestException, ValueError):
-            logger.exception("Could not fetch existing DHCPv6 reservation for edit (ip=%s)", ip_address)
+            logger.exception("Could not fetch existing DHCPv6 reservation for edit (%s)", lookup.label)
             messages.error(
                 request, "Failed to reload the existing DHCPv6 reservation. Edit aborted to prevent IP loss."
             )
             return redirect(return_url)
         if existing is None:
-            messages.error(request, f"Reservation {ip_address} no longer exists in subnet {subnet_id}.")
+            messages.error(request, f"Reservation {lookup.label} no longer exists in subnet {subnet_id}.")
             return redirect(return_url)
         raw_existing_ips = existing.get("ip-addresses")
         if isinstance(raw_existing_ips, list):
@@ -968,7 +1235,10 @@ class ServerReservation6EditView(_KeaChangeMixin, generic.ObjectView):
             existing_ips = [raw_existing_ips]
         else:
             existing_ips = []
-        if not existing_ips:
+        # An IP-keyed edit that reloads no addresses means the reload lost them, and
+        # writing that back would delete the reservation's IPs.  An identifier-keyed
+        # edit of a prefix-delegation-only host legitimately has none.
+        if not existing_ips and not lookup.by_identifier:
             messages.error(
                 request, "Failed to reload the existing DHCPv6 reservation. Edit aborted to prevent IP loss."
             )
@@ -979,22 +1249,20 @@ class ServerReservation6EditView(_KeaChangeMixin, generic.ObjectView):
             initial={
                 "subnet_id": subnet_id,
                 "ip_addresses": ",".join(existing_ips),
+                "prefixes": ",".join(_reservation_prefix_list(existing)),
                 "identifier_type": existing_id_type,
                 "identifier": existing_id_value,
             },
         )
-        # Mark key fields as disabled — Django uses initial values for validation and rendering.
-        form.fields["subnet_id"].disabled = True
-        form.fields["ip_addresses"].disabled = True
-        form.fields["identifier_type"].disabled = True
-        form.fields["identifier"].disabled = True
+        # Django takes a disabled field's value from initial, so seeding must precede this.
+        self.apply_immutable_fields(form)
         options_formset, options_valid = _build_reservation_options_formset(request.POST)
         if form.is_valid() and options_valid:
             cd = form.cleaned_data
             # Start from existing data and overwrite user-editable fields (merge not replace #52).
             reservation: dict[str, Any] = dict(existing)
             reservation["subnet-id"] = subnet_id
-            reservation["ip-addresses"] = existing_ips
+            _apply_v6_addresses_and_prefixes(reservation, cd)
             # Replace identifier — remove all known identifier keys first.
             for _id_key in _ALL_IDENTIFIER_KEYS:
                 reservation.pop(_id_key, None)
@@ -1003,15 +1271,7 @@ class ServerReservation6EditView(_KeaChangeMixin, generic.ObjectView):
                 reservation["hostname"] = cd["hostname"]
             else:
                 reservation.pop("hostname", None)
-            option_data = [
-                {"name": f["name"], "data": f["data"], **({"always-send": True} if f.get("always_send") else {})}
-                for f in (getattr(options_formset, "cleaned_data", []) or [])
-                if f and f.get("name") and not f.get("DELETE")
-            ]
-            if option_data:
-                reservation["option-data"] = option_data
-            else:
-                reservation.pop("option-data", None)
+            _merge_reservation_option_data(reservation, options_formset)
             try:
                 client = server.get_client(version=6)
                 client.reservation_update("dhcp6", reservation)
@@ -1049,22 +1309,25 @@ class ServerReservation6EditView(_KeaChangeMixin, generic.ObjectView):
         )
 
 
-class ServerReservation4DeleteView(_KeaChangeMixin, generic.ObjectView):
-    """Delete confirmation for a DHCPv4 host reservation."""
+class ServerReservation4DeleteView(_ReservationLookupMixin, _KeaChangeMixin, generic.ObjectView):
+    """Delete confirmation for a DHCPv4 host reservation, addressed by IP."""
 
     queryset = Server.objects.all()
     template_name = "netbox_kea/server_reservation_delete.html"
     tab = _RESERVATIONS_TAB
+    dhcp_version = 4
 
-    def get(self, request: HttpRequest, pk: int, subnet_id: int, ip_address: str) -> HttpResponse:
+    def get(self, request: HttpRequest, pk: int, subnet_id: int, **kwargs) -> HttpResponse:
         """Show deletion confirmation page."""
         server = self.get_object(pk=pk)
+        lookup = self.get_lookup(request, subnet_id, **kwargs)
         return render(
             request,
             self.template_name,
             {
                 "object": server,
-                "ip_address": ip_address,
+                "ip_address": lookup.ip_address,
+                "reservation_label": lookup.label,
                 "subnet_id": subnet_id,
                 "dhcp_version": 4,
                 "return_url": reverse("plugins:netbox_kea:server_reservations4", args=[pk]),
@@ -1072,65 +1335,52 @@ class ServerReservation4DeleteView(_KeaChangeMixin, generic.ObjectView):
             },
         )
 
-    def post(self, request: HttpRequest, pk: int, subnet_id: int, ip_address: str) -> HttpResponse:
+    def post(self, request: HttpRequest, pk: int, subnet_id: int, **kwargs) -> HttpResponse:
         """Issue reservation-del to Kea and redirect."""
         server = self.get_object(pk=pk)
+        lookup = self.get_lookup(request, subnet_id, **kwargs)
         return_url = reverse("plugins:netbox_kea:server_reservations4", args=[pk])
         try:
             client = server.get_client(version=4)
-            client.reservation_del("dhcp4", subnet_id=subnet_id, ip_address=ip_address)
-            messages.success(request, f"Reservation for {ip_address} deleted.")
-            _add_reservation_journal(
-                server, request.user, "deleted", {"ip-address": ip_address, "subnet-id": subnet_id}
-            )
-
-            reservation_deleted.send_robust(
-                sender=None,
-                server=server,
-                ip_address=ip_address,
-                dhcp_version=4,
-                request=request,
-            )
+            client.reservation_del("dhcp4", **lookup.to_kwargs())
+            messages.success(request, f"Reservation for {lookup.label} deleted.")
+            _add_reservation_journal(server, request.user, "deleted", _deleted_journal_entry(lookup))
+            _send_reservation_deleted(server, lookup, 4, request)
         except PartialPersistError:
-            _add_reservation_journal(
-                server, request.user, "deleted", {"ip-address": ip_address, "subnet-id": subnet_id}
-            )
-            reservation_deleted.send_robust(
-                sender=None,
-                server=server,
-                ip_address=ip_address,
-                dhcp_version=4,
-                request=request,
-            )
+            _add_reservation_journal(server, request.user, "deleted", _deleted_journal_entry(lookup))
+            _send_reservation_deleted(server, lookup, 4, request)
             messages.warning(request, "Change applied but may not survive a Kea restart (config-write failed).")
         except KeaException as exc:
-            logger.exception("Failed to delete DHCPv4 reservation for %s", ip_address)
+            logger.exception("Failed to delete DHCPv4 reservation for %s", lookup.label)
             messages.error(request, kea_error_hint(exc))
         except requests.RequestException:
-            logger.exception("Network error deleting DHCPv4 reservation for %s", ip_address)
+            logger.exception("Network error deleting DHCPv4 reservation for %s", lookup.label)
             messages.error(request, "Network error communicating with Kea: see server logs.")
         except ValueError:
-            logger.exception("Invalid Kea response when deleting DHCPv4 reservation for %s", ip_address)
+            logger.exception("Invalid Kea response when deleting DHCPv4 reservation for %s", lookup.label)
             messages.error(request, "Invalid response from Kea: see server logs.")
         return redirect(return_url)
 
 
-class ServerReservation6DeleteView(_KeaChangeMixin, generic.ObjectView):
-    """Delete confirmation for a DHCPv6 host reservation."""
+class ServerReservation6DeleteView(_ReservationLookupMixin, _KeaChangeMixin, generic.ObjectView):
+    """Delete confirmation for a DHCPv6 host reservation, addressed by IP."""
 
     queryset = Server.objects.all()
     template_name = "netbox_kea/server_reservation_delete.html"
     tab = _RESERVATIONS_TAB
+    dhcp_version = 6
 
-    def get(self, request: HttpRequest, pk: int, subnet_id: int, ip_address: str) -> HttpResponse:
+    def get(self, request: HttpRequest, pk: int, subnet_id: int, **kwargs) -> HttpResponse:
         """Show deletion confirmation page."""
         server = self.get_object(pk=pk)
+        lookup = self.get_lookup(request, subnet_id, **kwargs)
         return render(
             request,
             self.template_name,
             {
                 "object": server,
-                "ip_address": ip_address,
+                "ip_address": lookup.ip_address,
+                "reservation_label": lookup.label,
                 "subnet_id": subnet_id,
                 "dhcp_version": 6,
                 "return_url": reverse("plugins:netbox_kea:server_reservations6", args=[pk]),
@@ -1138,47 +1388,67 @@ class ServerReservation6DeleteView(_KeaChangeMixin, generic.ObjectView):
             },
         )
 
-    def post(self, request: HttpRequest, pk: int, subnet_id: int, ip_address: str) -> HttpResponse:
+    def post(self, request: HttpRequest, pk: int, subnet_id: int, **kwargs) -> HttpResponse:
         """Issue reservation-del to Kea and redirect."""
         server = self.get_object(pk=pk)
+        lookup = self.get_lookup(request, subnet_id, **kwargs)
         return_url = reverse("plugins:netbox_kea:server_reservations6", args=[pk])
         try:
             client = server.get_client(version=6)
-            client.reservation_del("dhcp6", subnet_id=subnet_id, ip_address=ip_address)
-            messages.success(request, f"DHCPv6 reservation for {ip_address} deleted.")
-            _add_reservation_journal(
-                server, request.user, "deleted", {"ip-address": ip_address, "subnet-id": subnet_id}
-            )
-
-            reservation_deleted.send_robust(
-                sender=None,
-                server=server,
-                ip_address=ip_address,
-                dhcp_version=6,
-                request=request,
-            )
+            client.reservation_del("dhcp6", **lookup.to_kwargs())
+            messages.success(request, f"DHCPv6 reservation for {lookup.label} deleted.")
+            _add_reservation_journal(server, request.user, "deleted", _deleted_journal_entry(lookup))
+            _send_reservation_deleted(server, lookup, 6, request)
         except PartialPersistError:
-            _add_reservation_journal(
-                server, request.user, "deleted", {"ip-address": ip_address, "subnet-id": subnet_id}
-            )
-            reservation_deleted.send_robust(
-                sender=None,
-                server=server,
-                ip_address=ip_address,
-                dhcp_version=6,
-                request=request,
-            )
+            _add_reservation_journal(server, request.user, "deleted", _deleted_journal_entry(lookup))
+            _send_reservation_deleted(server, lookup, 6, request)
             messages.warning(request, "Change applied but may not survive a Kea restart (config-write failed).")
         except KeaException as exc:
-            logger.exception("Failed to delete DHCPv6 reservation for %s", ip_address)
+            logger.exception("Failed to delete DHCPv6 reservation for %s", lookup.label)
             messages.error(request, kea_error_hint(exc))
         except requests.RequestException:
-            logger.exception("Network error deleting DHCPv6 reservation for %s", ip_address)
+            logger.exception("Network error deleting DHCPv6 reservation for %s", lookup.label)
             messages.error(request, "Network error communicating with Kea: see server logs.")
         except ValueError:
-            logger.exception("Invalid Kea response when deleting DHCPv6 reservation for %s", ip_address)
+            logger.exception("Invalid Kea response when deleting DHCPv6 reservation for %s", lookup.label)
             messages.error(request, "Invalid response from Kea: see server logs.")
         return redirect(return_url)
+
+
+# ---------------------------------------------------------------------------
+# Identifier-keyed variants
+# ---------------------------------------------------------------------------
+# A reservation that reserves no address cannot be addressed by one.  These routes
+# key on the client identifier instead, which arrives as a query parameter so the
+# URL reverses from integers alone.  The address stays editable here: Kea's
+# reservation-update replaces the whole host keyed by its identifier, so a host can
+# be given a fixed address, or have one removed, without changing its URL.
+
+
+class ServerReservation4EditByIdentifierView(ServerReservation4EditView):
+    """Edit a DHCPv4 host reservation addressed by its client identifier."""
+
+    lookup_by_identifier = True
+    immutable_fields = frozenset({"subnet_id", "identifier_type", "identifier"})
+
+
+class ServerReservation6EditByIdentifierView(ServerReservation6EditView):
+    """Edit a DHCPv6 host reservation addressed by its client identifier."""
+
+    lookup_by_identifier = True
+    immutable_fields = frozenset({"subnet_id", "identifier_type", "identifier"})
+
+
+class ServerReservation4DeleteByIdentifierView(ServerReservation4DeleteView):
+    """Delete a DHCPv4 host reservation addressed by its client identifier."""
+
+    lookup_by_identifier = True
+
+
+class ServerReservation6DeleteByIdentifierView(ServerReservation6DeleteView):
+    """Delete a DHCPv6 host reservation addressed by its client identifier."""
+
+    lookup_by_identifier = True
 
 
 def _get_reservation_identifier(
@@ -1200,6 +1470,42 @@ def _get_reservation_identifier(
         if reservation.get(itype):
             return itype, reservation[itype]
     return "hw-address", ""
+
+
+def _normalise_reservation_identifier(reservation: dict[str, Any], version: int) -> None:
+    """In-place: expose the reservation's identifier as ``identifier_type``/``identifier``.
+
+    Each table had one hard-coded identifier column — ``hw-address`` for DHCPv4,
+    ``duid`` for DHCPv6 — so a host identified any other way Kea allows (client-id,
+    circuit-id, flex-id, remote-id) rendered as a blank cell.  Both keys are empty
+    when the reservation carries no identifier at all.
+    """
+    identifier_type, identifier = _get_reservation_identifier(reservation, version)
+    reservation["identifier"] = identifier
+    reservation["identifier_type"] = identifier_type if identifier else ""
+
+
+def _reservation_prefix_list(reservation: dict[str, Any]) -> list[str]:
+    """Return a DHCPv6 reservation's delegated ``prefixes`` as a list of strings.
+
+    Mirrors the ``ip-addresses`` coercion: Kea sends a list, but a hand-written
+    configuration can carry a bare string.
+    """
+    raw = reservation.get("prefixes")
+    if isinstance(raw, list):
+        return [p for p in raw if isinstance(p, str) and p]
+    if isinstance(raw, str) and raw:
+        return [raw]
+    return []
+
+
+def _normalise_reservation_prefixes(reservation: dict[str, Any]) -> None:
+    """In-place counterpart of :func:`_reservation_prefix_list` for table rows.
+
+    A reservation that only delegates prefixes reserves nothing else, so this is the
+    only thing its row can show.
+    """
+    reservation["prefixes"] = _reservation_prefix_list(reservation)
 
 
 def _attach_reservation_action_urls(
@@ -1237,15 +1543,28 @@ def _attach_reservation_action_urls(
         r["delete_url"] = None
         if not can_change:
             continue
+        subnet_id = r.get("subnet_id", r.get("subnet-id"))
         ip_address = r.get("ip_address") or ""
-        if not ip_address:
-            continue
-        args = [server_pk, r.get("subnet_id", r.get("subnet-id")), ip_address]
         try:
-            edit_url = reverse(f"plugins:netbox_kea:server_reservation{version}_edit", args=args)
-            delete_url = reverse(f"plugins:netbox_kea:server_reservation{version}_delete", args=args)
+            if ip_address:
+                args = [server_pk, subnet_id, ip_address]
+                edit_url = reverse(f"plugins:netbox_kea:server_reservation{version}_edit", args=args)
+                delete_url = reverse(f"plugins:netbox_kea:server_reservation{version}_delete", args=args)
+            else:
+                # No address to key on — address by client identifier instead.
+                identifier_type = r.get("identifier_type") or ""
+                identifier = r.get("identifier") or ""
+                if not identifier:
+                    continue
+                query = urlencode({"identifier_type": identifier_type, "identifier": identifier})
+                args = [server_pk, subnet_id]
+                edit_url = f"{reverse(f'plugins:netbox_kea:server_reservation{version}_edit_by_identifier', args=args)}?{query}"
+                delete_url = (
+                    f"{reverse(f'plugins:netbox_kea:server_reservation{version}_delete_by_identifier', args=args)}"
+                    f"?{query}"
+                )
         except NoReverseMatch:
-            logger.debug("No reservation action URL for subnet-id=%r ip=%r", args[1], ip_address)
+            logger.debug("No reservation action URL for subnet-id=%r ip=%r", subnet_id, ip_address)
             continue
         r["edit_url"] = edit_url
         r["delete_url"] = delete_url

--- a/netbox_kea/views/reservations.py
+++ b/netbox_kea/views/reservations.py
@@ -1156,11 +1156,11 @@ class ServerReservation6EditView(_ReservationLookupMixin, _KeaChangeMixin, gener
         try:
             reservation = self._get_reservation(server, lookup)
         except KeaException as exc:
-            logger.exception("Failed to fetch DHCPv6 reservation %s in subnet %s", ip_address, subnet_id)
+            logger.exception("Failed to fetch DHCPv6 reservation %s in subnet %s", lookup.label, subnet_id)
             messages.error(request, kea_error_hint(exc))
             return redirect(return_url)
         except (requests.RequestException, ValueError):
-            logger.exception("Failed to fetch DHCPv6 reservation %s in subnet %s", ip_address, subnet_id)
+            logger.exception("Failed to fetch DHCPv6 reservation %s in subnet %s", lookup.label, subnet_id)
             messages.error(request, "Failed to retrieve reservation: see server logs for details.")
             return redirect(return_url)
         if reservation is None:
@@ -1213,7 +1213,6 @@ class ServerReservation6EditView(_ReservationLookupMixin, _KeaChangeMixin, gener
         """Validate and submit updated DHCPv6 reservation to Kea."""
         server = self.get_object(pk=pk)
         lookup = self.get_lookup(request, subnet_id, **kwargs)
-        ip_address = lookup.ip_address
         return_url = reverse("plugins:netbox_kea:server_reservations6", args=[pk])
         # Fetch existing reservation before form construction (#51) so ip_addresses initial is
         # accurate on re-render, and to enable merge-not-replace for all reservation keys (#52).
@@ -1286,13 +1285,13 @@ class ServerReservation6EditView(_ReservationLookupMixin, _KeaChangeMixin, gener
                 )
                 return redirect(return_url)
             except KeaException as exc:
-                logger.exception("Failed to update DHCPv6 reservation for %s", ip_address)
+                logger.exception("Failed to update DHCPv6 reservation for %s", lookup.label)
                 messages.error(request, kea_error_hint(exc))
             except requests.RequestException:
-                logger.exception("Network error updating DHCPv6 reservation for %s", ip_address)
+                logger.exception("Network error updating DHCPv6 reservation for %s", lookup.label)
                 messages.error(request, "Network error communicating with Kea: see server logs.")
             except ValueError:
-                logger.exception("Invalid Kea response when updating DHCPv6 reservation for %s", ip_address)
+                logger.exception("Invalid Kea response when updating DHCPv6 reservation for %s", lookup.label)
                 messages.error(request, "Invalid response from Kea: see server logs.")
         return render(
             request,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,10 @@ import requests
 @pytest.fixture(scope="session")
 def netbox_url() -> str:
     # Overridable so the harness can be published on another port when 8000 is taken.
-    return os.environ.get("NETBOX_URL", "http://localhost:8000")
+    # An empty NETBOX_URL means "unset", and a trailing slash would double up the / in
+    # every f-string that appends a path.
+    url = os.environ.get("NETBOX_URL") or "http://localhost:8000"
+    return url.rstrip("/")
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import os
+
 import pynetbox
 import pytest
 import requests
@@ -5,7 +7,8 @@ import requests
 
 @pytest.fixture(scope="session")
 def netbox_url() -> str:
-    return "http://localhost:8000"
+    # Overridable so the harness can be published on another port when 8000 is taken.
+    return os.environ.get("NETBOX_URL", "http://localhost:8000")
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,9 +8,9 @@ import requests
 @pytest.fixture(scope="session")
 def netbox_url() -> str:
     # Overridable so the harness can be published on another port when 8000 is taken.
-    # An empty NETBOX_URL means "unset", and a trailing slash would double up the / in
+    # A blank NETBOX_URL means "unset", and a trailing slash would double up the / in
     # every f-string that appends a path.
-    url = os.environ.get("NETBOX_URL") or "http://localhost:8000"
+    url = os.environ.get("NETBOX_URL", "").strip() or "http://localhost:8000"
     return url.rstrip("/")
 
 

--- a/tests/docker/docker-compose.override.yml
+++ b/tests/docker/docker-compose.override.yml
@@ -31,7 +31,7 @@ services:
         psql -d kea -tAc "SELECT 1 FROM pg_tables WHERE tablename='schema_version'" | grep -q 1 \
           || psql -q -v ON_ERROR_STOP=1 -d kea -f /schema/dhcpdb_create.pgsql
   kea-dhcp4: &kea
-    image: docker.cloudsmith.io/isc/docker/kea-dhcp4:3.2.0
+    image: docker.cloudsmith.io/isc/docker/kea-dhcp4:${KEA_VERSION:-3.2.0}
     command: kea-dhcp4 -X -c /etc/kea/kea-dhcp4.conf
     depends_on:
       kea-db-init:
@@ -44,7 +44,7 @@ services:
       - 127.0.0.1:8001:8000
   kea-dhcp6:
     <<: *kea
-    image: docker.cloudsmith.io/isc/docker/kea-dhcp6:3.2.0
+    image: docker.cloudsmith.io/isc/docker/kea-dhcp6:${KEA_VERSION:-3.2.0}
     command: kea-dhcp6 -X -c /etc/kea/kea-dhcp6.conf
     ports:
       - 127.0.0.1:8003:8000

--- a/tests/docker/docker-compose.override.yml
+++ b/tests/docker/docker-compose.override.yml
@@ -6,9 +6,36 @@
 # that policy check to a warning. The sockets are loopback-bound and nginx terminates
 # TLS/basic-auth in front, so an unauthenticated daemon socket is acceptable here.
 services:
+  # Reservation add/update/delete are host_cmds commands and host_cmds only writes to
+  # a host database — with none configured Kea answers "Host database not available".
+  # Both daemons share one, so the schema is loaded once before either starts.
+  # test_setup.sh fetches the schema for the exact Kea version the daemons run.
+  kea-db-init:
+    image: docker.io/postgres:16-alpine
+    depends_on:
+      - postgres
+    environment:
+      PGHOST: postgres
+      PGUSER: netbox
+      PGPASSWORD: J5brHrAXFLQSif0K
+    volumes:
+      - ./kea_schema/:/schema/:ro
+    entrypoint:
+      - sh
+      - -c
+      - |
+        set -e
+        until pg_isready -q; do sleep 1; done
+        psql -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='kea'" | grep -q 1 \
+          || psql -d postgres -c "CREATE DATABASE kea"
+        psql -d kea -tAc "SELECT 1 FROM pg_tables WHERE tablename='schema_version'" | grep -q 1 \
+          || psql -q -v ON_ERROR_STOP=1 -d kea -f /schema/dhcpdb_create.pgsql
   kea-dhcp4: &kea
     image: docker.cloudsmith.io/isc/docker/kea-dhcp4:3.2.0
     command: kea-dhcp4 -X -c /etc/kea/kea-dhcp4.conf
+    depends_on:
+      kea-db-init:
+        condition: service_completed_successfully
     volumes:
       - ./kea_configs/:/etc/kea/:ro
     # Host-exposed for the test-side KeaClient (netbox->kea uses the service name).

--- a/tests/docker/kea_configs/kea-dhcp4.conf
+++ b/tests/docker/kea_configs/kea-dhcp4.conf
@@ -70,19 +70,17 @@
         "lfc-interval": 3600
     },
 
-    // Kea allows storing host reservations in a database. If your network is
-    // small or you have few reservations, it's probably easier to keep them
-    // in the configuration file. If your network is large, it's usually better
-    // to use database for it. To enable it, uncomment the following:
-    // "hosts-database": {
-    //     "type": "mysql",
-    //     "name": "kea",
-    //     "user": "kea",
-    //     "password": "kea",
-    //     "host": "localhost",
-    //     "port": 3306
-    // },
-    // See Section 7.2.3 "Hosts storage" for details.
+    // Kea allows storing host reservations in a database. See Section 7.2.3
+    // "Hosts storage" for details.  host_cmds writes go to that database and never
+    // to this file, so reservation add/update/delete need one configured;
+    // kea-db-init loads its schema before this daemon starts.
+    "hosts-database": {
+        "type": "postgresql",
+        "name": "kea",
+        "host": "postgres",
+        "user": "netbox",
+        "password": "J5brHrAXFLQSif0K"
+    },
 
     // Setup reclamation of the expired leases and leases affinity.
     // Expired leases will be reclaimed every 10 seconds. Every 25
@@ -251,9 +249,12 @@
     // additional forensic logging capabilities, ability to reserve hosts in
     // more flexible ways, and even add extra commands. For a list of available
     // hook libraries, see https://gitlab.isc.org/isc-projects/kea/wikis/Hooks-available.
+    // libdhcp_pgsql must load before the hosts-database above can be opened.
     "hooks-libraries": [
+        {"library": "/usr/lib/kea/hooks/libdhcp_pgsql.so"},
         {"library": "/usr/lib/kea/hooks/libdhcp_lease_cmds.so"},
-        {"library": "/usr/lib/kea/hooks/libdhcp_stat_cmds.so"}
+        {"library": "/usr/lib/kea/hooks/libdhcp_stat_cmds.so"},
+        {"library": "/usr/lib/kea/hooks/libdhcp_host_cmds.so"}
     ],
     //   {
     //       // Forensic Logging library generates forensic type of audit trail

--- a/tests/docker/kea_configs/kea-dhcp6.conf
+++ b/tests/docker/kea_configs/kea-dhcp6.conf
@@ -64,19 +64,17 @@
         "lfc-interval": 3600
     },
 
-    // Kea allows storing host reservations in a database. If your network is
-    // small or you have few reservations, it's probably easier to keep them
-    // in the configuration file. If your network is large, it's usually better
-    // to use database for it. To enable it, uncomment the following:
-    // "hosts-database": {
-    //     "type": "mysql",
-    //     "name": "kea",
-    //     "user": "kea",
-    //     "password": "kea",
-    //     "host": "localhost",
-    //     "port": 3306
-    // },
-    // See Section 8.2.3 "Hosts storage" for details.
+    // Kea allows storing host reservations in a database. See Section 8.2.3
+    // "Hosts storage" for details.  host_cmds writes go to that database and never
+    // to this file, so reservation add/update/delete need one configured;
+    // kea-db-init loads its schema before this daemon starts.
+    "hosts-database": {
+        "type": "postgresql",
+        "name": "kea",
+        "host": "postgres",
+        "user": "netbox",
+        "password": "J5brHrAXFLQSif0K"
+    },
 
     // Setup reclamation of the expired leases and leases affinity.
     // Expired leases will be reclaimed every 10 seconds. Every 25
@@ -197,9 +195,12 @@
     // additional forensic logging capabilities, ability to reserve hosts in
     // more flexible ways, and even add extra commands. For a list of available
     // hook libraries, see https://gitlab.isc.org/isc-projects/kea/wikis/Hooks-available.
+    // libdhcp_pgsql must load before the hosts-database above can be opened.
     "hooks-libraries": [
+        {"library": "/usr/lib/kea/hooks/libdhcp_pgsql.so"},
         {"library": "/usr/lib/kea/hooks/libdhcp_lease_cmds.so"},
-        {"library": "/usr/lib/kea/hooks/libdhcp_stat_cmds.so"}
+        {"library": "/usr/lib/kea/hooks/libdhcp_stat_cmds.so"},
+        {"library": "/usr/lib/kea/hooks/libdhcp_host_cmds.so"}
     ],
     //   {
     //       // Forensic Logging library generates forensic type of audit trail

--- a/tests/test_netbox_kea_api_server.py
+++ b/tests/test_netbox_kea_api_server.py
@@ -42,10 +42,10 @@ def test_server_api_bulk_actions(nb_api: pynetbox.api, kea_server_kwargs: dict):
     assert nb_api.plugins.kea.servers.delete(servers) is True
 
 
-def test_graphql(nb_api: pynetbox.api, nb_http: requests.Session, kea_server_kwargs: dict):
+def test_graphql(nb_api: pynetbox.api, nb_http: requests.Session, kea_server_kwargs: dict, netbox_url: str):
     server = nb_api.plugins.kea.servers.create(name="gql-test", **kea_server_kwargs)
     r = nb_http.post(
-        "http://localhost:8000/graphql/",
+        f"{netbox_url}/graphql/",
         json={
             "query": """
 {
@@ -75,7 +75,7 @@ def test_graphql(nb_api: pynetbox.api, nb_http: requests.Session, kea_server_kwa
 
     # Ensure ca_password is not a valid field
     r = nb_http.post(
-        "http://localhost:8000/graphql/",
+        f"{netbox_url}/graphql/",
         json={
             "query": """
 {
@@ -96,7 +96,7 @@ def test_graphql(nb_api: pynetbox.api, nb_http: requests.Session, kea_server_kwa
 
     for secret_field in ("dhcp4_password", "dhcp6_password"):
         r = nb_http.post(
-            "http://localhost:8000/graphql/",
+            f"{netbox_url}/graphql/",
             json={
                 "query": f"""
 {{
@@ -114,7 +114,7 @@ def test_graphql(nb_api: pynetbox.api, nb_http: requests.Session, kea_server_kwa
         assert r_json["errors"][0]["message"] == f"Cannot query field '{secret_field}' on type 'ServerType'."
 
     r = nb_http.post(
-        "http://localhost:8000/graphql/",
+        f"{netbox_url}/graphql/",
         json={
             "query": """
 {

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -11,7 +11,8 @@ chmod -R 0777 ./tests/docker/certs/
 # Reservation management needs a Kea host database, and Kea refuses a schema whose
 # version is not exactly the one it was built against, so take the schema from the
 # release tarball of the version the daemons run (see docker-compose.override.yml).
-KEA_VERSION="${KEA_VERSION:-3.2.0}"
+# Exported so docker-compose.override.yml pins the daemon images to the same version.
+export KEA_VERSION="${KEA_VERSION:-3.2.0}"
 KEA_TARBALL_SHA256="${KEA_TARBALL_SHA256:-14bf695d37b65b9b1bf550fea5d0adaf9806c50e5419ef2a176a4b8e9aade3df}"
 echo "Fetching Kea $KEA_VERSION host database schema"
 mkdir -p ./tests/docker/kea_schema/

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -8,6 +8,19 @@ openssl req -new -newkey rsa:2048 -sha256 -days 365 -nodes -x509 -keyout ./tests
 openssl req -new -newkey rsa:2048 -sha256 -days 365 -nodes -x509 -keyout ./tests/docker/certs/nginx.key -out ./tests/docker/certs/nginx.crt -addext "subjectAltName=DNS:nginx" -subj "/CN=nginx"
 chmod -R 0777 ./tests/docker/certs/
 
+# Reservation management needs a Kea host database, and Kea refuses a schema whose
+# version is not exactly the one it was built against, so take the schema from the
+# release tarball of the version the daemons run (see docker-compose.override.yml).
+KEA_VERSION="${KEA_VERSION:-3.2.0}"
+KEA_TARBALL_SHA256="${KEA_TARBALL_SHA256:-14bf695d37b65b9b1bf550fea5d0adaf9806c50e5419ef2a176a4b8e9aade3df}"
+echo "Fetching Kea $KEA_VERSION host database schema"
+mkdir -p ./tests/docker/kea_schema/
+curl -fsSL -o "/tmp/kea-$KEA_VERSION.tar.xz" \
+    "https://downloads.isc.org/isc/kea/$KEA_VERSION/kea-$KEA_VERSION.tar.xz"
+echo "$KEA_TARBALL_SHA256  /tmp/kea-$KEA_VERSION.tar.xz" | sha256sum -c -
+tar xJf "/tmp/kea-$KEA_VERSION.tar.xz" -C ./tests/docker/kea_schema/ --strip-components=6 \
+    "kea-$KEA_VERSION/src/share/database/scripts/pgsql/dhcpdb_create.pgsql"
+
 echo "Copying whl"
 WHL_FILE=$(ls ./dist/ | grep .whl)
 cp  "./dist/$WHL_FILE" ./tests/docker/

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -15,10 +15,15 @@ KEA_VERSION="${KEA_VERSION:-3.2.0}"
 KEA_TARBALL_SHA256="${KEA_TARBALL_SHA256:-14bf695d37b65b9b1bf550fea5d0adaf9806c50e5419ef2a176a4b8e9aade3df}"
 echo "Fetching Kea $KEA_VERSION host database schema"
 mkdir -p ./tests/docker/kea_schema/
-curl -fsSL -o "/tmp/kea-$KEA_VERSION.tar.xz" \
+# Private temp dir: a fixed /tmp path is guessable, so another user could plant the
+# tarball (or symlink it elsewhere) before curl writes it.
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+tarball="$tmp_dir/kea-$KEA_VERSION.tar.xz"
+curl -fsSL -o "$tarball" \
     "https://downloads.isc.org/isc/kea/$KEA_VERSION/kea-$KEA_VERSION.tar.xz"
-echo "$KEA_TARBALL_SHA256  /tmp/kea-$KEA_VERSION.tar.xz" | sha256sum -c -
-tar xJf "/tmp/kea-$KEA_VERSION.tar.xz" -C ./tests/docker/kea_schema/ --strip-components=6 \
+echo "$KEA_TARBALL_SHA256  $tarball" | sha256sum -c -
+tar xJf "$tarball" -C ./tests/docker/kea_schema/ --strip-components=6 \
     "kea-$KEA_VERSION/src/share/database/scripts/pgsql/dhcpdb_create.pgsql"
 
 echo "Copying whl"

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1845,18 +1845,28 @@ def test_reservation4_without_address_matches_lease_by_identifier(
 ) -> None:
     """A row with no address takes its lease status from a real lease with the same MAC."""
     mac = "aa:bb:cc:00:01:04"
+    lease_ip = "192.0.2.150"
     reservation_keys.append((4, RESERVATION_SUBNET_ID, "hw-address", mac))
     _reservation_del(kea_client, 4, RESERVATION_SUBNET_ID, "hw-address", mac)
     kea_client.command(
         "lease4-add",
         service=["dhcp4"],
-        arguments={"ip-address": "192.0.2.150", "hw-address": mac, "hostname": "leased-client"},
+        arguments={"ip-address": lease_ip, "hw-address": mac, "hostname": "leased-client"},
     )
-    _add_reservation4_without_address(page, plugin_base, reservation_server.id, mac, "no-address-leased")
+    # reservation_keys only drops reservations, so the lease needs its own cleanup.
+    try:
+        _add_reservation4_without_address(page, plugin_base, reservation_server.id, mac, "no-address-leased")
 
-    row = page.locator("table.object-list > tbody > tr").filter(has_text=mac)
-    expect(row).to_have_count(1)
-    expect(row.get_by_text("Active Lease", exact=True)).to_be_visible()
+        row = page.locator("table.object-list > tbody > tr").filter(has_text=mac)
+        expect(row).to_have_count(1)
+        expect(row.get_by_text("Active Lease", exact=True)).to_be_visible()
+    finally:
+        kea_client.command(
+            "lease4-del",
+            service=["dhcp4"],
+            arguments={"ip-address": lease_ip},
+            check=(0, 3),
+        )
 
 
 def test_reservation6_prefix_only_round_trip(

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1631,3 +1631,273 @@ def test_dhcpv6_lease_long_duid(page: Page, kea: KeaClient, with_test_server_onl
 
     # The last column should not be off the page.
     expect(page.locator("table.object-list > tbody > tr > td").last).to_be_in_viewport()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Reservations that reserve no address (issue #110)
+#
+# host_cmds only writes to the host database the harness configures, so these
+# drive the plugin's own add / edit / delete pages and then read the result back
+# from the daemon: a DHCPv4 host keyed only by a client identifier, and a DHCPv6
+# host that only delegates prefixes.
+# ─────────────────────────────────────────────────────────────────────────────
+
+#: Kea subnet id 1 exists in both harness configs (192.0.2.0/24 and 2001:db8:1::/64).
+RESERVATION_SUBNET_ID = 1
+
+
+@pytest.fixture
+def reservation_server(
+    nb_api: pynetbox.api, kea_url: str, kea_dhcp6_url: str, page: Page, netbox_login: None, plugin_base: str
+):
+    """Dual-stack server the reservation tests address by primary key."""
+    server = nb_api.plugins.kea.servers.create(
+        name="reservations", ca_url=kea_url, dhcp6_url=kea_dhcp6_url, has_control_agent=False
+    )
+    try:
+        yield server
+    finally:
+        server.delete()
+
+
+@pytest.fixture
+def reservation_keys(kea_client: _DualEndpointKeaClient):
+    """Reservation keys to drop from the host database before and after the test."""
+    keys: list[tuple[Literal[4, 6], int, str, str]] = []
+    yield keys
+    for key in keys:
+        _reservation_del(kea_client, *key)
+
+
+def _reservation_key_args(subnet_id: int, identifier_type: str, identifier: str) -> dict[str, Any]:
+    return {"subnet-id": subnet_id, "identifier-type": identifier_type, "identifier": identifier}
+
+
+def _reservation_get(
+    kea: KeaClient, version: Literal[4, 6], subnet_id: int, identifier_type: str, identifier: str
+) -> dict[str, Any] | None:
+    """Read one reservation back from the daemon, or None when it holds no such host."""
+    resp = kea.command(
+        "reservation-get",
+        service=[f"dhcp{version}"],
+        arguments=_reservation_key_args(subnet_id, identifier_type, identifier),
+        check=(0, 3),
+    )
+    return resp[0].get("arguments") if resp[0]["result"] == 0 else None
+
+
+def _reservation_del(
+    kea: KeaClient, version: Literal[4, 6], subnet_id: int, identifier_type: str, identifier: str
+) -> None:
+    """Delete a reservation directly, tolerating one that is not there."""
+    kea.command(
+        "reservation-del",
+        service=[f"dhcp{version}"],
+        arguments=_reservation_key_args(subnet_id, identifier_type, identifier),
+        check=(0, 3),
+    )
+
+
+def _select_identifier_type(page: Page, label: str) -> None:
+    """Pick a value from the Tom Select-wrapped Identifier Type field."""
+    page.locator("#id_identifier_type + div.form-select").click()
+    page.locator("#id_identifier_type-ts-dropdown").get_by_role("option", name=label, exact=True).click()
+
+
+def _save_reservation_form(page: Page, version: Literal[4, 6]) -> None:
+    """Submit the reservation form; a validation error would keep us on the form."""
+    page.get_by_role("button", name="Save").click()
+    page.wait_for_url(re.compile(rf"/reservations{version}/$"))
+
+
+def _reservation_by_identifier_url(
+    plugin_base: str,
+    server_id: int,
+    version: Literal[4, 6],
+    action: str,
+    identifier_type: str,
+    identifier: str,
+) -> str:
+    return (
+        f"{plugin_base}/servers/{server_id}/reservations{version}/{RESERVATION_SUBNET_ID}/{action}-by-identifier/"
+        f"?identifier_type={quote_plus(identifier_type)}&identifier={quote_plus(identifier)}"
+    )
+
+
+def _add_reservation4_without_address(
+    page: Page,
+    plugin_base: str,
+    server_id: int,
+    identifier: str,
+    hostname: str,
+    option: tuple[str, str] | None = None,
+) -> None:
+    """Create a DHCPv4 host keyed by MAC with no fixed address, through the add form."""
+    page.goto(f"{plugin_base}/servers/{server_id}/reservations4/add/")
+    page.locator("#id_subnet_id").fill(str(RESERVATION_SUBNET_ID))
+    _select_identifier_type(page, "Hardware Address")
+    page.locator("#id_identifier").fill(identifier)
+    page.locator("#id_hostname").fill(hostname)
+    if option is not None:
+        page.locator("#id_options-0-name").fill(option[0])
+        page.locator("#id_options-0-data").fill(option[1])
+    _save_reservation_form(page, 4)
+
+
+def _add_reservation6_prefix_only(
+    page: Page, plugin_base: str, server_id: int, identifier: str, hostname: str, prefix: str
+) -> None:
+    """Create a DHCPv6 host that delegates a prefix and reserves no address."""
+    page.goto(f"{plugin_base}/servers/{server_id}/reservations6/add/")
+    page.locator("#id_subnet_id").fill(str(RESERVATION_SUBNET_ID))
+    page.locator("#id_prefixes").fill(prefix)
+    _select_identifier_type(page, "DUID")
+    page.locator("#id_identifier").fill(identifier)
+    page.locator("#id_hostname").fill(hostname)
+    _save_reservation_form(page, 6)
+
+
+def test_reservation4_add_without_address(
+    page: Page,
+    plugin_base: str,
+    kea_client: _DualEndpointKeaClient,
+    reservation_server,
+    reservation_keys: list,
+) -> None:
+    """Kea stores a DHCPv4 host with an identifier, a hostname and options but no address."""
+    mac = "aa:bb:cc:00:01:01"
+    reservation_keys.append((4, RESERVATION_SUBNET_ID, "hw-address", mac))
+    _reservation_del(kea_client, 4, RESERVATION_SUBNET_ID, "hw-address", mac)
+
+    _add_reservation4_without_address(
+        page, plugin_base, reservation_server.id, mac, "no-address-v4", ("domain-name-servers", "192.0.2.53")
+    )
+
+    stored = _reservation_get(kea_client, 4, RESERVATION_SUBNET_ID, "hw-address", mac)
+    assert stored is not None
+    assert "ip-address" not in stored
+    assert stored["hostname"] == "no-address-v4"
+    assert [(o["name"], o["data"]) for o in stored["option-data"]] == [("domain-name-servers", "192.0.2.53")]
+
+    row = page.locator("table.object-list > tbody > tr").filter(has_text=mac)
+    expect(row).to_have_count(1)
+    expect(row.get_by_text("No address", exact=True)).to_be_visible()
+
+
+def test_reservation4_edit_by_identifier_keeps_option_data(
+    page: Page,
+    plugin_base: str,
+    kea_client: _DualEndpointKeaClient,
+    reservation_server,
+    reservation_keys: list,
+) -> None:
+    """Editing the hostname by identifier leaves option-data and the missing address alone."""
+    mac = "aa:bb:cc:00:01:02"
+    reservation_keys.append((4, RESERVATION_SUBNET_ID, "hw-address", mac))
+    _reservation_del(kea_client, 4, RESERVATION_SUBNET_ID, "hw-address", mac)
+    _add_reservation4_without_address(
+        page, plugin_base, reservation_server.id, mac, "before-edit", ("boot-file-name", "http://192.0.2.1/ztp.py")
+    )
+
+    page.goto(_reservation_by_identifier_url(plugin_base, reservation_server.id, 4, "edit", "hw-address", mac))
+    # The form is populated from the daemon, and this route freezes only the key.
+    expect(page.locator("#id_hostname")).to_have_value("before-edit")
+    expect(page.locator("#id_identifier")).to_be_disabled()
+    expect(page.locator("#id_ip_address")).to_be_editable()
+    page.locator("#id_hostname").fill("after-edit")
+    _save_reservation_form(page, 4)
+
+    stored = _reservation_get(kea_client, 4, RESERVATION_SUBNET_ID, "hw-address", mac)
+    assert stored is not None
+    assert stored["hostname"] == "after-edit"
+    assert "ip-address" not in stored
+    assert [(o["name"], o["data"]) for o in stored["option-data"]] == [("boot-file-name", "http://192.0.2.1/ztp.py")]
+
+
+def test_reservation4_delete_by_identifier(
+    page: Page,
+    plugin_base: str,
+    kea_client: _DualEndpointKeaClient,
+    reservation_server,
+    reservation_keys: list,
+) -> None:
+    """A host with no address is deletable by the identifier that is the only key it has."""
+    mac = "aa:bb:cc:00:01:03"
+    reservation_keys.append((4, RESERVATION_SUBNET_ID, "hw-address", mac))
+    _reservation_del(kea_client, 4, RESERVATION_SUBNET_ID, "hw-address", mac)
+    _add_reservation4_without_address(page, plugin_base, reservation_server.id, mac, "to-be-deleted")
+    assert _reservation_get(kea_client, 4, RESERVATION_SUBNET_ID, "hw-address", mac) is not None
+
+    page.goto(_reservation_by_identifier_url(plugin_base, reservation_server.id, 4, "delete", "hw-address", mac))
+    expect(page.get_by_text(f"hw-address {mac}")).to_be_visible()
+    page.locator('form[method="post"] button.btn-danger').click()
+    page.wait_for_url(re.compile(r"/reservations4/$"))
+
+    assert _reservation_get(kea_client, 4, RESERVATION_SUBNET_ID, "hw-address", mac) is None
+
+
+def test_reservation4_without_address_matches_lease_by_identifier(
+    page: Page,
+    plugin_base: str,
+    kea_client: _DualEndpointKeaClient,
+    reservation_server,
+    reservation_keys: list,
+) -> None:
+    """A row with no address takes its lease status from a real lease with the same MAC."""
+    mac = "aa:bb:cc:00:01:04"
+    reservation_keys.append((4, RESERVATION_SUBNET_ID, "hw-address", mac))
+    _reservation_del(kea_client, 4, RESERVATION_SUBNET_ID, "hw-address", mac)
+    kea_client.command(
+        "lease4-add",
+        service=["dhcp4"],
+        arguments={"ip-address": "192.0.2.150", "hw-address": mac, "hostname": "leased-client"},
+    )
+    _add_reservation4_without_address(page, plugin_base, reservation_server.id, mac, "no-address-leased")
+
+    row = page.locator("table.object-list > tbody > tr").filter(has_text=mac)
+    expect(row).to_have_count(1)
+    expect(row.get_by_text("Active Lease", exact=True)).to_be_visible()
+
+
+def test_reservation6_prefix_only_round_trip(
+    page: Page,
+    plugin_base: str,
+    kea_client: _DualEndpointKeaClient,
+    reservation_server,
+    reservation_keys: list,
+) -> None:
+    """A DHCPv6 host that only delegates a prefix survives add, edit by identifier and delete."""
+    duid = "01:02:03:04:05:06:07:b1"
+    prefix = "2001:db8:8:b1::/64"
+    reservation_keys.append((6, RESERVATION_SUBNET_ID, "duid", duid))
+    _reservation_del(kea_client, 6, RESERVATION_SUBNET_ID, "duid", duid)
+
+    _add_reservation6_prefix_only(page, plugin_base, reservation_server.id, duid, "pd-only", prefix)
+
+    stored = _reservation_get(kea_client, 6, RESERVATION_SUBNET_ID, "duid", duid)
+    assert stored is not None
+    assert stored["prefixes"] == [prefix]
+    assert not stored.get("ip-addresses")
+    assert stored["hostname"] == "pd-only"
+
+    row = page.locator("table.object-list > tbody > tr").filter(has_text=duid)
+    expect(row).to_have_count(1)
+    expect(row.get_by_text("No address", exact=True)).to_be_visible()
+    expect(row.get_by_text(prefix, exact=True)).to_be_visible()
+
+    page.goto(_reservation_by_identifier_url(plugin_base, reservation_server.id, 6, "edit", "duid", duid))
+    expect(page.locator("#id_prefixes")).to_have_value(prefix)
+    page.locator("#id_hostname").fill("pd-only-renamed")
+    _save_reservation_form(page, 6)
+
+    stored = _reservation_get(kea_client, 6, RESERVATION_SUBNET_ID, "duid", duid)
+    assert stored is not None
+    assert stored["hostname"] == "pd-only-renamed"
+    assert stored["prefixes"] == [prefix]
+    assert not stored.get("ip-addresses")
+
+    page.goto(_reservation_by_identifier_url(plugin_base, reservation_server.id, 6, "delete", "duid", duid))
+    page.locator('form[method="post"] button.btn-danger').click()
+    page.wait_for_url(re.compile(r"/reservations6/$"))
+
+    assert _reservation_get(kea_client, 6, RESERVATION_SUBNET_ID, "duid", duid) is None


### PR DESCRIPTION
Fixes #110

A Kea host reservation may legally reserve no address — an identifier-only DHCPv4 host carrying just a hostname, option-data or client-classes, or a DHCPv6 host that only delegates prefixes. The reservations tab crashed rendering such rows (every mutation route was keyed by IP) and the sync job failed on them.

Commit 1 stops the bleeding: the tab renders again and the sync job no longer fails on an address-less host.

Commit 2 makes address-less reservations first-class:

- **Tables**: identifier column showing the value and which Kea key it came from (previously only hw-address/DUID rendered; other identifier types showed a blank cell), a v6 delegated-prefixes column, and a muted "No address" badge instead of an empty cell. Global tabs inherit all of it.
- **Edit/delete by client identifier**: four integer-only routes carrying the identifier in the query string, so no reservation value can make a URL fail to reverse; one shared lookup validates GET and POST identically (unknown/wrong-version type, missing, empty, repeated, conflicting or over-long values → 400; well-formed but absent in Kea → 404). The address stays editable, so a host can gain or lose its fixed address without changing the key it is addressed by.
- **Forms/CSV**: address optional everywhere; per-type identifier validation shared between form and CSV importer, with type-aware length caps (a maximal 128-octet DUID is 383 characters and is now accepted; opaque identifiers keep the 255 guard); a shared delegated-prefix validator (canonical form, deduplicated, bounded, prefix length ≥ 1); CSV columns matched by header name with exactly one identifier column per file.
- **Lease status without an address**: lease enrichment also collects per-subnet lease identifiers (v4 hw-address/client-id, v6 duid/hw-address), so an address-less row shows its client's active lease — matched only within its own subnet. Addressed rows keep the IP match.
- An options formset absent from a submission no longer wipes option-data the request never touched; a submitted formset with all rows deleted still clears them.
- `reservation_deleted` now sends a uniform payload on every route and outcome (`ip_address` / `identifier_type` / `identifier`, `None` where not applicable).

## Testing

- Unit: **2403 passed** (27 new tests for the behaviors above, each proven red against the unfixed code).
- Integration against real Kea 3.2.0 daemons: **149 passed**, including 5 new tests that drive the add / edit-by-identifier / delete-by-identifier pages and read the host back from the daemon — proving real Kea accepts the payloads this PR builds, and that untouched option-data survives an identifier-keyed `reservation-update`. The test harness gained a PostgreSQL hosts database (`libdhcp_pgsql` + `libdhcp_host_cmds`, schema loaded by a one-shot init service from the pinned upstream `dhcpdb_create.pgsql`) because `host_cmds` persists only to a host database.
- ruff, mock-discipline, REUSE and all pre-commit hooks clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added identifier-keyed edit/delete routes and workflows for address-less DHCPv4 reservations and DHCPv6 prefix-only reservations.
  * Updated reservation UI tables to display identifier/prefix details with reliable “No address” rendering.
* **Bug Fixes**
  * Improved IPAM sync summaries and conflict reporting, including accurate skipped counts for no-address reservations.
* **Documentation**
  * Expanded README for sync summary fields and reservation delete signal payload behavior.
* **Tests**
  * Added/expanded coverage for bulk import, UI flows, validation edge cases, and conflict/skip scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->